### PR TITLE
Add Claude global configuration manager (settings, agents, commands)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -671,6 +671,138 @@ pub async fn delete_snippet(state: State<'_, AppState>, id: String) -> Result<()
     db.delete_snippet(&id)
 }
 
+// Claude Global Configuration (~/.claude/)
+
+/// Returns the path to the user's ~/.claude directory
+fn get_claude_dir() -> Result<std::path::PathBuf, String> {
+    let home = if cfg!(target_os = "windows") {
+        std::env::var("USERPROFILE").map_err(|_| "USERPROFILE not set".to_string())?
+    } else {
+        std::env::var("HOME").map_err(|_| "HOME not set".to_string())?
+    };
+    Ok(std::path::Path::new(&home).join(".claude"))
+}
+
+/// Validates that a filename is safe (no path traversal)
+fn validate_filename(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Filename cannot be empty".to_string());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('\0') {
+        return Err("Invalid filename".to_string());
+    }
+    Ok(())
+}
+
+#[command]
+pub async fn read_claude_settings() -> Result<String, String> {
+    let settings_path = get_claude_dir()?.join("settings.json");
+    if !settings_path.exists() {
+        return Ok("{}".to_string());
+    }
+    std::fs::read_to_string(&settings_path)
+        .map_err(|e| format!("Failed to read settings.json: {}", e))
+}
+
+#[command]
+pub async fn write_claude_settings(content: String) -> Result<(), String> {
+    // Validate it's valid JSON
+    serde_json::from_str::<serde_json::Value>(&content)
+        .map_err(|e| format!("Invalid JSON: {}", e))?;
+    let claude_dir = get_claude_dir()?;
+    std::fs::create_dir_all(&claude_dir).map_err(|e| e.to_string())?;
+    std::fs::write(claude_dir.join("settings.json"), &content)
+        .map_err(|e| format!("Failed to write settings.json: {}", e))
+}
+
+#[command]
+pub async fn list_claude_agents() -> Result<Vec<String>, String> {
+    let agents_dir = get_claude_dir()?.join("agents");
+    if !agents_dir.exists() {
+        return Ok(vec![]);
+    }
+    let entries = std::fs::read_dir(&agents_dir).map_err(|e| e.to_string())?;
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .filter_map(|e| e.file_name().to_str().map(String::from))
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+#[command]
+pub async fn read_claude_agent(name: String) -> Result<String, String> {
+    validate_filename(&name)?;
+    let path = get_claude_dir()?.join("agents").join(&name);
+    if !path.exists() {
+        return Err(format!("Agent file not found: {}", name));
+    }
+    std::fs::read_to_string(&path).map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn write_claude_agent(name: String, content: String) -> Result<(), String> {
+    validate_filename(&name)?;
+    let agents_dir = get_claude_dir()?.join("agents");
+    std::fs::create_dir_all(&agents_dir).map_err(|e| e.to_string())?;
+    std::fs::write(agents_dir.join(&name), &content).map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn delete_claude_agent(name: String) -> Result<(), String> {
+    validate_filename(&name)?;
+    let path = get_claude_dir()?.join("agents").join(&name);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[command]
+pub async fn list_claude_commands() -> Result<Vec<String>, String> {
+    let commands_dir = get_claude_dir()?.join("commands");
+    if !commands_dir.exists() {
+        return Ok(vec![]);
+    }
+    let entries = std::fs::read_dir(&commands_dir).map_err(|e| e.to_string())?;
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .filter_map(|e| e.file_name().to_str().map(String::from))
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+#[command]
+pub async fn read_claude_command(name: String) -> Result<String, String> {
+    validate_filename(&name)?;
+    let path = get_claude_dir()?.join("commands").join(&name);
+    if !path.exists() {
+        return Err(format!("Command file not found: {}", name));
+    }
+    std::fs::read_to_string(&path).map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn write_claude_command(name: String, content: String) -> Result<(), String> {
+    validate_filename(&name)?;
+    let commands_dir = get_claude_dir()?.join("commands");
+    std::fs::create_dir_all(&commands_dir).map_err(|e| e.to_string())?;
+    std::fs::write(commands_dir.join(&name), &content).map_err(|e| e.to_string())
+}
+
+#[command]
+pub async fn delete_claude_command(name: String) -> Result<(), String> {
+    validate_filename(&name)?;
+    let path = get_claude_dir()?.join("commands").join(&name);
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 // Agent Teams (multi-agent orchestration)
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,6 +67,16 @@ fn main() {
             commands::get_snippets,
             commands::delete_snippet,
             commands::get_active_teams,
+            commands::read_claude_settings,
+            commands::write_claude_settings,
+            commands::list_claude_agents,
+            commands::read_claude_agent,
+            commands::write_claude_agent,
+            commands::delete_claude_agent,
+            commands::list_claude_commands,
+            commands::read_claude_command,
+            commands::write_claude_command,
+            commands::delete_claude_command,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { CommandPalette } from './components/CommandPalette';
 import { SetupWizard } from './components/SetupWizard';
 import { AutoUpdater } from './components/AutoUpdater';
 import { WhatsNewModal } from './components/WhatsNewModal';
+import { ClaudeConfigModal } from './components/ClaudeConfigModal';
 import { OrchestrationPanel } from './components/OrchestrationPanel';
 import { useAppStore } from './store/appStore';
 import { useTerminalStore } from './store/terminalStore';
@@ -76,7 +77,7 @@ interface SavedTerminalConfig {
 }
 
 function App() {
-  const { sidebarOpen, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, whatsNewOpen, notifyOnFinish, restoreSession, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
+  const { sidebarOpen, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, whatsNewOpen, claudeConfigOpen, notifyOnFinish, restoreSession, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
   const { handleTerminalOutput, updateTerminalStatus, createTerminal } = useTerminalStore();
   const [showSetup, setShowSetup] = useState<boolean | null>(null);
   const { notify } = useNotification();
@@ -322,6 +323,7 @@ function App() {
             {sessionHistoryOpen && <SessionHistory />}
             {snippetsModalOpen && <SnippetsModal />}
             {whatsNewOpen && <WhatsNewModal />}
+            {claudeConfigOpen && <ClaudeConfigModal />}
           </AnimatePresence>
           {commandPaletteOpen && <CommandPalette />}
         </>

--- a/src/components/ClaudeConfigModal.tsx
+++ b/src/components/ClaudeConfigModal.tsx
@@ -1,0 +1,430 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { X, Plus, Trash2, Save, FileText, Settings, Terminal, AlertCircle, Check } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { useAppStore } from '../store/appStore';
+
+type Tab = 'settings' | 'agents' | 'commands';
+
+export function ClaudeConfigModal() {
+  const { closeClaudeConfig } = useAppStore();
+  const [activeTab, setActiveTab] = useState<Tab>('settings');
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={closeClaudeConfig}
+    >
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.15 }}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-bg-elevated ring-1 ring-white/[0.08] rounded-lg shadow-2xl w-full max-w-4xl overflow-hidden"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-4">
+            <h2 className="text-text-primary text-[14px] font-semibold">Claude Configuration</h2>
+            <div className="flex gap-1">
+              {([
+                { key: 'settings', label: 'Settings', icon: Settings },
+                { key: 'agents', label: 'Agents', icon: FileText },
+                { key: 'commands', label: 'Commands', icon: Terminal },
+              ] as const).map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => setActiveTab(key)}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-medium transition-colors ${
+                    activeTab === key
+                      ? 'bg-accent-primary/10 text-accent-primary ring-1 ring-accent-primary/30'
+                      : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.04]'
+                  }`}
+                >
+                  <Icon size={13} />
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={closeClaudeConfig}
+            className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="h-[560px]">
+          {activeTab === 'settings' && <SettingsTab />}
+          {activeTab === 'agents' && <FileListTab type="agents" />}
+          {activeTab === 'commands' && <FileListTab type="commands" />}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+// --- Settings Tab: JSON editor for ~/.claude/settings.json ---
+
+function SettingsTab() {
+  const [content, setContent] = useState('');
+  const [originalContent, setOriginalContent] = useState('');
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    setLoading(true);
+    try {
+      const raw = await invoke<string>('read_claude_settings');
+      // Pretty-print the JSON
+      const formatted = JSON.stringify(JSON.parse(raw), null, 2);
+      setContent(formatted);
+      setOriginalContent(formatted);
+    } catch (err) {
+      setContent('{}');
+      setOriginalContent('{}');
+    }
+    setLoading(false);
+  };
+
+  const handleSave = async () => {
+    setStatus('saving');
+    setError('');
+    try {
+      // Validate JSON before sending
+      JSON.parse(content);
+      await invoke('write_claude_settings', { content });
+      setOriginalContent(content);
+      setStatus('saved');
+      setTimeout(() => setStatus('idle'), 2000);
+    } catch (err) {
+      setStatus('error');
+      setError(String(err));
+    }
+  };
+
+  const hasChanges = content !== originalContent;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      if (hasChanges) handleSave();
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center text-text-tertiary text-[13px]">
+        Loading settings...
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
+        <div className="flex items-center gap-2">
+          <p className="text-text-secondary text-[12px]">~/.claude/settings.json</p>
+          {hasChanges && (
+            <span className="text-[11px] text-warning bg-warning/10 px-1.5 py-0.5 rounded">unsaved</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {status === 'error' && (
+            <div className="flex items-center gap-1.5 text-error text-[11px]">
+              <AlertCircle size={12} />
+              <span className="max-w-[200px] truncate">{error}</span>
+            </div>
+          )}
+          {status === 'saved' && (
+            <div className="flex items-center gap-1.5 text-success text-[11px]">
+              <Check size={12} />
+              Saved
+            </div>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={!hasChanges || status === 'saving'}
+            className="flex items-center gap-1.5 bg-accent-primary hover:bg-accent-secondary disabled:opacity-40 text-white h-7 px-3 rounded-md text-[12px] font-medium transition-colors"
+          >
+            <Save size={12} />
+            Save
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 p-4 overflow-hidden">
+        <textarea
+          value={content}
+          onChange={(e) => {
+            setContent(e.target.value);
+            setStatus('idle');
+            setError('');
+          }}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          className="w-full h-full bg-bg-primary ring-1 ring-border-light rounded-md p-3 text-text-primary text-[13px] font-mono resize-none focus:outline-none focus:ring-accent-primary transition-colors leading-relaxed"
+          placeholder='{ }'
+        />
+      </div>
+    </div>
+  );
+}
+
+// --- File List Tab: Agents or Commands ---
+
+function FileListTab({ type }: { type: 'agents' | 'commands' }) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [content, setContent] = useState('');
+  const [originalContent, setOriginalContent] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [newFileName, setNewFileName] = useState('');
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const listCommand = type === 'agents' ? 'list_claude_agents' : 'list_claude_commands';
+  const readCommand = type === 'agents' ? 'read_claude_agent' : 'read_claude_command';
+  const writeCommand = type === 'agents' ? 'write_claude_agent' : 'write_claude_command';
+  const deleteCommand = type === 'agents' ? 'delete_claude_agent' : 'delete_claude_command';
+
+  const loadFiles = useCallback(async () => {
+    setLoading(true);
+    try {
+      const names = await invoke<string[]>(listCommand);
+      setFiles(names);
+    } catch {
+      setFiles([]);
+    }
+    setLoading(false);
+  }, [listCommand]);
+
+  useEffect(() => {
+    loadFiles();
+  }, [loadFiles]);
+
+  const handleSelectFile = async (name: string) => {
+    try {
+      const fileContent = await invoke<string>(readCommand, { name });
+      setSelectedFile(name);
+      setContent(fileContent);
+      setOriginalContent(fileContent);
+      setIsCreating(false);
+      setStatus('idle');
+      setError('');
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const handleCreate = () => {
+    setIsCreating(true);
+    setSelectedFile(null);
+    setNewFileName(type === 'agents' ? 'new-agent.md' : 'new-command.md');
+    setContent(type === 'agents' ? getAgentTemplate() : getCommandTemplate());
+    setOriginalContent('');
+    setStatus('idle');
+    setError('');
+  };
+
+  const handleSave = async () => {
+    const name = isCreating ? newFileName : selectedFile;
+    if (!name) return;
+
+    setStatus('saving');
+    setError('');
+    try {
+      await invoke(writeCommand, { name, content });
+      setOriginalContent(content);
+      setStatus('saved');
+      if (isCreating) {
+        setIsCreating(false);
+        setSelectedFile(name);
+      }
+      await loadFiles();
+      setTimeout(() => setStatus('idle'), 2000);
+    } catch (err) {
+      setStatus('error');
+      setError(String(err));
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    try {
+      await invoke(deleteCommand, { name });
+      if (selectedFile === name) {
+        setSelectedFile(null);
+        setContent('');
+        setOriginalContent('');
+      }
+      await loadFiles();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const hasChanges = content !== originalContent;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      if (hasChanges || isCreating) handleSave();
+    }
+  };
+
+  const label = type === 'agents' ? 'Agent' : 'Command';
+  const dirPath = type === 'agents' ? '~/.claude/agents/' : '~/.claude/commands/';
+
+  return (
+    <div className="h-full flex">
+      {/* File List */}
+      <div className="w-56 border-r border-border p-3 flex flex-col">
+        <button
+          onClick={handleCreate}
+          className="flex items-center gap-2 w-full bg-accent-primary hover:bg-accent-secondary text-white py-2 px-3 rounded-md text-[12px] font-medium mb-3 transition-colors"
+        >
+          <Plus size={14} />
+          New {label}
+        </button>
+
+        <p className="text-text-tertiary text-[10px] mb-2 px-1">{dirPath}</p>
+
+        <div className="flex-1 overflow-y-auto space-y-0.5">
+          {loading ? (
+            <p className="text-text-tertiary text-[12px] text-center py-4">Loading...</p>
+          ) : files.length === 0 ? (
+            <p className="text-text-tertiary text-[12px] text-center py-4">
+              No {type} yet
+            </p>
+          ) : (
+            files.map((name) => (
+              <div
+                key={name}
+                onClick={() => handleSelectFile(name)}
+                className={`group flex items-center justify-between p-2 rounded-md cursor-pointer transition-colors ${
+                  selectedFile === name
+                    ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
+                    : 'hover:bg-white/[0.04]'
+                }`}
+              >
+                <p className="text-text-primary text-[12px] font-medium truncate flex-1">{name}</p>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(name);
+                  }}
+                  className="p-0.5 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0"
+                  title={`Delete ${name}`}
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="flex-1 flex flex-col">
+        {selectedFile || isCreating ? (
+          <>
+            <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
+              <div className="flex items-center gap-2">
+                {isCreating ? (
+                  <input
+                    type="text"
+                    value={newFileName}
+                    onChange={(e) => setNewFileName(e.target.value)}
+                    className="bg-bg-primary ring-1 ring-border-light rounded-md h-7 px-2 text-text-primary text-[12px] font-mono focus:outline-none focus:ring-accent-primary transition-colors w-48"
+                    placeholder="filename.md"
+                    autoFocus
+                  />
+                ) : (
+                  <p className="text-text-secondary text-[12px] font-mono">{selectedFile}</p>
+                )}
+                {hasChanges && (
+                  <span className="text-[11px] text-warning bg-warning/10 px-1.5 py-0.5 rounded">unsaved</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {status === 'error' && (
+                  <div className="flex items-center gap-1.5 text-error text-[11px]">
+                    <AlertCircle size={12} />
+                    <span className="max-w-[200px] truncate">{error}</span>
+                  </div>
+                )}
+                {status === 'saved' && (
+                  <div className="flex items-center gap-1.5 text-success text-[11px]">
+                    <Check size={12} />
+                    Saved
+                  </div>
+                )}
+                <button
+                  onClick={handleSave}
+                  disabled={(!hasChanges && !isCreating) || status === 'saving'}
+                  className="flex items-center gap-1.5 bg-accent-primary hover:bg-accent-secondary disabled:opacity-40 text-white h-7 px-3 rounded-md text-[12px] font-medium transition-colors"
+                >
+                  <Save size={12} />
+                  Save
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 p-4 overflow-hidden">
+              <textarea
+                value={content}
+                onChange={(e) => {
+                  setContent(e.target.value);
+                  setStatus('idle');
+                  setError('');
+                }}
+                onKeyDown={handleKeyDown}
+                spellCheck={false}
+                className="w-full h-full bg-bg-primary ring-1 ring-border-light rounded-md p-3 text-text-primary text-[13px] font-mono resize-none focus:outline-none focus:ring-accent-primary transition-colors leading-relaxed"
+                placeholder={`Enter ${type === 'agents' ? 'agent' : 'command'} content...`}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="h-full flex items-center justify-center text-text-tertiary text-[13px]">
+            Select a file or create a new {type === 'agents' ? 'agent' : 'command'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getAgentTemplate(): string {
+  return `# Agent Name
+
+Description of what this agent does.
+
+## Instructions
+
+- Instruction 1
+- Instruction 2
+`;
+}
+
+function getCommandTemplate(): string {
+  return `# Command Name
+
+Description of this command.
+
+## Steps
+
+$ARGUMENTS
+`;
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -372,6 +372,7 @@ export function SettingsModal() {
                 ['Split View', `${mod}+\\`],
                 ['Snippets', `${mod}+Shift+S`],
                 ['Search Terminal', `${mod}+Shift+F`],
+                ['Claude Config', 'F6'],
               ].map(([label, shortcut]) => (
                 <div key={label} className="flex justify-between text-[12px]">
                   <span className="text-text-secondary">{label}</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { AnimatePresence } from 'framer-motion';
-import { Plus, Search, MoreVertical, Copy, Trash2, Edit3, Tag, Grid3X3, FolderOpen, Clock, FileText } from 'lucide-react';
+import { Plus, Search, MoreVertical, Copy, Trash2, Edit3, Tag, Grid3X3, FolderOpen, Clock, FileText, Settings } from 'lucide-react';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
 
@@ -25,7 +25,7 @@ export function Sidebar() {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
   const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, updateLabel, updateNickname, unreadTerminalIds } = useTerminalStore();
-  const { openProfileModal, openNewTerminalModal, openWorkspaceModal, openSessionHistory, openSnippetsModal, addToGrid, removeFromGrid, gridTerminalIds, setGridMode } = useAppStore();
+  const { openProfileModal, openNewTerminalModal, openWorkspaceModal, openSessionHistory, openSnippetsModal, openClaudeConfig, addToGrid, removeFromGrid, gridTerminalIds, setGridMode } = useAppStore();
 
   const terminalList = useMemo(() =>
     Array.from(terminals.values())
@@ -275,6 +275,13 @@ export function Sidebar() {
         >
           <FileText size={13} />
           Snippets
+        </button>
+        <button
+          onClick={() => openClaudeConfig()}
+          className="w-full flex items-center justify-center gap-1.5 text-text-secondary hover:text-text-primary text-[12px] py-1.5 hover:bg-white/[0.04] rounded-md transition-colors"
+        >
+          <Settings size={13} />
+          Claude Config
         </button>
         <button
           onClick={() => openProfileModal()}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -97,6 +97,17 @@ export function useKeyboardShortcuts() {
         useAppStore.getState().toggleOrchestration();
       }
 
+      // Claude Config: F6
+      if (e.key === 'F6') {
+        e.preventDefault();
+        const state = useAppStore.getState();
+        if (state.claudeConfigOpen) {
+          state.closeClaudeConfig();
+        } else {
+          state.openClaudeConfig();
+        }
+      }
+
       // Toggle Grid Mode: Ctrl+G
       if (ctrl && e.key === 'g') {
         e.preventDefault();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -49,6 +49,9 @@ interface AppState {
   // Snippets (F5)
   snippetsModalOpen: boolean;
 
+  // Claude Config (F6)
+  claudeConfigOpen: boolean;
+
   // What's New
   whatsNewOpen: boolean;
   lastSeenVersion: string | null;
@@ -106,6 +109,10 @@ interface AppState {
   // Snippets actions (F5)
   openSnippetsModal: () => void;
   closeSnippetsModal: () => void;
+
+  // Claude Config actions (F6)
+  openClaudeConfig: () => void;
+  closeClaudeConfig: () => void;
 
   // What's New actions
   openWhatsNew: () => void;
@@ -182,6 +189,9 @@ export const useAppStore = create<AppState>()(
 
       // Snippets (F5)
       snippetsModalOpen: false,
+
+      // Claude Config (F6)
+      claudeConfigOpen: false,
 
       // What's New
       whatsNewOpen: false,
@@ -265,6 +275,10 @@ export const useAppStore = create<AppState>()(
       // Snippets actions (F5)
       openSnippetsModal: () => set({ snippetsModalOpen: true }),
       closeSnippetsModal: () => set({ snippetsModalOpen: false }),
+
+      // Claude Config actions (F6)
+      openClaudeConfig: () => set({ claudeConfigOpen: true }),
+      closeClaudeConfig: () => set({ claudeConfigOpen: false }),
 
       // What's New actions
       openWhatsNew: () => set({ whatsNewOpen: true }),


### PR DESCRIPTION
New feature to manage global Claude Code configuration from within the app:
- Settings tab: JSON editor for ~/.claude/settings.json
- Agents tab: Create/edit/delete files in ~/.claude/agents/
- Commands tab: Create/edit/delete files in ~/.claude/commands/
- 10 new Rust IPC commands with filename validation for security
- Accessible via F6 shortcut or sidebar "Claude Config" button