### PR TITLE
Add Git panel, branch switcher, and tab reorder

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -514,6 +514,7 @@ pub async fn clear_last_session(state: State<'_, AppState>) -> Result<(), String
 pub struct FileChange {
     pub path: String,
     pub status: String,
+    pub staged: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -583,26 +584,51 @@ pub async fn get_terminal_changes(
     }
 
     let stdout = String::from_utf8_lossy(&status_output.stdout);
-    let changes: Vec<FileChange> = stdout
-        .lines()
-        .filter(|line| line.len() >= 3)
-        .map(|line| {
-            let code = &line[..2];
-            let path = line[3..].to_string();
-            let status = match code.trim() {
-                "??" => "untracked",
-                "A" | "A " => "new",
-                "M" | "M " | " M" | "MM" => "modified",
-                "D" | "D " | " D" => "deleted",
-                r if r.starts_with('R') => "renamed",
-                _ => "modified",
-            };
-            FileChange {
-                path,
-                status: status.to_string(),
+    let mut changes: Vec<FileChange> = Vec::new();
+    for line in stdout.lines() {
+        if line.len() < 3 { continue; }
+        let x = line.as_bytes().get(0).copied().unwrap_or(b' ') as char;
+        let y = line.as_bytes().get(1).copied().unwrap_or(b' ') as char;
+        // Rename line: "R  old -> new"
+        let raw_path = &line[3..];
+        let path = if raw_path.contains(" -> ") {
+            raw_path.split(" -> ").nth(1).unwrap_or(raw_path).to_string()
+        } else {
+            raw_path.to_string()
+        };
+
+        if x == '?' && y == '?' {
+            // Untracked — always unstaged
+            changes.push(FileChange { path, status: "untracked".into(), staged: false });
+            continue;
+        }
+
+        let map_code = |c: char| match c {
+            'A' => "new",
+            'M' => "modified",
+            'D' => "deleted",
+            'R' => "renamed",
+            'C' => "new",
+            'U' => "modified", // conflicted — treat as modified
+            'T' => "modified", // type change
+            _ => "",
+        };
+
+        // Staged side (X)
+        if x != ' ' && x != '?' {
+            let status = map_code(x);
+            if !status.is_empty() {
+                changes.push(FileChange { path: path.clone(), status: status.into(), staged: true });
             }
-        })
-        .collect();
+        }
+        // Unstaged side (Y)
+        if y != ' ' && y != '?' {
+            let status = map_code(y);
+            if !status.is_empty() {
+                changes.push(FileChange { path, status: status.into(), staged: false });
+            }
+        }
+    }
 
     Ok(FileChangesResult {
         terminal_id: id,
@@ -973,6 +999,265 @@ pub async fn get_repo_branches(
         .collect();
 
     Ok(branches)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StashEntry {
+    pub reference: String, // e.g. "stash@{0}"
+    pub message: String,
+    pub branch: Option<String>,
+}
+
+fn run_git(path: &str, args: &[&str]) -> Result<String, String> {
+    let out = shell_command("git", args)
+        .current_dir(path)
+        .output()
+        .map_err(|e| format!("Failed to run git {}: {}", args.join(" "), e))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        return Err(if !stderr.is_empty() { stderr } else { stdout });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+fn validate_stash_ref(r: &str) -> Result<(), String> {
+    // Must be "stash@{N}" to prevent argument injection
+    if !r.starts_with("stash@{") || !r.ends_with('}') {
+        return Err("Invalid stash reference".to_string());
+    }
+    let inner = &r[7..r.len() - 1];
+    if inner.is_empty() || !inner.chars().all(|c| c.is_ascii_digit()) {
+        return Err("Invalid stash reference".to_string());
+    }
+    Ok(())
+}
+
+fn validate_file_list(files: &[String]) -> Result<(), String> {
+    if files.is_empty() {
+        return Err("No files selected".to_string());
+    }
+    for f in files {
+        if f.is_empty() || f.contains('\0') {
+            return Err("Invalid file path".to_string());
+        }
+        // Reject absolute paths and parent-dir traversal. Git always reports
+        // repo-relative paths, so legitimate inputs never need these.
+        if f.starts_with('/') || f.starts_with('\\') || f.contains("..") {
+            return Err(format!("Invalid file path: {}", f));
+        }
+    }
+    Ok(())
+}
+
+#[command]
+pub async fn git_stage_files(
+    state: State<'_, AppState>,
+    path: String,
+    files: Vec<String>,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    validate_file_list(&files)?;
+    // `git add -- <file>...` with `--` to terminate options
+    let mut args: Vec<&str> = vec!["add", "--"];
+    for f in &files { args.push(f); }
+    run_git(&path, &args).map(|_| ())
+}
+
+#[command]
+pub async fn git_unstage_files(
+    state: State<'_, AppState>,
+    path: String,
+    files: Vec<String>,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    validate_file_list(&files)?;
+    // Use `git reset HEAD -- <file>` for broad git-version compatibility.
+    // `git restore --staged` (2.23+) is the modern equivalent.
+    let mut args: Vec<&str> = vec!["reset", "HEAD", "--"];
+    for f in &files { args.push(f); }
+    // `git reset` returns non-zero on no-op or initial-commit edge cases, but
+    // the files do end up unstaged — we tolerate non-fatal stderr.
+    match run_git(&path, &args) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            // On a repo with no HEAD yet, use `git rm --cached` as fallback.
+            if e.contains("ambiguous argument 'HEAD'") || e.contains("unknown revision") {
+                let mut fb: Vec<&str> = vec!["rm", "--cached", "--"];
+                for f in &files { fb.push(f); }
+                run_git(&path, &fb).map(|_| ())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+#[command]
+pub async fn git_commit(
+    state: State<'_, AppState>,
+    path: String,
+    message: String,
+    auto_stage: AutoStageMode,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    if message.trim().is_empty() {
+        return Err("Commit message cannot be empty".to_string());
+    }
+    // If the caller asks us to auto-stage, do so. Otherwise commit what's
+    // already staged — and if nothing is staged, return a clear error.
+    match auto_stage {
+        AutoStageMode::None => {
+            let status = run_git(&path, &["diff", "--cached", "--name-only"])?;
+            if status.trim().is_empty() {
+                return Err("Nothing is staged — stage files first or choose 'stage all'".to_string());
+            }
+        }
+        AutoStageMode::Tracked => { run_git(&path, &["add", "-u"])?; }
+        AutoStageMode::All => { run_git(&path, &["add", "-A"])?; }
+    }
+
+    // Pass message via a temp file to avoid any shell-quoting concerns for
+    // multi-line or special-character messages.
+    let tmp = std::env::temp_dir().join(format!(
+        "ct-commit-msg-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    ));
+    std::fs::write(&tmp, message.as_bytes()).map_err(|e| format!("Failed to write commit message: {}", e))?;
+    let tmp_str = tmp.to_string_lossy().to_string();
+    let res = run_git(&path, &["commit", "-F", &tmp_str]);
+    let _ = std::fs::remove_file(&tmp);
+    res.map(|_| ())
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum AutoStageMode {
+    None,
+    Tracked,
+    All,
+}
+
+#[command]
+pub async fn git_push(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    run_git(&path, &["push"]).map(|_| ())
+}
+
+#[command]
+pub async fn git_stash_push(
+    state: State<'_, AppState>,
+    path: String,
+    message: Option<String>,
+    include_untracked: bool,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    let mut args: Vec<String> = vec!["stash".into(), "push".into()];
+    if include_untracked { args.push("-u".into()); }
+    if let Some(m) = message.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        // Use a temp file via `-F`? `git stash push` doesn't support -F; use -m.
+        // Reject control chars to keep cmd.exe happy on Windows.
+        if m.chars().any(|c| c.is_control()) {
+            return Err("Stash message cannot contain control characters".to_string());
+        }
+        args.push("-m".into());
+        args.push(m.to_string());
+    }
+    let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    run_git(&path, &str_args).map(|_| ())
+}
+
+#[command]
+pub async fn git_list_stashes(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<Vec<StashEntry>, String> {
+    validate_path_is_trusted(&state, &path).await?;
+    // Format: "<ref>\x1f<subject>" — \x1f (unit separator) is safe against
+    // colons/spaces in the subject.
+    let out = run_git(&path, &["stash", "list", "--format=%gd\x1f%s"])?;
+    let mut entries = Vec::new();
+    for line in out.lines() {
+        let mut parts = line.splitn(2, '\x1f');
+        let reference = parts.next().unwrap_or("").trim().to_string();
+        let subject = parts.next().unwrap_or("").trim().to_string();
+        if reference.is_empty() { continue; }
+        // Branch name is often encoded as "WIP on <branch>: ..." or "On <branch>: ..."
+        let branch = subject
+            .strip_prefix("WIP on ")
+            .or_else(|| subject.strip_prefix("On "))
+            .and_then(|s| s.split_once(':'))
+            .map(|(b, _)| b.trim().to_string());
+        entries.push(StashEntry { reference, message: subject, branch });
+    }
+    Ok(entries)
+}
+
+#[command]
+pub async fn git_stash_apply(
+    state: State<'_, AppState>,
+    path: String,
+    reference: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    validate_stash_ref(&reference)?;
+    run_git(&path, &["stash", "apply", &reference]).map(|_| ())
+}
+
+#[command]
+pub async fn git_stash_pop(
+    state: State<'_, AppState>,
+    path: String,
+    reference: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    validate_stash_ref(&reference)?;
+    run_git(&path, &["stash", "pop", &reference]).map(|_| ())
+}
+
+#[command]
+pub async fn git_stash_drop(
+    state: State<'_, AppState>,
+    path: String,
+    reference: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    validate_stash_ref(&reference)?;
+    run_git(&path, &["stash", "drop", &reference]).map(|_| ())
+}
+
+#[command]
+pub async fn checkout_branch(
+    state: State<'_, AppState>,
+    path: String,
+    branch: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    // Defense against arg injection — branch names cannot start with '-' and
+    // cannot contain characters git disallows for refs anyway, but we're extra
+    // strict with a conservative allowlist.
+    if branch.is_empty() || branch.starts_with('-') {
+        return Err("Invalid branch name".to_string());
+    }
+    if branch.chars().any(|c| c.is_control() || c == ' ' || c == '~' || c == '^' || c == ':' || c == '?' || c == '*' || c == '[') {
+        return Err("Invalid branch name".to_string());
+    }
+    let output = shell_command("git", &["checkout", &branch])
+        .current_dir(&path)
+        .output()
+        .map_err(|e| format!("Failed to run git checkout: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(if !stderr.is_empty() { stderr } else { stdout });
+    }
+    Ok(())
 }
 
 #[command]
@@ -1845,4 +2130,150 @@ pub async fn get_active_teams() -> Result<Vec<TeamInfo>, String> {
     }
 
     Ok(teams)
+}
+
+// ─── Git repo scan (sidebar Git panel) ────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScannedGitRepo {
+    pub path: String,
+    pub relative_path: String,
+    pub branch: Option<String>,
+    pub is_worktree: bool,
+    pub is_main_repo: bool,
+    pub dirty: bool,
+    pub ahead: u32,
+    pub behind: u32,
+}
+
+fn git_branch_for(path: &std::path::Path) -> Option<String> {
+    let out = shell_command("git", &["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(path)
+        .output()
+        .ok()?;
+    if !out.status.success() { return None; }
+    let b = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if b == "HEAD" || b.is_empty() { None } else { Some(b) }
+}
+
+fn git_is_worktree(path: &std::path::Path) -> bool {
+    let git_dir = shell_command("git", &["rev-parse", "--git-dir"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    let common = shell_command("git", &["rev-parse", "--git-common-dir"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    match (git_dir, common) {
+        (Some(d), Some(c)) => {
+            let dc = std::path::PathBuf::from(&d).canonicalize().ok();
+            let cc = std::path::PathBuf::from(&c).canonicalize().ok();
+            match (dc, cc) { (Some(a), Some(b)) => a != b, _ => d != c }
+        }
+        _ => false,
+    }
+}
+
+fn git_dirty(path: &std::path::Path) -> bool {
+    shell_command("git", &["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn git_ahead_behind(path: &std::path::Path) -> (u32, u32) {
+    // rev-list --count --left-right HEAD...@{u}   → "ahead\tbehind"
+    let out = shell_command("git", &["rev-list", "--count", "--left-right", "HEAD...@{u}"])
+        .current_dir(path)
+        .output();
+    let Ok(out) = out else { return (0, 0); };
+    if !out.status.success() { return (0, 0); }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let mut parts = s.split_whitespace();
+    let a: u32 = parts.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+    let b: u32 = parts.next().and_then(|v| v.parse().ok()).unwrap_or(0);
+    (a, b)
+}
+
+const SCAN_SKIP_DIRS: &[&str] = &[
+    "node_modules", "target", ".git", "dist", "build", "out",
+    ".next", ".nuxt", ".turbo", ".cache", ".venv", "venv", "__pycache__",
+    ".idea", ".vscode", "vendor",
+];
+
+fn scan_for_repos(
+    root: &std::path::Path,
+    current: &std::path::Path,
+    depth: u32,
+    max_depth: u32,
+    results: &mut Vec<ScannedGitRepo>,
+    limit: usize,
+) {
+    if results.len() >= limit { return; }
+    if depth > max_depth { return; }
+
+    // Is `current` itself a git repo?
+    let dot_git = current.join(".git");
+    if dot_git.exists() {
+        let branch = git_branch_for(current);
+        let is_wt = git_is_worktree(current);
+        let dirty = git_dirty(current);
+        let (ahead, behind) = git_ahead_behind(current);
+        let rel = current.strip_prefix(root).unwrap_or(current).to_string_lossy().to_string();
+        let relative_path = if rel.is_empty() { ".".to_string() } else { rel };
+        let is_main = current == root;
+        results.push(ScannedGitRepo {
+            path: current.to_string_lossy().to_string(),
+            relative_path,
+            branch,
+            is_worktree: is_wt,
+            is_main_repo: is_main,
+            dirty,
+            ahead,
+            behind,
+        });
+        // Don't descend into a repo's own directory when looking for *nested*
+        // repos — a nested repo is one whose parent is not itself a repo root.
+        // Allow descent only for the root itself so we can find sub-repos
+        // embedded as submodules or siblings.
+        if !is_main { return; }
+    }
+
+    let Ok(entries) = std::fs::read_dir(current) else { return; };
+    for entry in entries.flatten() {
+        if results.len() >= limit { return; }
+        let path = entry.path();
+        if !path.is_dir() { continue; }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.starts_with('.') && name != ".git" { continue; }
+        if SCAN_SKIP_DIRS.iter().any(|s| *s == name) { continue; }
+        scan_for_repos(root, &path, depth + 1, max_depth, results, limit);
+    }
+}
+
+#[command]
+pub async fn scan_git_repos(
+    state: State<'_, AppState>,
+    root_path: String,
+) -> Result<Vec<ScannedGitRepo>, String> {
+    validate_path_is_trusted(&state, &root_path).await?;
+    let root = std::path::Path::new(&root_path)
+        .canonicalize()
+        .map_err(|e| format!("Invalid path: {}", e))?;
+    let mut results = Vec::new();
+    // max_depth 4 handles common monorepo layouts (apps/x, packages/y/z)
+    // limit 40 guards against runaway scans
+    scan_for_repos(&root, &root, 0, 4, &mut results, 40);
+    Ok(results)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -65,6 +65,16 @@ fn main() {
             commands::get_worktree_info,
             commands::list_worktrees,
             commands::get_repo_branches,
+            commands::checkout_branch,
+            commands::git_commit,
+            commands::git_push,
+            commands::git_stage_files,
+            commands::git_unstage_files,
+            commands::git_stash_push,
+            commands::git_list_stashes,
+            commands::git_stash_apply,
+            commands::git_stash_pop,
+            commands::git_stash_drop,
             commands::create_worktree,
             commands::remove_worktree,
             commands::get_session_history,
@@ -95,6 +105,7 @@ fn main() {
             commands::read_memory_file,
             commands::write_memory_file,
             commands::list_claude_md_files,
+            commands::scan_git_repos,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src/components/FileChangesPanel.tsx
+++ b/src/components/FileChangesPanel.tsx
@@ -1,14 +1,19 @@
-import { useState, useEffect } from 'react';
-import { RefreshCw, GitBranch, GitFork, FilePlus, FileEdit, FileX, FileQuestion, ArrowRightLeft, FolderOpen, ChevronRight, ChevronDown } from 'lucide-react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { RefreshCw, GitBranch, GitFork, FilePlus, FileEdit, FileX, FileQuestion, ArrowRightLeft, FolderOpen, ChevronRight, ChevronDown, CircleDot, ArrowUp, ArrowDown, Upload, Archive, Package, Loader2, Trash2, Download, Plus, Minus } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
+import { toast } from '../store/toastStore';
 import { InlineDiffView } from './InlineDiffView';
+import type { WorktreeInfo } from '../types/git';
 
 interface FileChange {
   path: string;
   status: string;
+  staged: boolean;
 }
+
+type AutoStageMode = 'none' | 'tracked' | 'all';
 
 interface FileChangesResult {
   terminal_id: string;
@@ -17,6 +22,23 @@ interface FileChangesResult {
   is_git_repo: boolean;
   branch: string | null;
   error: string | null;
+}
+
+interface ScannedGitRepo {
+  path: string;
+  relative_path: string;
+  branch: string | null;
+  is_worktree: boolean;
+  is_main_repo: boolean;
+  dirty: boolean;
+  ahead: number;
+  behind: number;
+}
+
+interface StashEntry {
+  reference: string;
+  message: string;
+  branch: string | null;
 }
 
 const statusConfig: Record<string, { label: string; color: string; icon: React.ReactNode }> = {
@@ -29,14 +51,198 @@ const statusConfig: Record<string, { label: string; color: string; icon: React.R
 
 export function FileChangesPanel() {
   const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
+  const terminals = useTerminalStore((s) => s.terminals);
   const gitInfoCache = useTerminalStore((s) => s.gitInfoCache);
   const changesRefreshTrigger = useAppStore((s) => s.changesRefreshTrigger);
   const openWorktreeModal = useAppStore((s) => s.openWorktreeModal);
+  const showGitPanel = useAppStore((s) => s.showGitPanel);
   const activeGitInfo = activeTerminalId ? gitInfoCache.get(activeTerminalId) : null;
+  const activeCwd = useMemo(() => {
+    if (!activeTerminalId) return null;
+    return terminals.get(activeTerminalId)?.config.working_directory ?? null;
+  }, [activeTerminalId, terminals]);
   const [result, setResult] = useState<FileChangesResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
+  const [repos, setRepos] = useState<ScannedGitRepo[]>([]);
+  const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
+  const [reposLoading, setReposLoading] = useState(false);
+  const [reposExpanded, setReposExpanded] = useState(true);
+
+  // Commit / push / stash state
+  const [commitMessage, setCommitMessage] = useState('');
+  const [committing, setCommitting] = useState(false);
+  const [pushing, setPushing] = useState(false);
+  const [stashing, setStashing] = useState(false);
+  const [stashes, setStashes] = useState<StashEntry[]>([]);
+  const [stashesExpanded, setStashesExpanded] = useState(false);
+  const [stashActing, setStashActing] = useState<string | null>(null);
+  // Files currently being staged/unstaged — keyed by "stage:path" or "unstage:path"
+  const [stagingPaths, setStagingPaths] = useState<Set<string>>(new Set());
+  const triggerChangesRefreshAction = useAppStore.getState().triggerChangesRefresh;
+
+  const fetchRepos = useCallback(async (cwd: string) => {
+    setReposLoading(true);
+    try {
+      const rows = await invoke<ScannedGitRepo[]>('scan_git_repos', { rootPath: cwd });
+      setRepos(rows);
+
+      // Pick a repo path to query worktrees on. Prefer the main repo from
+      // `get_worktree_info` (handles the case where cwd is itself a linked
+      // worktree); fall back to the scanned root.
+      const mainRow = rows.find((r) => r.is_main_repo);
+      const wtRoot = activeGitInfo?.main_repo_path ?? mainRow?.path ?? null;
+      if (wtRoot) {
+        try {
+          const wts = await invoke<WorktreeInfo[]>('list_worktrees', { path: wtRoot });
+          setWorktrees(wts);
+        } catch {
+          setWorktrees([]);
+        }
+      } else {
+        setWorktrees([]);
+      }
+    } catch {
+      setRepos([]);
+      setWorktrees([]);
+    } finally {
+      setReposLoading(false);
+    }
+  }, [activeGitInfo?.main_repo_path]);
+
+  useEffect(() => {
+    if (!showGitPanel) return;
+    if (!activeCwd) { setRepos([]); setWorktrees([]); return; }
+    fetchRepos(activeCwd);
+  }, [activeCwd, showGitPanel, changesRefreshTrigger, fetchRepos]);
+
+  const fetchStashes = useCallback(async (cwd: string) => {
+    try {
+      const rows = await invoke<StashEntry[]>('git_list_stashes', { path: cwd });
+      setStashes(rows);
+    } catch {
+      setStashes([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!activeCwd || !result?.is_git_repo) { setStashes([]); return; }
+    fetchStashes(activeCwd);
+  }, [activeCwd, result?.is_git_repo, changesRefreshTrigger, fetchStashes]);
+
+  const handleCommit = useCallback(async (thenPush: boolean, autoStage: AutoStageMode) => {
+    if (!activeCwd) return;
+    const msg = commitMessage.trim();
+    if (!msg) {
+      toast.error('Commit', 'Enter a commit message');
+      return;
+    }
+    setCommitting(true);
+    try {
+      await invoke('git_commit', { path: activeCwd, message: msg, autoStage });
+      toast.success('Committed', thenPush ? 'Pushing…' : msg.split('\n')[0]);
+      setCommitMessage('');
+      if (thenPush) {
+        setPushing(true);
+        try {
+          await invoke('git_push', { path: activeCwd });
+          toast.success('Pushed', 'Changes pushed to remote');
+        } catch (err) {
+          toast.error('Push failed', typeof err === 'string' ? err : 'Unknown error');
+        } finally {
+          setPushing(false);
+        }
+      }
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error('Commit failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setCommitting(false);
+    }
+  }, [activeCwd, commitMessage, triggerChangesRefreshAction]);
+
+  const stageFiles = useCallback(async (files: string[]) => {
+    if (!activeCwd || files.length === 0) return;
+    setStagingPaths((prev) => {
+      const next = new Set(prev);
+      for (const f of files) next.add(`stage:${f}`);
+      return next;
+    });
+    try {
+      await invoke('git_stage_files', { path: activeCwd, files });
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error('Stage failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setStagingPaths((prev) => {
+        const next = new Set(prev);
+        for (const f of files) next.delete(`stage:${f}`);
+        return next;
+      });
+    }
+  }, [activeCwd, triggerChangesRefreshAction]);
+
+  const unstageFiles = useCallback(async (files: string[]) => {
+    if (!activeCwd || files.length === 0) return;
+    setStagingPaths((prev) => {
+      const next = new Set(prev);
+      for (const f of files) next.add(`unstage:${f}`);
+      return next;
+    });
+    try {
+      await invoke('git_unstage_files', { path: activeCwd, files });
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error('Unstage failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setStagingPaths((prev) => {
+        const next = new Set(prev);
+        for (const f of files) next.delete(`unstage:${f}`);
+        return next;
+      });
+    }
+  }, [activeCwd, triggerChangesRefreshAction]);
+
+  const handleStash = useCallback(async () => {
+    if (!activeCwd) return;
+    setStashing(true);
+    try {
+      const msg = commitMessage.trim() || null;
+      await invoke('git_stash_push', { path: activeCwd, message: msg, includeUntracked: true });
+      toast.success('Stashed', msg ?? 'Working changes stashed');
+      setCommitMessage('');
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error('Stash failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setStashing(false);
+    }
+  }, [activeCwd, commitMessage, triggerChangesRefreshAction]);
+
+  const runStashOp = useCallback(async (
+    op: 'git_stash_apply' | 'git_stash_pop' | 'git_stash_drop',
+    reference: string,
+    label: string,
+  ) => {
+    if (!activeCwd) return;
+    setStashActing(`${op}:${reference}`);
+    try {
+      await invoke(op, { path: activeCwd, reference });
+      toast.success(label, `${reference} — done`);
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error(`${label} failed`, typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setStashActing(null);
+    }
+  }, [activeCwd, triggerChangesRefreshAction]);
+
+  // Split worktrees into "linked" (not the main repo) and tag the active one
+  const linkedWorktrees = useMemo(
+    () => worktrees.filter((w) => !w.is_main),
+    [worktrees]
+  );
 
   const fetchChanges = async () => {
     if (!activeTerminalId) return;
@@ -58,14 +264,10 @@ export function FileChangesPanel() {
   }, [activeTerminalId, changesRefreshTrigger]);
 
   // Group changes by status
-  const grouped = result?.changes.reduce<Record<string, FileChange[]>>((acc, change) => {
-    const key = change.status;
-    if (!acc[key]) acc[key] = [];
-    acc[key].push(change);
-    return acc;
-  }, {}) ?? {};
-
-  const statusOrder = ['new', 'modified', 'deleted', 'renamed', 'untracked'];
+  const stagedChanges = result?.changes.filter((c) => c.staged) ?? [];
+  const unstagedChanges = result?.changes.filter((c) => !c.staged) ?? [];
+  const hasStaged = stagedChanges.length > 0;
+  const hasUnstaged = unstagedChanges.length > 0;
 
   return (
     <div className="h-full bg-bg-secondary border-l border-border flex flex-col">
@@ -106,6 +308,73 @@ export function FileChangesPanel() {
         )}
       </div>
 
+      {/* Repositories section — root repo + worktree + nested sub-repos */}
+      {showGitPanel && activeTerminalId && (
+        <div className="border-b border-border">
+          <div className="flex items-center justify-between h-[26px] px-3">
+            <button
+              onClick={() => setReposExpanded((v) => !v)}
+              className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors flex-1 min-w-0 text-left"
+            >
+              {reposExpanded ? (
+                <ChevronDown size={12} strokeWidth={1.75} className="flex-shrink-0" />
+              ) : (
+                <ChevronRight size={12} strokeWidth={1.75} className="flex-shrink-0" />
+              )}
+              <span className="text-[10.5px] font-semibold uppercase tracking-[0.06em] flex-shrink-0">
+                Repositories
+              </span>
+              <span className="text-text-tertiary text-[11px]">
+                {repos.length > 0 ? `(${repos.length})` : reposLoading ? '…' : ''}
+              </span>
+            </button>
+            <button
+              onClick={() => activeCwd && fetchRepos(activeCwd)}
+              className={`w-5 h-5 flex items-center justify-center rounded-[3px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors ${
+                reposLoading ? 'animate-spin' : ''
+              }`}
+              title="Rescan"
+            >
+              <RefreshCw size={11} strokeWidth={1.75} />
+            </button>
+          </div>
+          {reposExpanded && (
+            <div className="px-2 pb-2 space-y-0.5">
+              {!reposLoading && repos.length === 0 && (
+                <div className="text-text-tertiary text-[11px] px-2 py-1">
+                  No Git repositories detected
+                </div>
+              )}
+              {repos.filter((r) => r.is_main_repo).map((r) => (
+                <RepoRow key={r.path} repo={r} />
+              ))}
+
+              {linkedWorktrees.length > 0 && (
+                <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
+                  Worktrees ({linkedWorktrees.length})
+                </div>
+              )}
+              {linkedWorktrees.map((wt) => (
+                <WorktreeRow
+                  key={wt.path}
+                  wt={wt}
+                  isActive={activeCwd != null && pathsEqual(activeCwd, wt.path)}
+                />
+              ))}
+
+              {repos.some((r) => !r.is_main_repo) && (
+                <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
+                  Nested ({repos.filter((r) => !r.is_main_repo).length})
+                </div>
+              )}
+              {repos.filter((r) => !r.is_main_repo).map((r) => (
+                <RepoRow key={r.path} repo={r} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-1.5">
         {!activeTerminalId && (
@@ -138,51 +407,184 @@ export function FileChangesPanel() {
           </div>
         )}
 
-        {result && result.changes.length > 0 && statusOrder.map((status) => {
-          const files = grouped[status];
-          if (!files || files.length === 0) return null;
-          const config = statusConfig[status] || statusConfig.untracked;
-          return (
-            <div key={status} className="mb-2">
-              <div className="flex items-center gap-1.5 px-2 py-1">
-                <span className={config.color}>{config.icon}</span>
-                <span className="text-text-secondary text-[11px] font-medium uppercase tracking-wider">
-                  {config.label}
-                </span>
-                <span className="text-text-tertiary text-[11px]">({files.length})</span>
-              </div>
-              {files.map((file) => {
-                const isExpanded = expandedFile === file.path;
+        {hasStaged && (
+          <ChangeGroup
+            title="Staged"
+            count={stagedChanges.length}
+            files={stagedChanges}
+            staged={true}
+            expandedFile={expandedFile}
+            setExpandedFile={setExpandedFile}
+            activeTerminalId={activeTerminalId}
+            stagingPaths={stagingPaths}
+            onStage={stageFiles}
+            onUnstage={unstageFiles}
+            onBulk={() => unstageFiles(stagedChanges.map((f) => f.path))}
+          />
+        )}
+
+        {hasUnstaged && (
+          <ChangeGroup
+            title="Changes"
+            count={unstagedChanges.length}
+            files={unstagedChanges}
+            staged={false}
+            expandedFile={expandedFile}
+            setExpandedFile={setExpandedFile}
+            activeTerminalId={activeTerminalId}
+            stagingPaths={stagingPaths}
+            onStage={stageFiles}
+            onUnstage={unstageFiles}
+            onBulk={() => stageFiles(unstagedChanges.map((f) => f.path))}
+          />
+        )}
+      </div>
+
+      {/* Stashes — collapsible list, only when there are stashes */}
+      {result?.is_git_repo && stashes.length > 0 && (
+        <div className="border-t border-border">
+          <button
+            onClick={() => setStashesExpanded((v) => !v)}
+            className="w-full flex items-center justify-between h-[26px] px-3 text-text-secondary hover:text-text-primary transition-colors"
+          >
+            <div className="flex items-center gap-1.5">
+              {stashesExpanded ? (
+                <ChevronDown size={12} strokeWidth={1.75} />
+              ) : (
+                <ChevronRight size={12} strokeWidth={1.75} />
+              )}
+              <span className="text-[10.5px] font-semibold uppercase tracking-[0.06em]">
+                Stashes
+              </span>
+              <span className="text-text-tertiary text-[11px]">({stashes.length})</span>
+            </div>
+          </button>
+          {stashesExpanded && (
+            <div className="px-2 pb-2 space-y-0.5">
+              {stashes.map((s) => {
+                const isApplying = stashActing === `git_stash_apply:${s.reference}`;
+                const isPopping = stashActing === `git_stash_pop:${s.reference}`;
+                const isDropping = stashActing === `git_stash_drop:${s.reference}`;
+                const busy = isApplying || isPopping || isDropping;
                 return (
-                  <div key={file.path}>
-                    <div
-                      onClick={() => setExpandedFile(isExpanded ? null : file.path)}
-                      className="ml-3 px-2 py-1 rounded hover:bg-white/[0.04] transition-colors cursor-pointer flex items-center gap-1"
-                    >
-                      {isExpanded ? (
-                        <ChevronDown size={12} className="text-text-tertiary shrink-0" />
-                      ) : (
-                        <ChevronRight size={12} className="text-text-tertiary shrink-0" />
-                      )}
-                      <p className={`text-[12px] font-mono truncate ${config.color}`} title={file.path}>
-                        {file.path}
-                      </p>
-                    </div>
-                    {isExpanded && activeTerminalId && (
-                      <div className="ml-3 mr-1 mb-1 rounded overflow-hidden border border-border/30">
-                        <InlineDiffView
-                          filePath={file.path}
-                          terminalId={activeTerminalId}
-                        />
+                  <div
+                    key={s.reference}
+                    className="group flex items-start gap-1.5 px-2 py-1 rounded-[3px] hover:bg-white/[0.04]"
+                  >
+                    <Archive size={11} className="mt-[2px] flex-shrink-0 text-text-secondary" strokeWidth={1.75} />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-[11px] font-mono text-text-secondary flex-shrink-0">
+                          {s.reference}
+                        </span>
+                        {s.branch && (
+                          <span className="text-[10px] text-text-tertiary truncate">
+                            on {s.branch}
+                          </span>
+                        )}
                       </div>
-                    )}
+                      <div className="text-text-tertiary text-[11px] truncate" title={s.message}>
+                        {s.message}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        disabled={busy}
+                        onClick={() => runStashOp('git_stash_apply', s.reference, 'Apply')}
+                        className="p-1 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-40"
+                        title="Apply (keep stash)"
+                      >
+                        {isApplying ? <Loader2 size={11} className="animate-spin" /> : <Download size={11} />}
+                      </button>
+                      <button
+                        disabled={busy}
+                        onClick={() => runStashOp('git_stash_pop', s.reference, 'Pop')}
+                        className="p-1 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-accent-primary transition-colors disabled:opacity-40"
+                        title="Pop (apply &amp; drop)"
+                      >
+                        {isPopping ? <Loader2 size={11} className="animate-spin" /> : <Package size={11} />}
+                      </button>
+                      <button
+                        disabled={busy}
+                        onClick={() => {
+                          if (confirm(`Drop ${s.reference}? This cannot be undone.`)) {
+                            runStashOp('git_stash_drop', s.reference, 'Drop');
+                          }
+                        }}
+                        className="p-1 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-error transition-colors disabled:opacity-40"
+                        title="Drop"
+                      >
+                        {isDropping ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
+                      </button>
+                    </div>
                   </div>
                 );
               })}
             </div>
-          );
-        })}
-      </div>
+          )}
+        </div>
+      )}
+
+      {/* Commit bar */}
+      {result?.is_git_repo && (
+        <div className="border-t border-border p-2">
+          <textarea
+            value={commitMessage}
+            onChange={(e) => setCommitMessage(e.target.value)}
+            placeholder="Commit / stash message…"
+            rows={2}
+            className="w-full bg-bg-primary ring-1 ring-inset ring-border rounded-md px-2 py-1.5 text-[12px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-accent-primary/60 resize-none"
+          />
+          <div className="flex items-center justify-between mt-2 gap-1">
+            <span className="text-[11px] text-text-tertiary">
+              {hasStaged ? `${stagedChanges.length} staged` : 'Nothing staged'}
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={handleStash}
+                disabled={stashing || committing || pushing || result.changes.length === 0}
+                className="flex items-center gap-1 h-7 px-2 rounded-md text-[11.5px] text-text-secondary hover:bg-white/[0.06] hover:text-text-primary transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+                title="Stash working changes"
+              >
+                {stashing ? <Loader2 size={12} className="animate-spin" /> : <Archive size={12} />}
+                Stash
+              </button>
+              {hasStaged ? (
+                <>
+                  <button
+                    onClick={() => handleCommit(false, 'none')}
+                    disabled={committing || pushing || stashing || !commitMessage.trim()}
+                    className="flex items-center gap-1 h-7 px-2.5 rounded-md text-[11.5px] font-medium bg-accent-primary hover:bg-accent-secondary text-white transition-colors disabled:opacity-40 disabled:hover:bg-accent-primary"
+                    title="Commit staged files only"
+                  >
+                    {committing && !pushing ? <Loader2 size={12} className="animate-spin" /> : null}
+                    Commit
+                  </button>
+                  <button
+                    onClick={() => handleCommit(true, 'none')}
+                    disabled={committing || pushing || stashing || !commitMessage.trim()}
+                    className="flex items-center gap-1 h-7 px-2 rounded-md text-[11.5px] text-accent-primary hover:bg-accent-primary/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+                    title="Commit staged and push"
+                  >
+                    {pushing ? <Loader2 size={12} className="animate-spin" /> : <Upload size={12} />}
+                    &amp; Push
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => handleCommit(false, 'all')}
+                  disabled={committing || pushing || stashing || !commitMessage.trim() || result.changes.length === 0}
+                  className="flex items-center gap-1 h-7 px-2.5 rounded-md text-[11.5px] font-medium bg-accent-primary hover:bg-accent-secondary text-white transition-colors disabled:opacity-40 disabled:hover:bg-accent-primary"
+                  title="Stage all changes and commit"
+                >
+                  {committing ? <Loader2 size={12} className="animate-spin" /> : null}
+                  Commit all
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Footer */}
       <div className="p-2 border-t border-border">
@@ -198,6 +600,170 @@ export function FileChangesPanel() {
           <p className="text-text-secondary text-[11px]">
             {result ? `${result.changes.length} changed file${result.changes.length !== 1 ? 's' : ''}` : 'Press F2 to toggle'}
           </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ChangeGroupProps {
+  title: string;
+  count: number;
+  files: FileChange[];
+  staged: boolean;
+  expandedFile: string | null;
+  setExpandedFile: (v: string | null) => void;
+  activeTerminalId: string | null;
+  stagingPaths: Set<string>;
+  onStage: (files: string[]) => void;
+  onUnstage: (files: string[]) => void;
+  onBulk: () => void;
+}
+
+function ChangeGroup({
+  title, count, files, staged, expandedFile, setExpandedFile,
+  activeTerminalId, stagingPaths, onStage, onUnstage, onBulk,
+}: ChangeGroupProps) {
+  return (
+    <div className="mb-2">
+      <div className="flex items-center justify-between px-2 py-1 border-b border-border/30 mb-1">
+        <div className="flex items-center gap-1.5">
+          <span className={`text-[11px] font-semibold uppercase tracking-wider ${
+            staged ? 'text-accent-primary' : 'text-text-secondary'
+          }`}>
+            {title}
+          </span>
+          <span className="text-text-tertiary text-[11px]">({count})</span>
+        </div>
+        <button
+          onClick={onBulk}
+          className={`flex items-center gap-0.5 h-5 px-1.5 rounded text-[10.5px] transition-colors ${
+            staged
+              ? 'text-text-tertiary hover:bg-white/[0.06] hover:text-text-secondary'
+              : 'text-accent-primary hover:bg-accent-primary/10'
+          }`}
+          title={staged ? 'Unstage all' : 'Stage all'}
+        >
+          {staged ? <Minus size={11} /> : <Plus size={11} />}
+          {staged ? 'Unstage all' : 'Stage all'}
+        </button>
+      </div>
+
+      {files.map((file) => {
+        const isExpanded = expandedFile === file.path;
+        const config = statusConfig[file.status] || statusConfig.untracked;
+        const busyKey = staged ? `unstage:${file.path}` : `stage:${file.path}`;
+        const isBusy = stagingPaths.has(busyKey);
+        return (
+          <div key={`${staged ? 's' : 'u'}:${file.path}`} className="group">
+            <div
+              onClick={() => setExpandedFile(isExpanded ? null : file.path)}
+              className="ml-1 px-2 py-1 rounded hover:bg-white/[0.04] transition-colors cursor-pointer flex items-center gap-1"
+            >
+              {isExpanded ? (
+                <ChevronDown size={12} className="text-text-tertiary shrink-0" />
+              ) : (
+                <ChevronRight size={12} className="text-text-tertiary shrink-0" />
+              )}
+              <span className={`${config.color} shrink-0`}>{config.icon}</span>
+              <p className={`flex-1 text-[12px] font-mono truncate ${config.color}`} title={file.path}>
+                {file.path}
+              </p>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (isBusy) return;
+                  if (staged) onUnstage([file.path]);
+                  else onStage([file.path]);
+                }}
+                disabled={isBusy}
+                className={`shrink-0 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity ${
+                  staged
+                    ? 'text-text-tertiary hover:bg-white/[0.08] hover:text-text-primary'
+                    : 'text-accent-primary hover:bg-accent-primary/15'
+                } disabled:opacity-60`}
+                title={staged ? 'Unstage file' : 'Stage file'}
+              >
+                {isBusy
+                  ? <Loader2 size={11} className="animate-spin" />
+                  : staged ? <Minus size={11} /> : <Plus size={11} />}
+              </button>
+            </div>
+            {isExpanded && activeTerminalId && (
+              <div className="ml-3 mr-1 mb-1 rounded overflow-hidden border border-border/30">
+                <InlineDiffView filePath={file.path} terminalId={activeTerminalId} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function pathsEqual(a: string, b: string): boolean {
+  const norm = (p: string) => p.replace(/[\\/]+$/, '').replace(/\\/g, '/').toLowerCase();
+  return norm(a) === norm(b);
+}
+
+function WorktreeRow({ wt, isActive }: { wt: WorktreeInfo; isActive: boolean }) {
+  const displayName = wt.path.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || wt.path;
+  return (
+    <div
+      className={`flex items-start gap-1.5 px-2 py-1 rounded-[3px] hover:bg-white/[0.04] ${
+        isActive ? 'bg-accent-primary/10' : ''
+      }`}
+      title={wt.path}
+    >
+      <GitFork size={11} className="mt-[2px] flex-shrink-0 text-purple-400" strokeWidth={1.75} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11.5px] font-mono truncate text-purple-400">
+            {wt.branch || '(detached)'}
+          </span>
+          {isActive && (
+            <span className="text-[9px] px-1 rounded bg-accent-primary/20 text-accent-primary flex-shrink-0">
+              active
+            </span>
+          )}
+        </div>
+        <div className="text-text-tertiary text-[10.5px] truncate">
+          {displayName}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RepoRow({ repo }: { repo: ScannedGitRepo }) {
+  const Icon = repo.is_worktree ? GitFork : GitBranch;
+  const branchColor = repo.is_worktree ? 'text-purple-400' : 'text-accent-primary';
+  return (
+    <div
+      className="flex items-start gap-1.5 px-2 py-1 rounded-[3px] hover:bg-white/[0.04]"
+      title={repo.path}
+    >
+      <Icon size={11} className={`mt-[2px] flex-shrink-0 ${branchColor}`} strokeWidth={1.75} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className={`text-[11.5px] font-mono truncate ${branchColor}`}>
+            {repo.branch || '(detached)'}
+          </span>
+          {repo.dirty && <CircleDot size={9} className="text-warning flex-shrink-0" strokeWidth={2} />}
+          {repo.ahead > 0 && (
+            <span className="flex items-center text-[10px] text-text-tertiary">
+              <ArrowUp size={9} strokeWidth={2} />{repo.ahead}
+            </span>
+          )}
+          {repo.behind > 0 && (
+            <span className="flex items-center text-[10px] text-text-tertiary">
+              <ArrowDown size={9} strokeWidth={2} />{repo.behind}
+            </span>
+          )}
+        </div>
+        <div className="text-text-tertiary text-[10.5px] truncate">
+          {repo.is_main_repo ? 'root' : repo.relative_path}
+          {repo.is_worktree ? ' · worktree' : ''}
         </div>
       </div>
     </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,7 +17,7 @@ interface UpdateCheckResult {
 }
 
 export function SettingsModal() {
-  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession, telemetryEnabled, setTelemetryEnabled } = useAppStore();
+  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession, telemetryEnabled, setTelemetryEnabled, showGitPanel, setShowGitPanel } = useAppStore();
   const [claudeVersion, setClaudeVersion] = useState<string>('');
   const [latestVersion, setLatestVersion] = useState<string>('');
   const [updateAvailable, setUpdateAvailable] = useState<boolean | null>(null);
@@ -321,6 +321,33 @@ export function SettingsModal() {
                   <span
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
                       notifyOnFinish ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* File Changes Panel */}
+          <div>
+            <h3 className="text-text-primary text-[13px] font-medium mb-2">File Changes Panel</h3>
+            <div className="bg-bg-primary rounded-md ring-1 ring-border p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-text-primary text-[13px]">Show Repositories section</p>
+                  <p className="text-text-tertiary text-[11px] mt-0.5">
+                    List the root repo, worktree, and nested sub-repositories for the active terminal's folder
+                  </p>
+                </div>
+                <button
+                  onClick={() => setShowGitPanel(!showGitPanel)}
+                  className={`relative w-10 h-5 rounded-full transition-colors ${
+                    showGitPanel ? 'bg-accent-primary' : 'bg-border-light'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                      showGitPanel ? 'translate-x-5' : 'translate-x-0'
                     }`}
                   />
                 </button>

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -14,7 +14,7 @@ import { getDragData, isTerminalDrag } from '../utils/dragDrop';
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
 export function TerminalTabs() {
-  const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache } = useTerminalStore();
+  const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache, reorderTerminals } = useTerminalStore();
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode } = useAppStore();
   const terminalList = useMemo(() => Array.from(terminals.values()).map(t => t.config), [terminals]);
 
@@ -174,7 +174,7 @@ export function TerminalTabs() {
             ref={tabsContainerRef}
             axis="x"
             values={terminalList}
-            onReorder={() => {}}
+            onReorder={(next) => reorderTerminals(next.map((t) => t.id))}
             className="flex items-center overflow-x-auto scrollbar-none"
           >
             {terminalList.map((terminal) => {

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import appIcon from '../assets/app-icon.png';
 import {
   Lightbulb,
@@ -10,11 +10,16 @@ import {
   X,
   GitBranch,
   ChevronDown,
+  Check,
+  Loader2,
+  Search as SearchIcon,
 } from 'lucide-react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getVersion } from '@tauri-apps/api/app';
+import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '../store/appStore';
 import { useTerminalStore } from '../store/terminalStore';
+import { toast } from '../store/toastStore';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
@@ -41,10 +46,18 @@ export function TitleBar() {
     hintsOpen,
     changesOpen,
     orchestrationOpen,
+    triggerChangesRefresh,
   } = useAppStore();
   const { terminals, activeTerminalId, gitInfoCache } = useTerminalStore();
+  const fetchGitInfo = useTerminalStore.getState().fetchGitInfo;
   const appWindow = getCurrentWindow();
   const [appVersion, setAppVersion] = useState('');
+  const [branchMenuOpen, setBranchMenuOpen] = useState(false);
+  const [branches, setBranches] = useState<string[]>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+  const [checkoutTarget, setCheckoutTarget] = useState<string | null>(null);
+  const [branchFilter, setBranchFilter] = useState('');
+  const branchMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     getVersion().then(setAppVersion);
@@ -56,6 +69,69 @@ export function TitleBar() {
     () => pickBreadcrumb(active?.config.working_directory),
     [active?.config.working_directory]
   );
+
+  const openBranchMenu = useCallback(async () => {
+    if (!active?.config.working_directory) return;
+    setBranchMenuOpen(true);
+    setBranchFilter('');
+    setBranchesLoading(true);
+    try {
+      const list = await invoke<string[]>('get_repo_branches', {
+        path: active.config.working_directory,
+      });
+      setBranches(list);
+    } catch (err) {
+      toast.error('Branches', typeof err === 'string' ? err : 'Failed to list branches');
+      setBranchMenuOpen(false);
+    } finally {
+      setBranchesLoading(false);
+    }
+  }, [active?.config.working_directory]);
+
+  const handleCheckout = useCallback(async (branch: string) => {
+    if (!active?.config.working_directory || !activeTerminalId) return;
+    if (branch === gitInfo?.current_branch) { setBranchMenuOpen(false); return; }
+    setCheckoutTarget(branch);
+    try {
+      await invoke('checkout_branch', {
+        path: active.config.working_directory,
+        branch,
+      });
+      toast.success('Checkout', `Switched to ${branch}`);
+      setBranchMenuOpen(false);
+      await fetchGitInfo(activeTerminalId);
+      triggerChangesRefresh();
+    } catch (err) {
+      toast.error('Checkout failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setCheckoutTarget(null);
+    }
+  }, [active?.config.working_directory, activeTerminalId, gitInfo?.current_branch, fetchGitInfo, triggerChangesRefresh]);
+
+  // Close on outside click + Escape
+  useEffect(() => {
+    if (!branchMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (branchMenuRef.current && !branchMenuRef.current.contains(e.target as Node)) {
+        setBranchMenuOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setBranchMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [branchMenuOpen]);
+
+  const filteredBranches = useMemo(() => {
+    const q = branchFilter.trim().toLowerCase();
+    if (!q) return branches;
+    return branches.filter((b) => b.toLowerCase().includes(q));
+  }, [branches, branchFilter]);
   const statusDot = !active
     ? 'bg-text-tertiary'
     : active.config.status === 'Running'
@@ -133,20 +209,79 @@ export function TitleBar() {
           />
         </button>
 
-        {/* Branch widget */}
+        {/* Branch switcher */}
         {gitInfo?.is_git_repo && gitInfo.current_branch && (
           <>
             <span className="w-px h-4 bg-[var(--ij-divider-soft)] mx-0.5" />
-            <button
-              className="no-drag flex items-center gap-1.5 h-7 px-2 rounded-[6px] hover:bg-white/[0.06] transition-colors"
-              title={`Branch: ${gitInfo.current_branch}`}
-            >
-              <GitBranch size={12} strokeWidth={1.75} className="text-text-secondary" />
-              <span className="text-text-primary text-[12px] font-mono truncate max-w-[140px]">
-                {gitInfo.current_branch}
-              </span>
-              <ChevronDown size={11} strokeWidth={2} className="text-text-tertiary" />
-            </button>
+            <div className="relative no-drag" ref={branchMenuRef}>
+              <button
+                onClick={() => (branchMenuOpen ? setBranchMenuOpen(false) : openBranchMenu())}
+                className={`flex items-center gap-1.5 h-7 px-2 rounded-[6px] transition-colors ${
+                  branchMenuOpen ? 'bg-white/[0.08]' : 'hover:bg-white/[0.06]'
+                }`}
+                title={`Branch: ${gitInfo.current_branch} — click to switch`}
+              >
+                <GitBranch size={12} strokeWidth={1.75} className="text-text-secondary" />
+                <span className="text-text-primary text-[12px] font-mono truncate max-w-[140px]">
+                  {gitInfo.current_branch}
+                </span>
+                <ChevronDown size={11} strokeWidth={2} className="text-text-tertiary" />
+              </button>
+
+              {branchMenuOpen && (
+                <div className="absolute left-0 top-full mt-1 z-50 w-[260px] bg-elevation-3 ring-1 ring-white/[0.08] rounded-lg shadow-elevation-3 overflow-hidden">
+                  <div className="p-2 border-b border-[var(--ij-divider-soft)]">
+                    <div className="relative">
+                      <SearchIcon size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-tertiary" strokeWidth={1.75} />
+                      <input
+                        autoFocus
+                        type="text"
+                        value={branchFilter}
+                        onChange={(e) => setBranchFilter(e.target.value)}
+                        placeholder="Filter branches…"
+                        className="w-full bg-elevation-0 ring-1 ring-inset ring-[var(--ij-divider)] rounded-[4px] h-7 pl-7 pr-2 text-[12px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-accent-primary/60"
+                      />
+                    </div>
+                  </div>
+                  <div className="max-h-[320px] overflow-y-auto py-1">
+                    {branchesLoading && (
+                      <div className="flex items-center gap-2 px-3 py-2 text-text-tertiary text-[12px]">
+                        <Loader2 size={12} className="animate-spin" />
+                        Loading branches…
+                      </div>
+                    )}
+                    {!branchesLoading && filteredBranches.length === 0 && (
+                      <div className="px-3 py-2 text-text-tertiary text-[12px]">
+                        {branches.length === 0 ? 'No branches' : 'No match'}
+                      </div>
+                    )}
+                    {!branchesLoading && filteredBranches.map((b) => {
+                      const isCurrent = b === gitInfo.current_branch;
+                      const isChecking = checkoutTarget === b;
+                      return (
+                        <button
+                          key={b}
+                          onClick={() => handleCheckout(b)}
+                          disabled={isChecking || isCurrent}
+                          className={`w-full flex items-center justify-between px-3 py-1.5 text-[12px] font-mono text-left transition-colors ${
+                            isCurrent
+                              ? 'text-accent-primary bg-accent-primary/10 cursor-default'
+                              : 'text-text-primary hover:bg-white/[0.05]'
+                          }`}
+                        >
+                          <span className="truncate">{b}</span>
+                          {isChecking ? (
+                            <Loader2 size={11} className="animate-spin text-text-tertiary flex-shrink-0" />
+                          ) : isCurrent ? (
+                            <Check size={12} className="text-accent-primary flex-shrink-0" />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -11,26 +11,30 @@ const ICON_MAP: Record<ToastType, typeof CheckCircle> = {
   info: Info,
 };
 
-const COLOR_MAP: Record<ToastType, { icon: string; bar: string; bg: string }> = {
+const COLOR_MAP: Record<ToastType, { icon: string; bar: string; tint: string; ring: string }> = {
   success: {
     icon: 'text-success',
     bar: 'bg-success',
-    bg: 'bg-success/[0.06]',
+    tint: 'bg-success/10',
+    ring: 'ring-success/40',
   },
   error: {
     icon: 'text-error',
     bar: 'bg-error',
-    bg: 'bg-error/[0.06]',
+    tint: 'bg-error/10',
+    ring: 'ring-error/40',
   },
   warning: {
     icon: 'text-warning',
     bar: 'bg-warning',
-    bg: 'bg-warning/[0.06]',
+    tint: 'bg-warning/10',
+    ring: 'ring-warning/40',
   },
   info: {
     icon: 'text-accent-primary',
     bar: 'bg-accent-primary',
-    bg: 'bg-accent-primary/[0.06]',
+    tint: 'bg-accent-primary/10',
+    ring: 'ring-accent-primary/40',
   },
 };
 
@@ -63,16 +67,15 @@ function ToastItem({ id, type, title, message, duration }: {
       animate={{ opacity: 1, x: 0, scale: 1 }}
       exit={{ opacity: 0, x: 80, scale: 0.95 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className={`
-        relative overflow-hidden rounded-lg
-        bg-elevation-3 ${colors.bg}
-        ring-1 ring-white/[0.08]
-        shadow-elevation-3
-        w-[320px] pointer-events-auto
-      `}
+      className={`relative overflow-hidden rounded-lg bg-elevation-3 ring-1 ${colors.ring} shadow-[0_8px_28px_rgba(0,0,0,0.6)] backdrop-blur-xl w-[320px] pointer-events-auto isolate`}
     >
+      {/* Colored tint layer — sits above the opaque base so the card stays opaque */}
+      <div className={`absolute inset-0 pointer-events-none ${colors.tint}`} />
+      {/* Left status accent bar */}
+      <div className={`absolute left-0 top-0 bottom-0 w-[3px] ${colors.bar}`} />
+
       {/* Content */}
-      <div className="flex items-start gap-2.5 px-3 py-2.5">
+      <div className="relative flex items-start gap-2.5 px-3 py-2.5 pl-4">
         <Icon size={16} className={`${colors.icon} mt-0.5 shrink-0`} />
         <div className="flex-1 min-w-0">
           <p className="text-text-primary text-[12px] font-medium leading-tight">
@@ -94,10 +97,10 @@ function ToastItem({ id, type, title, message, duration }: {
 
       {/* Progress bar */}
       {duration > 0 && (
-        <div className="h-[2px] w-full bg-white/[0.04]">
+        <div className="relative h-[2px] w-full bg-white/[0.06]">
           <div
             ref={progressRef}
-            className={`h-full ${colors.bar} opacity-40`}
+            className={`h-full ${colors.bar} opacity-70`}
             style={{ width: '100%' }}
           />
         </div>
@@ -110,7 +113,7 @@ export function ToastContainer() {
   const toasts = useToastStore((s) => s.toasts);
 
   return (
-    <div className="fixed bottom-8 right-3 z-[9999] flex flex-col-reverse gap-2 pointer-events-none">
+    <div className="fixed bottom-8 right-3 z-[100000] flex flex-col-reverse gap-2 pointer-events-none">
       <AnimatePresence mode="popLayout">
         {toasts.map((t) => (
           <ToastItem key={t.id} {...t} />

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -21,6 +21,7 @@ interface AppState {
   notifyOnFinish: boolean;
   restoreSession: boolean;
   telemetryEnabled: boolean;
+  showGitPanel: boolean;
 
   // Changes panel
   changesRefreshTrigger: number;
@@ -86,6 +87,7 @@ interface AppState {
   setNotifyOnFinish: (enabled: boolean) => void;
   setRestoreSession: (enabled: boolean) => void;
   setTelemetryEnabled: (enabled: boolean) => void;
+  setShowGitPanel: (enabled: boolean) => void;
 
   // Grid actions
   toggleGridMode: () => void;
@@ -189,6 +191,7 @@ export const useAppStore = create<AppState>()(
       notifyOnFinish: true,
       restoreSession: true,
       telemetryEnabled: true,
+      showGitPanel: true,
 
       // Changes panel
       changesRefreshTrigger: 0,
@@ -254,6 +257,7 @@ export const useAppStore = create<AppState>()(
       setNotifyOnFinish: (enabled) => set({ notifyOnFinish: enabled }),
       setRestoreSession: (enabled) => set({ restoreSession: enabled }),
       setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
+      setShowGitPanel: (enabled) => set({ showGitPanel: enabled }),
 
       // Grid actions
       toggleGridMode: () => set((state) => ({ gridMode: !state.gridMode })),
@@ -360,6 +364,7 @@ export const useAppStore = create<AppState>()(
         notifyOnFinish: state.notifyOnFinish,
         restoreSession: state.restoreSession,
         telemetryEnabled: state.telemetryEnabled,
+        showGitPanel: state.showGitPanel,
         orchestrationOpen: state.orchestrationOpen,
         lastSeenVersion: state.lastSeenVersion,
       }),

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -62,6 +62,7 @@ interface TerminalState {
   clearUnread: (id: string) => void;
   hasUnread: (id: string) => boolean;
   fetchGitInfo: (terminalId: string) => Promise<void>;
+  reorderTerminals: (orderedIds: string[]) => void;
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -290,4 +291,20 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       // Silently ignore — non-git dirs or git not installed
     }
   },
+
+  reorderTerminals: (orderedIds) => set((state) => {
+    // Rebuild the Map in the new order. JS Maps preserve insertion order,
+    // so consumers that iterate via `Array.from(terminals.values())` pick up
+    // the reorder automatically. Unknown ids are dropped and missing ids are
+    // appended at the end to stay resilient to races with concurrent adds.
+    const next = new Map<string, TerminalInstance>();
+    for (const id of orderedIds) {
+      const inst = state.terminals.get(id);
+      if (inst) next.set(id, inst);
+    }
+    for (const [id, inst] of state.terminals) {
+      if (!next.has(id)) next.set(id, inst);
+    }
+    return { terminals: next };
+  }),
 }));


### PR DESCRIPTION
## Summary
- **Git workflow in File Changes panel** — Repositories section (root repo, linked worktrees, nested sub-repos) + Staged/Changes sections with per-file stage/unstage + Commit / Commit & Push / Stash + Stashes list with Apply/Pop/Drop.
- **Branch switcher in the TitleBar** — the existing branch widget is now an interactive dropdown with filter and one-click checkout. Errors (dirty tree, etc.) surface as toasts.
- **Terminal tab reorder** — drag tabs to reorder; the existing Reorder group's `onReorder` now persists to a new `reorderTerminals` store action.
- **Toast fix** — the card was 94% transparent due to conflicting `bg-*` classes. Now opaque base + separate tint layer + colored ring/left bar + `backdrop-blur-xl` + top-most z-index.
- **Settings toggle** — show/hide the Repositories section in File Changes.

## Backend
New Rust commands (all scoped to trusted paths, with input validation):
- `scan_git_repos`, `checkout_branch`
- `git_commit` (supports `none` / `tracked` / `all` auto-stage modes; message via temp file to dodge shell-quoting), `git_push`
- `git_stage_files`, `git_unstage_files`
- `git_stash_push`, `git_list_stashes`, `git_stash_apply`, `git_stash_pop`, `git_stash_drop`

`get_terminal_changes` now preserves git's staged vs. worktree split from porcelain (a single file with both staged and unstaged edits produces two entries).

## Test plan
- [ ] Open a repo with nested sub-repos and/or linked worktrees — confirm they appear under Repositories.
- [ ] Click the TitleBar branch pill — dropdown lists branches; checkout switches, a dirty tree surfaces an error toast.
- [ ] Modify a file → it appears under Changes. Click `+` to stage → moves to Staged. Click `−` → moves back.
- [ ] With something staged, Commit commits only staged files; & Push pushes to remote.
- [ ] With nothing staged, Commit button reads "Commit all" and stages+commits in one shot.
- [ ] Stash works with and without a message; Apply/Pop/Drop each behave correctly and Drop prompts before destroying.
- [ ] Drag terminal tabs left/right to reorder.
- [ ] Trigger a toast (e.g. failed checkout) — card is fully opaque, readable, and above all other UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)