### PR TITLE
feat: add Duplicate Terminal action (Ctrl+Shift+D)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-terminal",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-terminal",
-      "version": "1.18.2",
+      "version": "1.19.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -83,7 +83,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1518,7 +1517,6 @@
       "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1536,7 +1534,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1608,8 +1605,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -1732,7 +1728,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2161,7 +2156,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2415,7 +2409,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2585,7 +2578,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2598,7 +2590,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2908,7 +2899,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3029,7 +3019,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { AnimatePresence, Reorder } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight } from 'lucide-react';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -36,6 +36,21 @@ export function TerminalTabs() {
       setSplitTerminals([activeTerminalId, terminalId]);
       setSplitMode(true);
     }
+  };
+
+  const { createTerminal } = useTerminalStore();
+  const handleDuplicate = (terminalId: string) => {
+    const instance = terminals.get(terminalId);
+    if (!instance) return;
+    const { label, working_directory, claude_args, env_vars, color_tag, nickname } = instance.config;
+    createTerminal(
+      label,
+      working_directory,
+      claude_args,
+      env_vars,
+      color_tag ?? undefined,
+      nickname ?? undefined,
+    );
   };
 
   const handleTabDragOver = useCallback((e: React.DragEvent, tabTerminalId: string) => {
@@ -242,6 +257,16 @@ export function TerminalTabs() {
                         <SplitSquareHorizontal size={12} />
                       </button>
                     )}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDuplicate(terminal.id);
+                      }}
+                      className="p-0.5 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-text-secondary transition-colors"
+                      title="Duplicate terminal"
+                    >
+                      <Copy size={12} />
+                    </button>
                     <button
                       onClick={(e) => {
                         e.stopPropagation();

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -77,6 +77,26 @@ export function useKeyboardShortcuts() {
         if (activeId) useTerminalStore.getState().closeTerminal(activeId);
       }
 
+      // Duplicate active terminal: Ctrl+Shift+D
+      if (ctrl && shift && e.key === 'D') {
+        e.preventDefault();
+        const activeId = activeIdRef.current;
+        if (activeId) {
+          const instance = terminalsRef.current.get(activeId);
+          if (instance) {
+            const { label, working_directory, claude_args, env_vars, color_tag, nickname } = instance.config;
+            useTerminalStore.getState().createTerminal(
+              label,
+              working_directory,
+              claude_args,
+              env_vars,
+              color_tag ?? undefined,
+              nickname ?? undefined,
+            );
+          }
+        }
+      }
+
       if (ctrl && e.key === ',') {
         e.preventDefault();
         useAppStore.getState().openSettings();


### PR DESCRIPTION
Clones the active terminal's config (working directory, claude args,
env vars, color tag, nickname) into a new terminal. Accessible via
Ctrl+Shift+D keyboard shortcut and a copy icon on tab hover.

https://claude.ai/code/session_01BkBpfkg4GVFRnMCZxADG2c