### PR TITLE
Fix Ctrl+V and Ctrl+Z keyboard shortcuts in terminal

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -91,16 +91,21 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
         return true;
       }
 
+      // Ctrl+V: Let browser handle paste natively — fires paste event
+      // on xterm's internal textarea, which xterm processes via onData.
+      // This is more reliable than the async Clipboard API which can fail
+      // silently due to focus/permission issues.
       if (isCtrl && e.key === 'v') {
+        return false;
+      }
+
+      // Ctrl+Z: Send suspend/EOF signal to terminal (prevent browser undo)
+      if (isCtrl && !e.shiftKey && e.key === 'z') {
         if (e.type === 'keydown') {
           e.preventDefault();
-          navigator.clipboard.readText().then((text) => {
-            if (text) {
-              writeToTerminal(terminalId, text);
-            }
-          });
+          writeToTerminal(terminalId, '\x1a');
         }
-        return false; // Block both keydown and keyup from xterm
+        return false;
       }
 
       return true;


### PR DESCRIPTION
## Summary
- **Ctrl+V**: Replace async Clipboard API with native browser paste handling. The Clipboard API was silently failing due to focus/permission issues, causing paste to not work intermittently
- **Ctrl+Z**: Add explicit handling that was completely missing. The browser was intercepting it as undo instead of sending the suspend/EOF signal to the terminal

## Test plan
- [ ] Open a terminal, copy text, verify Ctrl+V pastes reliably (including after switching windows)
- [ ] Verify Ctrl+Z sends suspend/EOF signal to the running process
- [ ] Verify Ctrl+C still copies selection / sends interrupt
- [ ] Verify Ctrl+Shift+F still toggles search

Generated with [Claude Code](https://claude.com/claude-code)