### PR TITLE
Fix terminal keyboard becoming unresponsive after mouse click or key press

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -15,6 +15,7 @@ interface TerminalViewProps {
 
 export function TerminalView({ terminalId }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const [searchVisible, setSearchVisible] = useState(false);
   const { terminals, writeToTerminal, resizeTerminal, setXterm } = useTerminalStore();
@@ -79,6 +80,19 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
     // Auto-focus so keyboard input works immediately without requiring a click
     terminal.focus();
 
+    // Re-focus xterm if its textarea loses focus to nothing (body/canvas),
+    // which happens in WebView2 after PTY output triggers React re-renders
+    // or when clicking the terminal canvas directly.
+    const handleBlur = () => {
+      requestAnimationFrame(() => {
+        const focused = document.activeElement;
+        if (!focused || focused === document.body || focused.tagName === 'CANVAS') {
+          terminal.focus();
+        }
+      });
+    };
+    terminal.textarea?.addEventListener('blur', handleBlur);
+
     // Handle Ctrl+C (copy) and Ctrl+V (paste) keyboard shortcuts
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       const isCtrl = e.ctrlKey || e.metaKey;
@@ -132,11 +146,14 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
     });
     resizeObserver.observe(containerRef.current);
 
+    terminalRef.current = terminal;
     setXterm(terminalId, terminal);
 
     return () => {
       resizeObserver.disconnect();
+      terminal.textarea?.removeEventListener('blur', handleBlur);
       searchAddonRef.current = null;
+      terminalRef.current = null;
       terminal.dispose();
     };
   }, [terminalId, instance, writeToTerminal, resizeTerminal, setXterm, toggleSearch]);
@@ -151,6 +168,7 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
       <div
         ref={containerRef}
         className="flex-1 min-h-0 w-full"
+        onMouseDown={() => terminalRef.current?.focus()}
       />
       <TerminalStatusBar terminalId={terminalId} />
     </div>


### PR DESCRIPTION
## Summary

- Re-focus xterm textarea when it loses focus to `document.body` or a canvas element, which happens in WebView2 after PTY output triggers React re-renders
- Add `onMouseDown` handler on the container div to immediately restore focus when clicking the terminal area
- Properly clean up the `blur` event listener on unmount

## Root Cause

In WebView2 (Tauri), PTY output can trigger React re-renders that briefly shift focus away from the xterm textarea to `document.body` or the terminal canvas. This left the terminal keyboard unresponsive until the user manually clicked into it.

## Test plan

- [ ] Open a terminal and type — keyboard input should work without clicking first
- [ ] Click the terminal canvas with the mouse — keyboard should remain responsive immediately after
- [ ] Trigger PTY output (run a long command) — keyboard should stay responsive throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)