### PR TITLE
Add 8 advanced Claude Code features

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -451,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +479,8 @@ dependencies = [
  "notify-rust",
  "open",
  "portable-pty",
+ "regex",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1311,8 +1319,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1322,9 +1332,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1615,6 +1627,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2058,6 +2071,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2988,6 +3007,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,6 +3157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3180,6 +3283,44 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
@@ -3270,6 +3411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,6 +3470,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3369,6 +3517,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3589,6 +3743,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4075,7 +4241,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4301,7 +4467,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.1",
  "rustls",
  "semver",
  "serde",
@@ -4544,6 +4710,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5097,6 +5278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,6 +5336,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,8 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 directories = "5"
 open = "5"
 strip-ansi-escapes = "0.2"
+regex = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -865,6 +865,366 @@ pub async fn delete_claude_command(name: String) -> Result<(), String> {
     Ok(())
 }
 
+// Telemetry commands
+
+#[command]
+pub async fn get_installation_id(state: State<'_, AppState>) -> Result<String, String> {
+    let db = state.db.lock().await;
+    db.get_or_create_installation_id()
+}
+
+#[command]
+pub async fn send_telemetry_heartbeat(
+    state: State<'_, AppState>,
+    enabled: bool,
+    app_version: String,
+) -> Result<(), String> {
+    if !enabled {
+        return Ok(());
+    }
+    let installation_id = {
+        let db = state.db.lock().await;
+        db.get_or_create_installation_id()?
+    };
+    tokio::spawn(crate::telemetry::send_heartbeat(installation_id, app_version));
+    Ok(())
+}
+
+// Session summary commands
+
+#[command]
+pub async fn summarize_session(log_path: String) -> Result<Option<String>, String> {
+    // Validate path is under the logs directory
+    let data_dir = directories::ProjectDirs::from("com", "claudeterminal", "ClaudeTerminal")
+        .ok_or("Failed to get project directories")?
+        .data_dir()
+        .to_path_buf();
+    let logs_dir = data_dir.join("logs");
+    std::fs::create_dir_all(&logs_dir).map_err(|e| format!("Failed to create logs directory: {}", e))?;
+
+    let canonical_path = match std::path::Path::new(&log_path).canonicalize() {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+    let canonical_logs = logs_dir
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve logs directory: {}", e))?;
+    if !canonical_path.starts_with(&canonical_logs) {
+        return Err("Access denied: path is not under logs directory".to_string());
+    }
+
+    // Read log file content (capped at 100KB)
+    let bytes = match std::fs::read(&canonical_path) {
+        Ok(b) => b,
+        Err(_) => return Ok(None),
+    };
+    let max_bytes = 100 * 1024;
+    let truncated = if bytes.len() > max_bytes {
+        &bytes[bytes.len() - max_bytes..]
+    } else {
+        &bytes
+    };
+    let log_content = String::from_utf8_lossy(truncated);
+
+    // Strip ANSI escape sequences
+    let ansi_re = regex::Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07|\x1b\[.*?[A-Za-z]")
+        .unwrap();
+    let clean_content = ansi_re.replace_all(&log_content, "").to_string();
+
+    if clean_content.trim().is_empty() {
+        return Ok(None);
+    }
+
+    // Run claude -p to summarize
+    let mut cmd = shell_command("claude", &["-p", "--model", "haiku", "Summarize what was accomplished in this terminal session in 2-3 bullet points. Be concise."]);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(_) => return Ok(None), // Claude Code not available
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        let _ = stdin.write_all(clean_content.as_bytes());
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(_) => return Ok(None),
+    };
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let summary = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if summary.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(summary))
+}
+
+#[command]
+pub async fn save_session_summary(
+    state: State<'_, AppState>,
+    terminal_id: String,
+    summary: String,
+) -> Result<(), String> {
+    let db = state.db.lock().await;
+    db.save_session_summary(&terminal_id, &summary)
+}
+
+#[command]
+pub async fn get_session_summary(
+    state: State<'_, AppState>,
+    terminal_id: String,
+) -> Result<Option<String>, String> {
+    let db = state.db.lock().await;
+    db.get_session_summary(&terminal_id)
+}
+
+// Team tasks command
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskInfo {
+    pub id: String,
+    pub subject: String,
+    pub status: String,
+    pub owner: Option<String>,
+    pub blocked_by: Vec<String>,
+    pub active_form: Option<String>,
+}
+
+#[command]
+pub async fn get_team_tasks(team_name: String) -> Result<Vec<TaskInfo>, String> {
+    // Validate team_name doesn't contain path traversal
+    if team_name.contains('/') || team_name.contains('\\') || team_name.contains("..") || team_name.contains('\0') {
+        return Err("Invalid team name".to_string());
+    }
+
+    let home = if cfg!(target_os = "windows") {
+        std::env::var("USERPROFILE").map_err(|_| "USERPROFILE not set".to_string())?
+    } else {
+        std::env::var("HOME").map_err(|_| "HOME not set".to_string())?
+    };
+
+    let tasks_dir = std::path::Path::new(&home)
+        .join(".claude")
+        .join("tasks")
+        .join(&team_name);
+
+    if !tasks_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let entries = std::fs::read_dir(&tasks_dir).map_err(|e| e.to_string())?;
+    let mut tasks = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        // Skip .highwatermark and non-JSON files
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') || !name.ends_with(".json") {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let val: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let id = val.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let subject = val.get("subject").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let status = val.get("status").and_then(|v| v.as_str()).unwrap_or("pending").to_string();
+        let owner = val.get("owner").and_then(|v| v.as_str()).map(String::from);
+        let active_form = val.get("activeForm").and_then(|v| v.as_str()).map(String::from);
+        let blocked_by: Vec<String> = val.get("blockedBy")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+
+        if !id.is_empty() {
+            tasks.push(TaskInfo {
+                id,
+                subject,
+                status,
+                owner,
+                blocked_by,
+                active_form,
+            });
+        }
+    }
+
+    // Sort by id
+    tasks.sort_by(|a, b| a.id.cmp(&b.id));
+
+    Ok(tasks)
+}
+
+// Memory & CLAUDE.md commands
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryFileInfo {
+    pub path: String,
+    pub name: String,
+    pub project: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeMdInfo {
+    pub path: String,
+    pub scope: String,
+    pub project_name: Option<String>,
+}
+
+/// Validates that a path is under ~/.claude/
+fn validate_claude_path(path: &str) -> Result<(), String> {
+    let claude_dir = get_claude_dir()?;
+    let canonical_claude = claude_dir
+        .canonicalize()
+        .unwrap_or_else(|_| claude_dir.clone());
+    let target = std::path::Path::new(path);
+    let canonical_target = target
+        .canonicalize()
+        .unwrap_or_else(|_| target.to_path_buf());
+    if !canonical_target.starts_with(&canonical_claude) {
+        return Err("Access denied: path is not under ~/.claude/".to_string());
+    }
+    Ok(())
+}
+
+#[command]
+pub async fn list_memory_files(project_path: Option<String>) -> Result<Vec<MemoryFileInfo>, String> {
+    let claude_dir = get_claude_dir()?;
+    let projects_dir = claude_dir.join("projects");
+
+    if !projects_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut files = Vec::new();
+
+    let scan_project = |project_dir: &std::path::Path, files: &mut Vec<MemoryFileInfo>| {
+        let memory_dir = project_dir.join("memory");
+        if !memory_dir.exists() || !memory_dir.is_dir() {
+            return;
+        }
+        let project_name = project_dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        if let Ok(entries) = std::fs::read_dir(&memory_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                    files.push(MemoryFileInfo {
+                        path: path.to_string_lossy().to_string(),
+                        name,
+                        project: project_name.clone(),
+                        size,
+                    });
+                }
+            }
+        }
+    };
+
+    if let Some(ref specific_project) = project_path {
+        // Scan only the specific project
+        let target = std::path::Path::new(specific_project);
+        if target.exists() && target.is_dir() {
+            scan_project(target, &mut files);
+        }
+    } else {
+        // Scan all projects
+        if let Ok(entries) = std::fs::read_dir(&projects_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    scan_project(&path, &mut files);
+                }
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+#[command]
+pub async fn read_memory_file(path: String) -> Result<String, String> {
+    validate_claude_path(&path)?;
+    std::fs::read_to_string(&path).map_err(|e| format!("Failed to read memory file: {}", e))
+}
+
+#[command]
+pub async fn write_memory_file(path: String, content: String) -> Result<(), String> {
+    validate_claude_path(&path)?;
+    // Ensure parent directory exists
+    if let Some(parent) = std::path::Path::new(&path).parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&path, &content).map_err(|e| format!("Failed to write memory file: {}", e))
+}
+
+#[command]
+pub async fn list_claude_md_files() -> Result<Vec<ClaudeMdInfo>, String> {
+    let mut files = Vec::new();
+    let claude_dir = get_claude_dir()?;
+
+    // Global ~/.claude/CLAUDE.md
+    let global_md = claude_dir.join("CLAUDE.md");
+    if global_md.exists() {
+        files.push(ClaudeMdInfo {
+            path: global_md.to_string_lossy().to_string(),
+            scope: "global".to_string(),
+            project_name: None,
+        });
+    }
+
+    // Project-level CLAUDE.md files in ~/.claude/projects/*/
+    let projects_dir = claude_dir.join("projects");
+    if projects_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&projects_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let md_path = path.join("CLAUDE.md");
+                    if md_path.exists() {
+                        let project_name = entry.file_name().to_string_lossy().to_string();
+                        files.push(ClaudeMdInfo {
+                            path: md_path.to_string_lossy().to_string(),
+                            scope: "project".to_string(),
+                            project_name: Some(project_name),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(files)
+}
+
 // Agent Teams (multi-agent orchestration)
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -84,10 +84,21 @@ impl Database {
                 created_at TEXT NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS session_summaries (
+                terminal_id TEXT PRIMARY KEY,
+                summary TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+
             CREATE INDEX IF NOT EXISTS idx_profiles_name ON profiles(name);
             CREATE INDEX IF NOT EXISTS idx_workspaces_name ON workspaces(name);
             CREATE INDEX IF NOT EXISTS idx_session_history_terminal_id ON session_history(terminal_id);
             CREATE INDEX IF NOT EXISTS idx_snippets_category ON snippets(category);
+
+            CREATE TABLE IF NOT EXISTS app_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
             "
         ).map_err(|e| e.to_string())?;
 
@@ -311,5 +322,50 @@ impl Database {
         self.conn.execute("DELETE FROM snippets WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
         Ok(())
+    }
+
+    // Session summary methods
+
+    pub fn save_session_summary(&self, terminal_id: &str, summary: &str) -> Result<(), String> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO session_summaries (terminal_id, summary, created_at) VALUES (?1, ?2, ?3)",
+            params![terminal_id, summary, chrono::Utc::now().to_rfc3339()],
+        ).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn get_session_summary(&self, terminal_id: &str) -> Result<Option<String>, String> {
+        let result: Result<String, _> = self.conn.query_row(
+            "SELECT summary FROM session_summaries WHERE terminal_id = ?1",
+            params![terminal_id],
+            |row| row.get(0),
+        );
+        match result {
+            Ok(summary) => Ok(Some(summary)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    // App meta methods
+
+    pub fn get_or_create_installation_id(&self) -> Result<String, String> {
+        let result: Result<String, _> = self.conn.query_row(
+            "SELECT value FROM app_meta WHERE key = 'installation_id'",
+            [],
+            |row| row.get(0),
+        );
+        match result {
+            Ok(id) => Ok(id),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                let id = uuid::Uuid::new_v4().to_string();
+                self.conn.execute(
+                    "INSERT INTO app_meta (key, value) VALUES ('installation_id', ?1)",
+                    params![id],
+                ).map_err(|e| e.to_string())?;
+                Ok(id)
+            }
+            Err(e) => Err(e.to_string()),
+        }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ mod commands;
 mod terminal;
 mod config;
 mod database;
+mod telemetry;
 
 use tauri::Manager;
 use std::sync::Arc;
@@ -78,6 +79,16 @@ fn main() {
             commands::read_claude_command,
             commands::write_claude_command,
             commands::delete_claude_command,
+            commands::get_installation_id,
+            commands::send_telemetry_heartbeat,
+            commands::get_team_tasks,
+            commands::summarize_session,
+            commands::save_session_summary,
+            commands::get_session_summary,
+            commands::list_memory_files,
+            commands::read_memory_file,
+            commands::write_memory_file,
+            commands::list_claude_md_files,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -1,0 +1,50 @@
+use serde::Serialize;
+
+const WORKER_URL: &str = "https://ct-analytics.claudeterminal.workers.dev";
+
+#[derive(Serialize)]
+struct HeartbeatPayload {
+    installation_id: String,
+    app_version: String,
+    os: String,
+    os_version: String,
+    timestamp: String,
+}
+
+pub async fn send_heartbeat(installation_id: String, app_version: String) {
+    let os = std::env::consts::OS.to_string();
+    let os_version = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+
+    let payload = HeartbeatPayload {
+        installation_id,
+        app_version,
+        os,
+        os_version,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[telemetry] Failed to create HTTP client: {}", e);
+            return;
+        }
+    };
+
+    match client
+        .post(format!("{}/heartbeat", WORKER_URL))
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            eprintln!("[telemetry] Heartbeat sent (status: {})", resp.status());
+        }
+        Err(e) => {
+            eprintln!("[telemetry] Heartbeat failed: {}", e);
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src ipc: http://ipc.localhost https://github.com"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src ipc: http://ipc.localhost https://github.com https://ct-analytics.claudeterminal.workers.dev"
     }
   },
   "bundle": {
@@ -68,6 +68,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM3OUNBMEQ5MzI2RUYwNTgKUldSWThHNHkyYUNjeDAxWjV3WjBnZHVtQlpDKzFtMVFkNmVIbnJuQ3QzbVk4dHI2Sk84ZnB1MjcK",
       "endpoints": [
+        "https://ct-analytics.claudeterminal.workers.dev/update",
         "https://github.com/talayash/claude-terminal/releases/latest/download/latest.json"
       ],
       "windows": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import { AutoUpdater } from './components/AutoUpdater';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ClaudeConfigModal } from './components/ClaudeConfigModal';
 import { OrchestrationPanel } from './components/OrchestrationPanel';
+import { SessionTimeline } from './components/SessionTimeline';
+import { MemoryEditor } from './components/MemoryEditor';
 import { useAppStore } from './store/appStore';
 import { useTerminalStore } from './store/terminalStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -78,8 +80,8 @@ interface SavedTerminalConfig {
 }
 
 function App() {
-  const { sidebarOpen, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, whatsNewOpen, claudeConfigOpen, notifyOnFinish, restoreSession, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
-  const { handleTerminalOutput, updateTerminalStatus, createTerminal } = useTerminalStore();
+  const { sidebarOpen, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, whatsNewOpen, claudeConfigOpen, sessionTimelineOpen, memoryEditorOpen, notifyOnFinish, restoreSession, telemetryEnabled, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
+  const { handleTerminalOutput, updateTerminalStatus, setLoopMode, setSessionSummary, createTerminal } = useTerminalStore();
   const [showSetup, setShowSetup] = useState<boolean | null>(null);
   const { notify } = useNotification();
 
@@ -119,15 +121,35 @@ function App() {
     checkWhatsNew();
   }, [showSetup, lastSeenVersion, setLastSeenVersion, openWhatsNew]);
 
+  // Telemetry heartbeat — fire once on startup
+  useEffect(() => {
+    if (showSetup !== false) return;
+    getVersion().then((appVersion) => {
+      invoke('send_telemetry_heartbeat', { enabled: telemetryEnabled, appVersion }).catch(() => {});
+    });
+  }, [showSetup]);
+
   useEffect(() => {
     const unlisten = listen<{ id: string; data: number[] }>('terminal-output', (event) => {
-      handleTerminalOutput(event.payload.id, new Uint8Array(event.payload.data));
+      const { id, data } = event.payload;
+      handleTerminalOutput(id, new Uint8Array(data));
+
+      // Detect loop mode from terminal output
+      try {
+        const text = new TextDecoder().decode(new Uint8Array(data));
+        const loopMatch = text.match(/loop\s+(\d+[smh])\s+(.+)/i);
+        if (loopMatch) {
+          setLoopMode(id, { interval: loopMatch[1], prompt: loopMatch[2] });
+        }
+      } catch {
+        // Ignore decode errors
+      }
     });
 
     return () => {
       unlisten.then(fn => fn());
     };
-  }, [handleTerminalOutput]);
+  }, [handleTerminalOutput, setLoopMode]);
 
   useEffect(() => {
     const unlisten = listen<{ id: string }>('terminal-finished', (event) => {
@@ -144,12 +166,37 @@ function App() {
       if (notifyOnFinish) {
         notify('Terminal Finished', `${name} has finished running.`);
       }
+
+      // Auto-summarize the session
+      (async () => {
+        try {
+          // Check if we already have a summary
+          const existing = await invoke<string | null>('get_session_summary', { terminalId: id });
+          if (existing) {
+            setSessionSummary(id, existing);
+            return;
+          }
+
+          // Get the log path for this terminal
+          const sessions = await invoke<{ id: number; terminal_id: string; log_path: string | null }[]>('get_session_history');
+          const session = sessions.find(s => s.terminal_id === id);
+          if (!session?.log_path) return;
+
+          const summary = await invoke<string | null>('summarize_session', { logPath: session.log_path });
+          if (summary) {
+            await invoke('save_session_summary', { terminalId: id, summary });
+            setSessionSummary(id, summary);
+          }
+        } catch (err) {
+          console.error('Failed to summarize session:', err);
+        }
+      })();
     });
 
     return () => {
       unlisten.then(fn => fn());
     };
-  }, [notifyOnFinish, notify, updateTerminalStatus]);
+  }, [notifyOnFinish, notify, updateTerminalStatus, setSessionSummary]);
 
   // Restore previous session on startup — show banner instead of silently restoring
   useEffect(() => {
@@ -339,6 +386,8 @@ function App() {
             {snippetsModalOpen && <SnippetsModal />}
             {whatsNewOpen && <WhatsNewModal />}
             {claudeConfigOpen && <ClaudeConfigModal />}
+            {sessionTimelineOpen && <SessionTimeline />}
+            {memoryEditorOpen && <MemoryEditor />}
           </AnimatePresence>
           {commandPaletteOpen && <CommandPalette />}
         </>

--- a/src/components/MemoryEditor.tsx
+++ b/src/components/MemoryEditor.tsx
@@ -1,0 +1,438 @@
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { X, FileText, Brain, BookOpen, Save, RotateCw, ChevronRight } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { useAppStore } from '../store/appStore';
+
+interface ClaudeMdInfo {
+  path: string;
+  scope: string;
+  projectName: string | null;
+}
+
+interface MemoryFileInfo {
+  path: string;
+  name: string;
+  project: string;
+  size: number;
+}
+
+type Tab = 'claudemd' | 'memory' | 'rules';
+
+export function MemoryEditor() {
+  const { closeMemoryEditor } = useAppStore();
+  const [activeTab, setActiveTab] = useState<Tab>('claudemd');
+
+  // CLAUDE.md state
+  const [claudeMdFiles, setClaudeMdFiles] = useState<ClaudeMdInfo[]>([]);
+  const [selectedClaudeMd, setSelectedClaudeMd] = useState<ClaudeMdInfo | null>(null);
+  const [claudeMdContent, setClaudeMdContent] = useState('');
+  const [claudeMdDirty, setClaudeMdDirty] = useState(false);
+
+  // Memory state
+  const [memoryFiles, setMemoryFiles] = useState<MemoryFileInfo[]>([]);
+  const [selectedMemory, setSelectedMemory] = useState<MemoryFileInfo | null>(null);
+  const [memoryContent, setMemoryContent] = useState('');
+  const [memoryDirty, setMemoryDirty] = useState(false);
+
+  // Rules state
+  const [ruleFiles] = useState<MemoryFileInfo[]>([]);
+  const [selectedRule, setSelectedRule] = useState<MemoryFileInfo | null>(null);
+  const [ruleContent, setRuleContent] = useState('');
+  const [ruleDirty, setRuleDirty] = useState(false);
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadClaudeMdFiles();
+    loadMemoryFiles();
+  }, []);
+
+  const loadClaudeMdFiles = async () => {
+    try {
+      const files = await invoke<ClaudeMdInfo[]>('list_claude_md_files');
+      setClaudeMdFiles(files);
+    } catch (err) {
+      console.error('Failed to load CLAUDE.md files:', err);
+    }
+  };
+
+  const loadMemoryFiles = async () => {
+    try {
+      const files = await invoke<MemoryFileInfo[]>('list_memory_files', {});
+      setMemoryFiles(files);
+    } catch (err) {
+      console.error('Failed to load memory files:', err);
+    }
+  };
+
+  const handleSelectClaudeMd = async (file: ClaudeMdInfo) => {
+    setSelectedClaudeMd(file);
+    setLoading(true);
+    setError(null);
+    try {
+      const content = await invoke<string>('read_memory_file', { path: file.path });
+      setClaudeMdContent(content);
+      setClaudeMdDirty(false);
+    } catch (err) {
+      setError(String(err));
+      setClaudeMdContent('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveClaudeMd = async () => {
+    if (!selectedClaudeMd) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await invoke('write_memory_file', { path: selectedClaudeMd.path, content: claudeMdContent });
+      setClaudeMdDirty(false);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSelectMemory = async (file: MemoryFileInfo) => {
+    setSelectedMemory(file);
+    setLoading(true);
+    setError(null);
+    try {
+      const content = await invoke<string>('read_memory_file', { path: file.path });
+      setMemoryContent(content);
+      setMemoryDirty(false);
+    } catch (err) {
+      setError(String(err));
+      setMemoryContent('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveMemory = async () => {
+    if (!selectedMemory) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await invoke('write_memory_file', { path: selectedMemory.path, content: memoryContent });
+      setMemoryDirty(false);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSelectRule = async (file: MemoryFileInfo) => {
+    setSelectedRule(file);
+    setLoading(true);
+    setError(null);
+    try {
+      const content = await invoke<string>('read_memory_file', { path: file.path });
+      setRuleContent(content);
+      setRuleDirty(false);
+    } catch (err) {
+      setError(String(err));
+      setRuleContent('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveRule = async () => {
+    if (!selectedRule) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await invoke('write_memory_file', { path: selectedRule.path, content: ruleContent });
+      setRuleDirty(false);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Group memory files by project
+  const memoryByProject = memoryFiles.reduce<Record<string, MemoryFileInfo[]>>((acc, f) => {
+    if (!acc[f.project]) acc[f.project] = [];
+    acc[f.project].push(f);
+    return acc;
+  }, {});
+
+  const tabs: { key: Tab; label: string; icon: typeof FileText }[] = [
+    { key: 'claudemd', label: 'CLAUDE.md', icon: FileText },
+    { key: 'memory', label: 'Auto-Memory', icon: Brain },
+    { key: 'rules', label: 'Rules', icon: BookOpen },
+  ];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={closeMemoryEditor}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.98 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.98 }}
+        transition={{ duration: 0.15 }}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-bg-elevated ring-1 ring-white/[0.08] rounded-lg shadow-2xl w-full max-w-3xl overflow-hidden flex flex-col"
+        style={{ height: '600px' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Brain size={16} className="text-accent-primary" />
+            <h2 className="text-text-primary text-[14px] font-semibold">Memory Editor</h2>
+            <span className="text-text-tertiary text-[11px]">F8</span>
+          </div>
+          <button
+            onClick={closeMemoryEditor}
+            className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-border">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`flex items-center gap-1.5 px-4 py-2.5 text-[12px] font-medium border-b-2 transition-colors ${
+                activeTab === tab.key
+                  ? 'border-accent-primary text-accent-primary'
+                  : 'border-transparent text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              <tab.icon size={13} />
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex overflow-hidden">
+          {activeTab === 'claudemd' && (
+            <>
+              {/* File List */}
+              <div className="w-48 border-r border-border overflow-y-auto p-2 flex-shrink-0">
+                {claudeMdFiles.length === 0 ? (
+                  <p className="text-text-tertiary text-[11px] text-center py-4">No CLAUDE.md files found</p>
+                ) : (
+                  claudeMdFiles.map((file) => (
+                    <button
+                      key={file.path}
+                      onClick={() => handleSelectClaudeMd(file)}
+                      className={`w-full text-left p-2 rounded-md text-[12px] mb-0.5 transition-colors ${
+                        selectedClaudeMd?.path === file.path
+                          ? 'bg-accent-primary/10 text-accent-primary'
+                          : 'text-text-primary hover:bg-white/[0.04]'
+                      }`}
+                    >
+                      <div className="flex items-center gap-1">
+                        <FileText size={12} className="flex-shrink-0" />
+                        <span className="truncate">
+                          {file.scope === 'global' ? 'Global' : file.projectName || 'Project'}
+                        </span>
+                      </div>
+                      <span className="text-text-tertiary text-[10px] capitalize">{file.scope}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+
+              {/* Editor */}
+              <div className="flex-1 flex flex-col">
+                {selectedClaudeMd ? (
+                  <>
+                    <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+                      <span className="text-text-secondary text-[11px] truncate">{selectedClaudeMd.path}</span>
+                      <button
+                        onClick={handleSaveClaudeMd}
+                        disabled={!claudeMdDirty || saving}
+                        className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] bg-accent-primary/10 text-accent-primary hover:bg-accent-primary/20 disabled:opacity-40 transition-colors"
+                      >
+                        <Save size={11} />
+                        {saving ? 'Saving...' : 'Save'}
+                      </button>
+                    </div>
+                    {loading ? (
+                      <div className="flex-1 flex items-center justify-center">
+                        <RotateCw size={16} className="text-text-tertiary animate-spin" />
+                      </div>
+                    ) : (
+                      <textarea
+                        value={claudeMdContent}
+                        onChange={(e) => { setClaudeMdContent(e.target.value); setClaudeMdDirty(true); }}
+                        className="flex-1 bg-bg-primary p-3 text-text-primary text-[12px] font-mono resize-none focus:outline-none"
+                        spellCheck={false}
+                      />
+                    )}
+                  </>
+                ) : (
+                  <div className="flex-1 flex items-center justify-center text-text-tertiary text-[12px]">
+                    Select a file to edit
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {activeTab === 'memory' && (
+            <>
+              {/* File List */}
+              <div className="w-52 border-r border-border overflow-y-auto p-2 flex-shrink-0">
+                {Object.keys(memoryByProject).length === 0 ? (
+                  <p className="text-text-tertiary text-[11px] text-center py-4">No memory files found</p>
+                ) : (
+                  Object.entries(memoryByProject).map(([project, files]) => (
+                    <div key={project} className="mb-2">
+                      <div className="flex items-center gap-1 px-2 py-1 text-text-secondary text-[10px] font-medium uppercase tracking-wider">
+                        <ChevronRight size={10} />
+                        <span className="truncate">{project}</span>
+                      </div>
+                      {files.map((file) => (
+                        <button
+                          key={file.path}
+                          onClick={() => handleSelectMemory(file)}
+                          className={`w-full text-left p-2 rounded-md text-[12px] mb-0.5 transition-colors ${
+                            selectedMemory?.path === file.path
+                              ? 'bg-accent-primary/10 text-accent-primary'
+                              : 'text-text-primary hover:bg-white/[0.04]'
+                          }`}
+                        >
+                          <div className="flex items-center gap-1">
+                            <Brain size={12} className="flex-shrink-0" />
+                            <span className="truncate">{file.name}</span>
+                          </div>
+                          <span className="text-text-tertiary text-[10px]">
+                            {file.size > 1024 ? `${(file.size / 1024).toFixed(1)}KB` : `${file.size}B`}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {/* Editor */}
+              <div className="flex-1 flex flex-col">
+                {selectedMemory ? (
+                  <>
+                    <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+                      <span className="text-text-secondary text-[11px] truncate">{selectedMemory.name}</span>
+                      <button
+                        onClick={handleSaveMemory}
+                        disabled={!memoryDirty || saving}
+                        className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] bg-accent-primary/10 text-accent-primary hover:bg-accent-primary/20 disabled:opacity-40 transition-colors"
+                      >
+                        <Save size={11} />
+                        {saving ? 'Saving...' : 'Save'}
+                      </button>
+                    </div>
+                    {loading ? (
+                      <div className="flex-1 flex items-center justify-center">
+                        <RotateCw size={16} className="text-text-tertiary animate-spin" />
+                      </div>
+                    ) : (
+                      <textarea
+                        value={memoryContent}
+                        onChange={(e) => { setMemoryContent(e.target.value); setMemoryDirty(true); }}
+                        className="flex-1 bg-bg-primary p-3 text-text-primary text-[12px] font-mono resize-none focus:outline-none"
+                        spellCheck={false}
+                      />
+                    )}
+                  </>
+                ) : (
+                  <div className="flex-1 flex items-center justify-center text-text-tertiary text-[12px]">
+                    Select a memory file to view/edit
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {activeTab === 'rules' && (
+            <>
+              <div className="w-48 border-r border-border overflow-y-auto p-2 flex-shrink-0">
+                {ruleFiles.length === 0 ? (
+                  <p className="text-text-tertiary text-[11px] text-center py-4">No rule files found</p>
+                ) : (
+                  ruleFiles.map((file) => (
+                    <button
+                      key={file.path}
+                      onClick={() => handleSelectRule(file)}
+                      className={`w-full text-left p-2 rounded-md text-[12px] mb-0.5 transition-colors ${
+                        selectedRule?.path === file.path
+                          ? 'bg-accent-primary/10 text-accent-primary'
+                          : 'text-text-primary hover:bg-white/[0.04]'
+                      }`}
+                    >
+                      <div className="flex items-center gap-1">
+                        <BookOpen size={12} className="flex-shrink-0" />
+                        <span className="truncate">{file.name}</span>
+                      </div>
+                    </button>
+                  ))
+                )}
+              </div>
+
+              <div className="flex-1 flex flex-col">
+                {selectedRule ? (
+                  <>
+                    <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+                      <span className="text-text-secondary text-[11px] truncate">{selectedRule.name}</span>
+                      <button
+                        onClick={handleSaveRule}
+                        disabled={!ruleDirty || saving}
+                        className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] bg-accent-primary/10 text-accent-primary hover:bg-accent-primary/20 disabled:opacity-40 transition-colors"
+                      >
+                        <Save size={11} />
+                        {saving ? 'Saving...' : 'Save'}
+                      </button>
+                    </div>
+                    {loading ? (
+                      <div className="flex-1 flex items-center justify-center">
+                        <RotateCw size={16} className="text-text-tertiary animate-spin" />
+                      </div>
+                    ) : (
+                      <textarea
+                        value={ruleContent}
+                        onChange={(e) => { setRuleContent(e.target.value); setRuleDirty(true); }}
+                        className="flex-1 bg-bg-primary p-3 text-text-primary text-[12px] font-mono resize-none focus:outline-none"
+                        spellCheck={false}
+                      />
+                    )}
+                  </>
+                ) : (
+                  <div className="flex-1 flex items-center justify-center text-text-tertiary text-[12px]">
+                    Select a rule file to view/edit
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Error display */}
+        {error && (
+          <div className="px-4 py-2 border-t border-border">
+            <p className="text-error text-[11px]">{error}</p>
+          </div>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/NewTerminalModal.tsx
+++ b/src/components/NewTerminalModal.tsx
@@ -42,6 +42,9 @@ export function NewTerminalModal() {
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [defaultDirectory, setDefaultDirectory] = useState('');
+  const [useWorktree, setUseWorktree] = useState(false);
+  const [selectedModel, setSelectedModel] = useState<'default' | 'opus' | 'sonnet' | 'haiku'>('default');
+  const [selectedEffort, setSelectedEffort] = useState<'default' | 'low' | 'medium' | 'high'>('default');
 
   useEffect(() => {
     loadProfiles();
@@ -130,10 +133,22 @@ export function NewTerminalModal() {
       const label = `${baseName} ${terminals.size + 1}`;
       const colorTag = TAG_COLORS[terminals.size % TAG_COLORS.length];
 
+      // Build final args with model, effort, and worktree prepended
+      const finalArgs = [...claudeArgs];
+      if (selectedModel !== 'default') {
+        finalArgs.unshift('--model', selectedModel);
+      }
+      if (selectedEffort !== 'default') {
+        finalArgs.unshift('--effort', selectedEffort);
+      }
+      if (useWorktree) {
+        finalArgs.unshift('--worktree');
+      }
+
       await createTerminal(
         label,
         workingDirectory,
-        claudeArgs,
+        finalArgs,
         envVars,
         colorTag,
         nickname || undefined
@@ -270,6 +285,69 @@ export function NewTerminalModal() {
               Command: <code className="text-text-secondary">claude {claudeArgs.join(' ')}</code>
             </p>
           </div>
+          {/* Worktree Toggle */}
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="text-text-secondary text-[12px]">Isolated Worktree</label>
+              <p className="text-text-tertiary text-[11px]">Run in a separate git worktree</p>
+            </div>
+            <button
+              onClick={() => setUseWorktree(!useWorktree)}
+              className={`relative w-9 h-5 rounded-full transition-colors ${
+                useWorktree ? 'bg-accent-primary' : 'bg-border-light'
+              }`}
+            >
+              <div
+                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                  useWorktree ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+
+          {/* Model Selector */}
+          <div>
+            <label className="block text-text-secondary text-[12px] mb-1.5">Model</label>
+            <div className="flex gap-1.5">
+              {(['default', 'opus', 'sonnet', 'haiku'] as const).map((model) => (
+                <button
+                  key={model}
+                  onClick={() => setSelectedModel(model)}
+                  className={`px-3 py-1.5 rounded-md text-[12px] font-medium transition-colors ${
+                    selectedModel === model
+                      ? model === 'opus' ? 'bg-purple-500/20 text-purple-400 ring-1 ring-purple-500/30'
+                      : model === 'sonnet' ? 'bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30'
+                      : model === 'haiku' ? 'bg-green-500/20 text-green-400 ring-1 ring-green-500/30'
+                      : 'bg-accent-primary/10 text-accent-primary ring-1 ring-accent-primary/30'
+                      : 'bg-bg-primary ring-1 ring-border-light text-text-secondary hover:ring-border'
+                  }`}
+                >
+                  {model === 'default' ? 'Default' : model.charAt(0).toUpperCase() + model.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Effort Selector */}
+          <div>
+            <label className="block text-text-secondary text-[12px] mb-1.5">Effort</label>
+            <div className="flex gap-1.5">
+              {(['default', 'low', 'medium', 'high'] as const).map((effort) => (
+                <button
+                  key={effort}
+                  onClick={() => setSelectedEffort(effort)}
+                  className={`px-3 py-1.5 rounded-md text-[12px] font-medium transition-colors ${
+                    selectedEffort === effort
+                      ? 'bg-accent-primary/10 text-accent-primary ring-1 ring-accent-primary/30'
+                      : 'bg-bg-primary ring-1 ring-border-light text-text-secondary hover:ring-border'
+                  }`}
+                >
+                  {effort === 'default' ? 'Default' : effort.charAt(0).toUpperCase() + effort.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
           {error && (
             <div className="p-3 rounded-md bg-error/5 ring-1 ring-error/20">
               <p className="text-error text-[12px]">{error}</p>

--- a/src/components/OrchestrationPanel.tsx
+++ b/src/components/OrchestrationPanel.tsx
@@ -26,6 +26,15 @@ interface TeamInfo {
   taskCount?: number;
 }
 
+interface TaskInfo {
+  id: string;
+  subject: string;
+  status: string;
+  owner: string | null;
+  blockedBy: string[];
+  activeForm: string | null;
+}
+
 function normalizePath(p: string): string {
   return p.toLowerCase().replace(/\\/g, '/').replace(/\/+$/, '');
 }
@@ -33,6 +42,7 @@ function normalizePath(p: string): string {
 export function OrchestrationPanel() {
   const [teams, setTeams] = useState<TeamInfo[]>([]);
   const [expandedTeam, setExpandedTeam] = useState<string | null>(null);
+  const [tasks, setTasks] = useState<Map<string, TaskInfo[]>>(new Map());
   const [loading, setLoading] = useState(false);
   const terminals = useTerminalStore((s) => s.terminals);
   const setActiveTerminal = useTerminalStore((s) => s.setActiveTerminal);
@@ -42,6 +52,20 @@ export function OrchestrationPanel() {
     try {
       const result = await invoke<TeamInfo[]>('get_active_teams');
       setTeams(result);
+
+      // Fetch tasks for expanded team
+      if (expandedTeam) {
+        try {
+          const teamTasks = await invoke<TaskInfo[]>('get_team_tasks', { teamName: expandedTeam });
+          setTasks((prev) => {
+            const next = new Map(prev);
+            next.set(expandedTeam, teamTasks);
+            return next;
+          });
+        } catch {
+          // Task fetch failed silently
+        }
+      }
     } catch (err) {
       console.error('Failed to fetch teams:', err);
     } finally {
@@ -49,11 +73,29 @@ export function OrchestrationPanel() {
     }
   };
 
+  const handleExpand = async (dirName: string) => {
+    const newExpanded = expandedTeam === dirName ? null : dirName;
+    setExpandedTeam(newExpanded);
+
+    if (newExpanded) {
+      try {
+        const teamTasks = await invoke<TaskInfo[]>('get_team_tasks', { teamName: newExpanded });
+        setTasks((prev) => {
+          const next = new Map(prev);
+          next.set(newExpanded, teamTasks);
+          return next;
+        });
+      } catch {
+        // Task fetch failed silently
+      }
+    }
+  };
+
   useEffect(() => {
     fetchTeams();
     const interval = setInterval(fetchTeams, 3000);
     return () => clearInterval(interval);
-  }, []);
+  }, [expandedTeam]);
 
   const findMatchingTerminal = (cwd: string): string | null => {
     const normalized = normalizePath(cwd);
@@ -111,7 +153,7 @@ export function OrchestrationPanel() {
             return (
               <div key={team.dirName} className="mb-1">
                 <button
-                  onClick={() => setExpandedTeam(isExpanded ? null : team.dirName)}
+                  onClick={() => handleExpand(team.dirName)}
                   className="w-full flex items-center gap-2 p-2 rounded-md hover:bg-white/[0.04] transition-colors"
                 >
                   {isExpanded ? (
@@ -176,6 +218,50 @@ export function OrchestrationPanel() {
                         </div>
                       </div>
                     ))}
+
+                    {/* Task Board */}
+                    {tasks.get(team.dirName) && tasks.get(team.dirName)!.length > 0 && (
+                      <div className="mt-2 pt-2 border-t border-border/50">
+                        <div className="flex items-center gap-1.5 px-1.5 mb-1.5">
+                          <ListTodo size={11} className="text-text-tertiary" />
+                          <span className="text-text-tertiary text-[10px] font-medium uppercase tracking-wider">Tasks</span>
+                        </div>
+                        {tasks.get(team.dirName)!.map((task) => (
+                          <div key={task.id} className="flex items-start gap-2 p-1.5 rounded-md hover:bg-white/[0.02]">
+                            <div className="mt-1 flex-shrink-0">
+                              <div
+                                className={`w-2 h-2 rounded-full ${
+                                  task.status === 'completed' ? 'bg-success' :
+                                  task.status === 'in_progress' ? 'bg-warning animate-pulse' :
+                                  'bg-text-tertiary'
+                                }`}
+                              />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <p className={`text-[11px] truncate ${
+                                task.status === 'completed' ? 'text-text-tertiary line-through' : 'text-text-primary'
+                              }`}>
+                                {task.status === 'in_progress' && task.activeForm
+                                  ? task.activeForm
+                                  : task.subject}
+                              </p>
+                              <div className="flex items-center gap-1.5 mt-0.5">
+                                {task.owner && (
+                                  <span className="text-[9px] text-text-tertiary bg-bg-primary px-1 rounded">
+                                    {task.owner}
+                                  </span>
+                                )}
+                                {task.blockedBy.length > 0 && (
+                                  <span className="text-[9px] text-warning bg-warning/10 px-1 rounded">
+                                    blocked
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/SessionInsights.tsx
+++ b/src/components/SessionInsights.tsx
@@ -1,0 +1,19 @@
+import { Sparkles } from 'lucide-react';
+
+interface SessionInsightsProps {
+  summary: string;
+}
+
+export function SessionInsights({ summary }: SessionInsightsProps) {
+  return (
+    <div className="bg-accent-primary/5 ring-1 ring-accent-primary/20 rounded-md p-3 mx-3 mb-3">
+      <div className="flex items-start gap-2">
+        <Sparkles size={14} className="text-accent-primary flex-shrink-0 mt-0.5" />
+        <div>
+          <p className="text-text-secondary text-[11px] font-medium mb-1">Session Summary</p>
+          <p className="text-text-primary text-[12px] whitespace-pre-wrap leading-relaxed">{summary}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { X, Clock, Play, Search, RotateCw } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { useAppStore } from '../store/appStore';
+import { useTerminalStore } from '../store/terminalStore';
+
+interface SessionHistoryEntry {
+  id: number;
+  terminal_id: string;
+  label: string;
+  started_at: string;
+  ended_at: string | null;
+  log_path: string | null;
+}
+
+function formatDuration(start: string, end: string | null): string {
+  if (!end) return 'running';
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 0) return '—';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function formatTime(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+export function SessionTimeline() {
+  const { closeSessionTimeline } = useAppStore();
+  const { createTerminal, terminals } = useTerminalStore();
+  const [sessions, setSessions] = useState<SessionHistoryEntry[]>([]);
+  const [filter, setFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [resuming, setResuming] = useState<number | null>(null);
+
+  const fetchSessions = async () => {
+    setLoading(true);
+    try {
+      const result = await invoke<SessionHistoryEntry[]>('get_session_history');
+      setSessions(result);
+    } catch (err) {
+      console.error('Failed to fetch session history:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!filter) return sessions;
+    const lower = filter.toLowerCase();
+    return sessions.filter((s) => s.label.toLowerCase().includes(lower));
+  }, [sessions, filter]);
+
+  const handleResume = async (session: SessionHistoryEntry) => {
+    setResuming(session.id);
+    try {
+      const label = `${session.label} (resumed)`;
+      const colorTags = [
+        'bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500',
+        'bg-blue-500', 'bg-purple-500', 'bg-pink-500',
+      ];
+      const colorTag = colorTags[terminals.size % colorTags.length];
+
+      await createTerminal(label, '.', ['--continue'], {}, colorTag);
+      closeSessionTimeline();
+    } catch (err) {
+      console.error('Failed to resume session:', err);
+    } finally {
+      setResuming(null);
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={closeSessionTimeline}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.98 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.98 }}
+        transition={{ duration: 0.15 }}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-bg-elevated ring-1 ring-white/[0.08] rounded-lg shadow-2xl w-full max-w-2xl overflow-hidden max-h-[80vh] flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Clock size={16} className="text-accent-primary" />
+            <h2 className="text-text-primary text-[14px] font-semibold">Session Timeline</h2>
+            <span className="text-text-tertiary text-[11px]">F7</span>
+          </div>
+          <button
+            onClick={closeSessionTimeline}
+            className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Filter */}
+        <div className="px-4 pt-3 pb-2">
+          <div className="relative">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" />
+            <input
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter sessions..."
+              className="w-full bg-bg-primary ring-1 ring-border-light rounded-md py-1.5 pl-8 pr-3 text-[12px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-accent-primary transition-colors"
+            />
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <div className="flex-1 overflow-y-auto px-4 pb-4">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <RotateCw size={16} className="text-text-tertiary animate-spin" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="text-center py-12">
+              <Clock size={32} className="text-text-tertiary mx-auto mb-3" />
+              <p className="text-text-secondary text-[13px]">
+                {filter ? 'No sessions match your filter' : 'No session history yet'}
+              </p>
+            </div>
+          ) : (
+            <div className="relative">
+              {/* Timeline line */}
+              <div className="absolute left-3 top-0 bottom-0 w-px bg-border" />
+
+              {filtered.map((session) => {
+                const isRunning = !session.ended_at;
+                return (
+                  <div key={session.id} className="relative flex gap-4 pb-4">
+                    {/* Timeline dot */}
+                    <div className="relative z-10 mt-1.5 flex-shrink-0">
+                      <div
+                        className={`w-2.5 h-2.5 rounded-full ring-2 ring-bg-elevated ${
+                          isRunning ? 'bg-success animate-pulse' : 'bg-text-tertiary'
+                        }`}
+                        style={{ marginLeft: '5px' }}
+                      />
+                    </div>
+
+                    {/* Content */}
+                    <div className="flex-1 bg-bg-primary ring-1 ring-border-light rounded-md p-3 group hover:ring-border transition-colors">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-text-primary text-[12px] font-medium truncate">
+                              {session.label}
+                            </span>
+                            {isRunning && (
+                              <span className="text-[10px] text-success bg-success/10 px-1.5 py-0.5 rounded-full font-medium">
+                                running
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-3 mt-1">
+                            <span className="text-text-tertiary text-[11px]">
+                              {formatTime(session.started_at)}
+                            </span>
+                            <span className="text-text-tertiary text-[11px]">
+                              {formatDuration(session.started_at, session.ended_at)}
+                            </span>
+                          </div>
+                        </div>
+
+                        {!isRunning && (
+                          <button
+                            onClick={() => handleResume(session)}
+                            disabled={resuming === session.id}
+                            className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-accent-primary bg-accent-primary/10 hover:bg-accent-primary/20 transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-50 flex-shrink-0"
+                          >
+                            <Play size={10} />
+                            {resuming === session.id ? 'Resuming...' : 'Resume'}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -16,7 +16,7 @@ interface UpdateCheckResult {
 }
 
 export function SettingsModal() {
-  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession } = useAppStore();
+  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession, telemetryEnabled, setTelemetryEnabled } = useAppStore();
   const [claudeVersion, setClaudeVersion] = useState<string>('');
   const [latestVersion, setLatestVersion] = useState<string>('');
   const [updateAvailable, setUpdateAvailable] = useState<boolean | null>(null);
@@ -347,6 +347,35 @@ export function SettingsModal() {
                   <span
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
                       restoreSession ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Analytics */}
+          <div>
+            <h3 className="text-text-primary text-[13px] font-medium mb-2">Analytics</h3>
+            <div className="bg-bg-primary rounded-md ring-1 ring-border p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-text-primary text-[13px]">Anonymous usage analytics</p>
+                  <p className="text-text-tertiary text-[11px] mt-0.5">
+                    Send anonymous app version and OS info to help improve ClaudeTerminal
+                  </p>
+                </div>
+                <button
+                  onClick={() => {
+                    setTelemetryEnabled(!telemetryEnabled);
+                  }}
+                  className={`relative w-10 h-5 rounded-full transition-colors ${
+                    telemetryEnabled ? 'bg-accent-primary' : 'bg-border-light'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                      telemetryEnabled ? 'translate-x-5' : 'translate-x-0'
                     }`}
                   />
                 </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { AnimatePresence } from 'framer-motion';
-import { Plus, Search, MoreVertical, Copy, Trash2, Edit3, Tag, Grid3X3, FolderOpen, Clock, FileText, Settings } from 'lucide-react';
+import { Plus, Search, MoreVertical, Copy, Trash2, Edit3, Tag, Grid3X3, FolderOpen, Clock, FileText, Settings, GitBranch, Brain } from 'lucide-react';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
 
@@ -25,7 +25,7 @@ export function Sidebar() {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
   const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, updateLabel, updateNickname, unreadTerminalIds } = useTerminalStore();
-  const { openProfileModal, openNewTerminalModal, openWorkspaceModal, openSessionHistory, openSnippetsModal, openClaudeConfig, addToGrid, removeFromGrid, gridTerminalIds, setGridMode } = useAppStore();
+  const { openProfileModal, openNewTerminalModal, openWorkspaceModal, openSessionHistory, openSnippetsModal, openClaudeConfig, openSessionTimeline, openMemoryEditor, addToGrid, removeFromGrid, gridTerminalIds, setGridMode } = useAppStore();
 
   const terminalList = useMemo(() =>
     Array.from(terminals.values())
@@ -142,6 +142,29 @@ export function Sidebar() {
                       }`}>
                         {STATUS_LABELS[terminal.status]}
                       </span>
+                      {(() => {
+                        const instance = terminals.get(terminal.id);
+                        return (
+                          <>
+                            {instance?.isWorktree && (
+                              <GitBranch size={10} className="text-cyan-400 flex-shrink-0" />
+                            )}
+                            {instance?.loopInfo && (
+                              <span className="w-1.5 h-1.5 rounded-full bg-purple-400 animate-pulse flex-shrink-0" title={`Loop: ${instance.loopInfo.interval}`} />
+                            )}
+                            {instance?.model && (
+                              <span className={`text-[9px] px-1 rounded font-medium flex-shrink-0 ${
+                                instance.model === 'opus' ? 'bg-purple-500/20 text-purple-400' :
+                                instance.model === 'sonnet' ? 'bg-blue-500/20 text-blue-400' :
+                                instance.model === 'haiku' ? 'bg-green-500/20 text-green-400' :
+                                'bg-white/[0.06] text-text-tertiary'
+                              }`}>
+                                {instance.model}
+                              </span>
+                            )}
+                          </>
+                        );
+                      })()}
                     </div>
                     <p className="text-text-tertiary text-[11px] truncate mt-0.5">
                       {terminal.working_directory}
@@ -277,11 +300,25 @@ export function Sidebar() {
           Snippets
         </button>
         <button
+          onClick={() => openSessionTimeline()}
+          className="w-full flex items-center justify-center gap-1.5 text-text-secondary hover:text-text-primary text-[12px] py-1.5 hover:bg-white/[0.04] rounded-md transition-colors"
+        >
+          <Clock size={13} />
+          Session Timeline
+        </button>
+        <button
           onClick={() => openClaudeConfig()}
           className="w-full flex items-center justify-center gap-1.5 text-text-secondary hover:text-text-primary text-[12px] py-1.5 hover:bg-white/[0.04] rounded-md transition-colors"
         >
           <Settings size={13} />
           Claude Config
+        </button>
+        <button
+          onClick={() => openMemoryEditor()}
+          className="w-full flex items-center justify-center gap-1.5 text-text-secondary hover:text-text-primary text-[12px] py-1.5 hover:bg-white/[0.04] rounded-md transition-colors"
+        >
+          <Brain size={13} />
+          Memory Editor
         </button>
         <button
           onClick={() => openProfileModal()}

--- a/src/components/TeleportActions.tsx
+++ b/src/components/TeleportActions.tsx
@@ -1,0 +1,39 @@
+import { Globe, Smartphone } from 'lucide-react';
+import { useTerminalStore } from '../store/terminalStore';
+
+interface TeleportActionsProps {
+  terminalId: string;
+}
+
+export function TeleportActions({ terminalId }: TeleportActionsProps) {
+  const { writeToTerminal } = useTerminalStore();
+
+  const handleTeleport = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await writeToTerminal(terminalId, '/teleport\n');
+  };
+
+  const handleRemoteControl = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await writeToTerminal(terminalId, '/remote-control\n');
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        onClick={handleTeleport}
+        title="Teleport to Web"
+        className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary hover:text-accent-primary transition-colors"
+      >
+        <Globe size={12} />
+      </button>
+      <button
+        onClick={handleRemoteControl}
+        title="Remote Control"
+        className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary hover:text-accent-primary transition-colors"
+      >
+        <Smartphone size={12} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import { AnimatePresence, Reorder } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw } from 'lucide-react';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch } from 'lucide-react';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
 import { TerminalView } from './TerminalView';
 import { TerminalGrid } from './TerminalGrid';
 import { SplitView } from './SplitView';
+import { TeleportActions } from './TeleportActions';
+import { SessionInsights } from './SessionInsights';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
@@ -93,7 +95,14 @@ export function TerminalTabs() {
             onReorder={() => {}}
             className="flex items-center overflow-x-auto"
           >
-            {terminalList.map((terminal) => (
+            {terminalList.map((terminal) => {
+              const instance = terminals.get(terminal.id);
+              const model = instance?.model;
+              const isWorktree = instance?.isWorktree;
+              const loopInfo = instance?.loopInfo;
+              const isRunning = terminal.status === 'Running';
+
+              return (
               <Reorder.Item
                 key={terminal.id}
                 value={terminal}
@@ -113,7 +122,27 @@ export function TerminalTabs() {
                   {terminal.color_tag && (
                     <div className={`w-2 h-2 rounded-full ${terminal.color_tag} flex-shrink-0`} />
                   )}
+                  {/* Badges */}
+                  {model && (
+                    <span className={`text-[9px] px-1 rounded font-medium flex-shrink-0 ${
+                      model === 'opus' ? 'bg-purple-500/20 text-purple-400' :
+                      model === 'sonnet' ? 'bg-blue-500/20 text-blue-400' :
+                      model === 'haiku' ? 'bg-green-500/20 text-green-400' :
+                      'bg-white/[0.06] text-text-tertiary'
+                    }`}>
+                      {model}
+                    </span>
+                  )}
+                  {isWorktree && (
+                    <GitBranch size={10} className="text-cyan-400 flex-shrink-0" />
+                  )}
+                  {loopInfo && (
+                    <span className="w-2 h-2 rounded-full bg-purple-400 animate-pulse flex-shrink-0" title={`Loop: ${loopInfo.interval}`} />
+                  )}
                   <span className="max-w-[160px] truncate">{terminal.nickname || terminal.label}</span>
+                  {isRunning && (
+                    <TeleportActions terminalId={terminal.id} />
+                  )}
                   <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                     {activeTerminalId && terminal.id !== activeTerminalId && (
                       <button
@@ -151,7 +180,8 @@ export function TerminalTabs() {
                   </div>
                 </button>
               </Reorder.Item>
-            ))}
+              );
+            })}
           </Reorder.Group>
 
           <button
@@ -191,9 +221,18 @@ export function TerminalTabs() {
           {activeTerminalId ? (
             <div
               key={activeTerminalId}
-              className="absolute inset-0"
+              className="absolute inset-0 flex flex-col"
             >
-              <TerminalView terminalId={activeTerminalId} />
+              <div className="flex-1 min-h-0">
+                <TerminalView terminalId={activeTerminalId} />
+              </div>
+              {(() => {
+                const inst = terminals.get(activeTerminalId);
+                if (inst?.config.status === 'Stopped' && inst?.sessionSummary) {
+                  return <SessionInsights summary={inst.sessionSummary} />;
+                }
+                return null;
+              })()}
             </div>
           ) : (
             <div className="absolute inset-0 flex flex-col items-center justify-center text-text-secondary">

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -108,6 +108,23 @@ export function useKeyboardShortcuts() {
         }
       }
 
+      // Session Timeline: F7
+      if (e.key === 'F7') {
+        e.preventDefault();
+        useAppStore.getState().toggleSessionTimeline();
+      }
+
+      // Memory Editor: F8
+      if (e.key === 'F8') {
+        e.preventDefault();
+        const state = useAppStore.getState();
+        if (state.memoryEditorOpen) {
+          state.closeMemoryEditor();
+        } else {
+          state.openMemoryEditor();
+        }
+      }
+
       // Toggle Grid Mode: Ctrl+G
       if (ctrl && e.key === 'g') {
         e.preventDefault();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -17,6 +17,7 @@ interface AppState {
   defaultClaudeArgs: string[];
   notifyOnFinish: boolean;
   restoreSession: boolean;
+  telemetryEnabled: boolean;
 
   // Changes panel
   changesRefreshTrigger: number;
@@ -52,6 +53,12 @@ interface AppState {
   // Claude Config (F6)
   claudeConfigOpen: boolean;
 
+  // Session Timeline (F7)
+  sessionTimelineOpen: boolean;
+
+  // Memory Editor (F8)
+  memoryEditorOpen: boolean;
+
   // What's New
   whatsNewOpen: boolean;
   lastSeenVersion: string | null;
@@ -71,6 +78,7 @@ interface AppState {
   setDefaultClaudeArgs: (args: string[]) => void;
   setNotifyOnFinish: (enabled: boolean) => void;
   setRestoreSession: (enabled: boolean) => void;
+  setTelemetryEnabled: (enabled: boolean) => void;
 
   // Grid actions
   toggleGridMode: () => void;
@@ -113,6 +121,15 @@ interface AppState {
   // Claude Config actions (F6)
   openClaudeConfig: () => void;
   closeClaudeConfig: () => void;
+
+  // Session Timeline actions (F7)
+  openSessionTimeline: () => void;
+  closeSessionTimeline: () => void;
+  toggleSessionTimeline: () => void;
+
+  // Memory Editor actions (F8)
+  openMemoryEditor: () => void;
+  closeMemoryEditor: () => void;
 
   // What's New actions
   openWhatsNew: () => void;
@@ -159,6 +176,7 @@ export const useAppStore = create<AppState>()(
       defaultClaudeArgs: [],
       notifyOnFinish: true,
       restoreSession: true,
+      telemetryEnabled: true,
 
       // Changes panel
       changesRefreshTrigger: 0,
@@ -194,6 +212,12 @@ export const useAppStore = create<AppState>()(
       // Claude Config (F6)
       claudeConfigOpen: false,
 
+      // Session Timeline (F7)
+      sessionTimelineOpen: false,
+
+      // Memory Editor (F8)
+      memoryEditorOpen: false,
+
       // What's New
       whatsNewOpen: false,
       lastSeenVersion: null,
@@ -213,6 +237,7 @@ export const useAppStore = create<AppState>()(
       setDefaultClaudeArgs: (args) => set({ defaultClaudeArgs: args }),
       setNotifyOnFinish: (enabled) => set({ notifyOnFinish: enabled }),
       setRestoreSession: (enabled) => set({ restoreSession: enabled }),
+      setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
 
       // Grid actions
       toggleGridMode: () => set((state) => ({ gridMode: !state.gridMode })),
@@ -281,6 +306,15 @@ export const useAppStore = create<AppState>()(
       openClaudeConfig: () => set({ claudeConfigOpen: true }),
       closeClaudeConfig: () => set({ claudeConfigOpen: false }),
 
+      // Session Timeline actions (F7)
+      openSessionTimeline: () => set({ sessionTimelineOpen: true }),
+      closeSessionTimeline: () => set({ sessionTimelineOpen: false }),
+      toggleSessionTimeline: () => set((state) => ({ sessionTimelineOpen: !state.sessionTimelineOpen })),
+
+      // Memory Editor actions (F8)
+      openMemoryEditor: () => set({ memoryEditorOpen: true }),
+      closeMemoryEditor: () => set({ memoryEditorOpen: false }),
+
       // What's New actions
       openWhatsNew: () => set({ whatsNewOpen: true }),
       closeWhatsNew: () => set({ whatsNewOpen: false }),
@@ -295,6 +329,7 @@ export const useAppStore = create<AppState>()(
         defaultClaudeArgs: state.defaultClaudeArgs,
         notifyOnFinish: state.notifyOnFinish,
         restoreSession: state.restoreSession,
+        telemetryEnabled: state.telemetryEnabled,
         orchestrationOpen: state.orchestrationOpen,
         lastSeenVersion: state.lastSeenVersion,
       }),

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -15,10 +15,20 @@ export interface TerminalConfig {
   color_tag: string | null;
 }
 
+export interface LoopInfo {
+  interval: string;
+  prompt: string;
+}
+
 interface TerminalInstance {
   config: TerminalConfig;
   xterm: Terminal | null;
   restoredOutput?: string;
+  model?: string;
+  effort?: string;
+  isWorktree: boolean;
+  loopInfo?: LoopInfo | null;
+  sessionSummary?: string | null;
 }
 
 interface TerminalState {
@@ -44,6 +54,8 @@ interface TerminalState {
   setXterm: (id: string, xterm: Terminal) => void;
   handleTerminalOutput: (id: string, data: Uint8Array) => void;
   updateTerminalStatus: (id: string, status: TerminalConfig['status']) => void;
+  setLoopMode: (id: string, info: LoopInfo | null) => void;
+  setSessionSummary: (id: string, summary: string | null) => void;
   getTerminalList: () => TerminalConfig[];
   clearUnread: (id: string) => void;
   hasUnread: (id: string) => boolean;
@@ -66,9 +78,22 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           nickname: nickname || null,
         },
       });
+      // Parse model, effort, worktree from claude_args
+      let model: string | undefined;
+      let effort: string | undefined;
+      const isWorktree = claudeArgs.includes('--worktree');
+      for (let i = 0; i < claudeArgs.length; i++) {
+        if (claudeArgs[i] === '--model' && i + 1 < claudeArgs.length) {
+          model = claudeArgs[i + 1];
+        }
+        if (claudeArgs[i] === '--effort' && i + 1 < claudeArgs.length) {
+          effort = claudeArgs[i + 1];
+        }
+      }
+
       set((state) => {
         const newTerminals = new Map(state.terminals);
-        newTerminals.set(config.id, { config, xterm: null, restoredOutput });
+        newTerminals.set(config.id, { config, xterm: null, restoredOutput, model, effort, isWorktree });
         return {
           terminals: newTerminals,
           activeTerminalId: config.id,
@@ -192,6 +217,28 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const instance = newTerminals.get(id);
       if (instance) {
         instance.config.status = status;
+      }
+      return { terminals: newTerminals };
+    });
+  },
+
+  setLoopMode: (id, info) => {
+    set((state) => {
+      const newTerminals = new Map(state.terminals);
+      const instance = newTerminals.get(id);
+      if (instance) {
+        instance.loopInfo = info;
+      }
+      return { terminals: newTerminals };
+    });
+  },
+
+  setSessionSummary: (id, summary) => {
+    set((state) => {
+      const newTerminals = new Map(state.terminals);
+      const instance = newTerminals.get(id);
+      if (instance) {
+        instance.sessionSummary = summary;
       }
       return { terminals: newTerminals };
     });

--- a/src/store/updaterStore.ts
+++ b/src/store/updaterStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { invoke } from '@tauri-apps/api/core';
+import { getVersion } from '@tauri-apps/api/app';
 
 interface UpdateInfo {
   version: string;
@@ -37,7 +38,23 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
 
     try {
       set({ status: 'checking', error: null });
-      const update = await check();
+
+      let headers: Record<string, string> = {};
+      try {
+        const [installationId, appVersion] = await Promise.all([
+          invoke<string>('get_installation_id'),
+          getVersion(),
+        ]);
+        headers = {
+          'X-Installation-Id': installationId,
+          'X-App-Version': appVersion,
+          'X-OS': navigator.platform,
+        };
+      } catch {
+        // Analytics headers are optional — continue without them
+      }
+
+      const update = await check({ headers });
 
       if (update) {
         set({


### PR DESCRIPTION
## Summary
- **Agent Teams Mission Control** (F4): Enhanced OrchestrationPanel with live task board showing status-colored dots, owner pills, and blocked-by indicators
- **Session Timeline & Resume Hub** (F7): Visual timeline modal of past sessions with one-click `--continue` resume
- **Loop Mode Dashboard**: Auto-detect loop mode from terminal output, display pulsing badges on tabs and sidebar
- **Worktree-Aware Spawning**: Toggle in New Terminal modal to prepend `--worktree` flag for isolated git worktrees
- **Model & Effort Switcher**: Per-terminal model (opus/sonnet/haiku) and effort (low/medium/high) pill selectors with color-coded tab badges
- **Teleport & Remote Control**: Quick-action Globe/Smartphone buttons on running terminals for `/teleport` and `/remote-control`
- **Smart Terminal Insights**: Auto-summarize sessions via Claude haiku on stop, display summary card below terminal
- **CLAUDE.md & Memory Editor** (F8): 3-tab modal for editing CLAUDE.md files, auto-memory files, and rules

### Backend (Rust)
- 8 new Tauri IPC commands: `get_team_tasks`, `summarize_session`, `save_session_summary`, `get_session_summary`, `read_memory_file`, `write_memory_file`, `list_memory_files`, `list_claude_md_files`
- New `session_summaries` SQLite table with CRUD
- Added `regex` crate dependency

### Frontend (React/TypeScript)
- 4 new components: `SessionTimeline`, `MemoryEditor`, `SessionInsights`, `TeleportActions`
- Enhanced stores: `appStore` (F7/F8 modals), `terminalStore` (model/effort/worktree/loop/summary fields)
- Enhanced components: `OrchestrationPanel`, `NewTerminalModal`, `TerminalTabs`, `Sidebar`
- New keyboard shortcuts: F7, F8

## Test plan
- [ ] `npm run tauri dev` compiles and launches without errors
- [ ] F7 opens Session Timeline with history entries and resume works
- [ ] F8 opens Memory Editor showing CLAUDE.md files
- [ ] F4 OrchestrationPanel shows tasks when a team is active
- [ ] New Terminal modal shows Model/Effort selectors and Worktree toggle
- [ ] Terminal tabs display model/worktree/loop badges correctly
- [ ] Teleport/Remote Control buttons visible on running terminals
- [ ] Stopped terminals show AI-generated session summary card

🤖 Generated with [Claude Code](https://claude.com/claude-code)