### PR TITLE
Add file explorer, inline editor, and package.json scripts runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "claude-terminal",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-terminal",
-      "version": "1.20.2",
+      "version": "1.20.3",
       "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-process": "^2.0.0",
@@ -21,6 +22,7 @@
         "@xterm/xterm": "^5.3.0",
         "framer-motion": "^10.16.0",
         "lucide-react": "^0.294.0",
+        "monaco-editor": "^0.52.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "uuid": "^9.0.0",
@@ -792,6 +794,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2283,6 +2308,13 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2779,6 +2811,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-process": "^2.0.0",
@@ -23,6 +24,7 @@
     "@xterm/xterm": "^5.3.0",
     "framer-motion": "^10.16.0",
     "lucide-react": "^0.294.0",
+    "monaco-editor": "^0.52.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -787,7 +787,7 @@ pub struct WorktreeDetectResult {
 async fn validate_path_is_trusted(state: &State<'_, AppState>, path: &str) -> Result<(), String> {
     let canonical_path = std::path::Path::new(path)
         .canonicalize()
-        .map_err(|_| "Invalid path: directory does not exist".to_string())?;
+        .map_err(|e| format!("Invalid path '{}': {}", path, e))?;
 
     let terminals = state.terminals.lock().await;
     let known_dirs = terminals.get_all_configs();
@@ -804,7 +804,10 @@ async fn validate_path_is_trusted(state: &State<'_, AppState>, path: &str) -> Re
     });
 
     if !is_trusted {
-        return Err("Path is not associated with any active terminal session".to_string());
+        return Err(format!(
+            "Path '{}' is not under any active terminal's working directory",
+            canonical_path.display()
+        ));
     }
     Ok(())
 }
@@ -2618,4 +2621,275 @@ pub async fn git_pull_branch(
         format!("{}\n{}", stdout, stderr)
     };
     Ok(combined)
+}
+
+#[derive(Debug, Serialize)]
+pub struct PackageScript {
+    pub name: String,
+    pub command: String,
+}
+
+/// Read `package.json` at the given directory and return its `scripts` map as
+/// an ordered list. Empty vec if no package.json exists or no scripts key.
+#[command]
+pub async fn list_package_scripts(
+    state: State<'_, AppState>,
+    cwd: String,
+) -> Result<Vec<PackageScript>, String> {
+    validate_path_is_trusted(&state, &cwd).await?;
+
+    let pkg_path = std::path::Path::new(&cwd).join("package.json");
+    let bytes = match std::fs::read(&pkg_path) {
+        Ok(b) => b,
+        Err(_) => return Ok(vec![]), // no package.json → no scripts, not an error
+    };
+    let json: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("Invalid package.json: {}", e))?;
+    let scripts = match json.get("scripts").and_then(|v| v.as_object()) {
+        Some(m) => m,
+        None => return Ok(vec![]),
+    };
+    let result: Vec<PackageScript> = scripts
+        .iter()
+        .filter_map(|(name, val)| {
+            val.as_str().map(|command| PackageScript {
+                name: name.clone(),
+                command: command.to_string(),
+            })
+        })
+        .collect();
+    Ok(result)
+}
+
+/// Spawn a child terminal that runs `npm run <script>` in the given cwd.
+/// The returned terminal config has the same shape as `create_terminal` so
+/// the frontend can reuse the regular terminal rendering pipeline.
+#[command]
+pub async fn create_script_terminal(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    cwd: String,
+    script_name: String,
+) -> Result<crate::terminal::TerminalConfig, String> {
+    validate_path_is_trusted(&state, &cwd).await?;
+
+    let (tx, mut rx) = mpsc::channel::<(String, Vec<u8>)>(1000);
+
+    let config = {
+        let mut terminals = state.terminals.lock().await;
+        terminals.create_script_terminal(
+            format!("npm run {}", script_name),
+            cwd,
+            script_name,
+            tx,
+        )?
+    };
+
+    let terminal_id = config.id.clone();
+    let terminals_arc = state.terminals.clone();
+    let app_clone = app.clone();
+    tokio::spawn(async move {
+        while let Some((id, data)) = rx.recv().await {
+            if let Err(e) = app_clone.emit("terminal-output", serde_json::json!({
+                "id": id,
+                "data": data,
+            })) {
+                eprintln!("Failed to emit terminal-output: {}", e);
+                break;
+            }
+        }
+        if let Ok(mut manager) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            terminals_arc.lock(),
+        ).await {
+            let _ = manager.update_status(&terminal_id, crate::terminal::TerminalStatus::Stopped);
+        }
+        if let Err(e) = app_clone.emit("terminal-finished", serde_json::json!({ "id": terminal_id })) {
+            eprintln!("Failed to emit terminal-finished: {}", e);
+        }
+    });
+
+    Ok(config)
+}
+
+/// Return the HEAD version of a file as a string. Used by the diff editor to
+/// show original vs current working copy. Returns an empty string if the file
+/// has no HEAD version (e.g., newly-added or untracked).
+#[command]
+pub async fn get_git_head_content(
+    state: State<'_, AppState>,
+    path: String,
+    file: String,
+) -> Result<String, String> {
+    validate_path_is_trusted(&state, &path).await?;
+    if file.is_empty() || file.starts_with('-') {
+        return Err("Invalid file path".to_string());
+    }
+    // git uses forward slashes in ref specs, even on Windows.
+    let normalized = file.replace('\\', "/");
+    let spec = format!("HEAD:{}", normalized);
+    let output = shell_command("git", &["show", &spec])
+        .current_dir(&path)
+        .output()
+        .map_err(|e| format!("Failed to run git show: {}", e))?;
+    if !output.status.success() {
+        // File has no HEAD version — treat as empty (new/untracked file).
+        return Ok(String::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Discard all changes to a single file: restores index + worktree to HEAD for
+/// tracked files, deletes from disk for untracked files/dirs. Destructive.
+#[command]
+pub async fn git_discard_file(
+    state: State<'_, AppState>,
+    path: String,
+    file: String,
+    untracked: bool,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+    if file.is_empty() || file.starts_with('-') {
+        return Err("Invalid file path".to_string());
+    }
+
+    if untracked {
+        // Untracked files/directories aren't tracked by git — just remove from disk.
+        // `file` is relative to `path`. Resolve and sanity-check it ends up inside
+        // the repo to avoid `..` escapes.
+        let joined = std::path::Path::new(&path).join(&file);
+        let canonical_target = joined.canonicalize().map_err(|e| {
+            format!("Cannot resolve '{}': {}", joined.display(), e)
+        })?;
+        let canonical_root = std::path::Path::new(&path)
+            .canonicalize()
+            .map_err(|e| format!("Cannot resolve repo '{}': {}", path, e))?;
+        if !canonical_target.starts_with(&canonical_root) {
+            return Err(format!(
+                "Refusing to delete path outside repo: {}",
+                canonical_target.display()
+            ));
+        }
+        let meta = std::fs::metadata(&canonical_target)
+            .map_err(|e| format!("Failed to stat '{}': {}", canonical_target.display(), e))?;
+        if meta.is_dir() {
+            std::fs::remove_dir_all(&canonical_target)
+                .map_err(|e| format!("Failed to delete directory: {}", e))?;
+        } else {
+            std::fs::remove_file(&canonical_target)
+                .map_err(|e| format!("Failed to delete file: {}", e))?;
+        }
+        return Ok(());
+    }
+
+    // Tracked file — reset index + worktree for just this file to HEAD.
+    let output = shell_command("git", &["checkout", "HEAD", "--", &file])
+        .current_dir(&path)
+        .output()
+        .map_err(|e| format!("Failed to run git checkout: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(if !stderr.is_empty() { stderr } else if !stdout.is_empty() { stdout } else { "git checkout failed".into() });
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File tree / editor commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct DirEntryInfo {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub size: u64,
+}
+
+/// List the immediate children of a directory. Does NOT recurse — the UI
+/// requests children lazily when the user expands a folder.
+#[command]
+pub async fn list_directory(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<Vec<DirEntryInfo>, String> {
+    validate_path_is_trusted(&state, &path).await?;
+
+    let mut entries: Vec<DirEntryInfo> = Vec::new();
+    let read_dir = std::fs::read_dir(&path).map_err(|e| format!("Failed to read directory: {}", e))?;
+    for entry in read_dir.flatten() {
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let file_name = entry.file_name().to_string_lossy().to_string();
+        let full_path = entry.path().to_string_lossy().to_string();
+        entries.push(DirEntryInfo {
+            name: file_name,
+            path: full_path,
+            is_dir: meta.is_dir(),
+            is_symlink: meta.file_type().is_symlink(),
+            size: if meta.is_file() { meta.len() } else { 0 },
+        });
+    }
+
+    // VS Code ordering: folders first, then files, each alphabetical (case-insensitive).
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+
+    Ok(entries)
+}
+
+/// Read a file as UTF-8 text. Refuses binary files and very large files so the
+/// editor can't be used to OOM the app.
+#[command]
+pub async fn read_text_file(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<String, String> {
+    validate_path_is_trusted(&state, &path).await?;
+
+    let meta = std::fs::metadata(&path).map_err(|e| format!("Failed to stat file: {}", e))?;
+    if meta.is_dir() {
+        return Err("Path is a directory".to_string());
+    }
+    const MAX_BYTES: u64 = 5 * 1024 * 1024; // 5 MB
+    if meta.len() > MAX_BYTES {
+        return Err(format!(
+            "File is too large to edit in-app ({} bytes, max {}).",
+            meta.len(),
+            MAX_BYTES
+        ));
+    }
+
+    let bytes = std::fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    // Quick binary sniff: any NUL byte in the first 8 KB → binary.
+    let sniff_len = bytes.len().min(8192);
+    if bytes[..sniff_len].contains(&0u8) {
+        return Err("File appears to be binary and cannot be edited as text.".to_string());
+    }
+    String::from_utf8(bytes).map_err(|_| "File is not valid UTF-8.".to_string())
+}
+
+/// Write UTF-8 text back to a file. Refuses to create new paths — the file must
+/// already exist in a trusted location.
+#[command]
+pub async fn write_text_file(
+    state: State<'_, AppState>,
+    path: String,
+    content: String,
+) -> Result<(), String> {
+    validate_path_is_trusted(&state, &path).await?;
+
+    let meta = std::fs::metadata(&path).map_err(|e| format!("Failed to stat file: {}", e))?;
+    if meta.is_dir() {
+        return Err("Path is a directory".to_string());
+    }
+    std::fs::write(&path, content.as_bytes()).map_err(|e| format!("Failed to write file: {}", e))?;
+    Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -112,6 +112,13 @@ fn main() {
             commands::write_memory_file,
             commands::list_claude_md_files,
             commands::scan_git_repos,
+            commands::list_directory,
+            commands::read_text_file,
+            commands::write_text_file,
+            commands::git_discard_file,
+            commands::get_git_head_content,
+            commands::list_package_scripts,
+            commands::create_script_terminal,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -247,6 +247,127 @@ impl TerminalManager {
         Ok(config)
     }
 
+    /// Spawn a PTY running `npm run <script>` in the given working directory.
+    /// Used by the package.json scripts runner. Reuses the same reader thread
+    /// plumbing as `create_terminal` so frontend handling is unchanged.
+    pub fn create_script_terminal(
+        &mut self,
+        label: String,
+        working_directory: String,
+        script_name: String,
+        tx: mpsc::Sender<(String, Vec<u8>)>,
+    ) -> Result<TerminalConfig, String> {
+        // npm script names come from package.json keys but the user picks them
+        // via UI, so reject any shell metacharacter as defense-in-depth.
+        if script_name.is_empty() || script_name.contains(Self::SHELL_METACHARACTERS) {
+            return Err(format!("Invalid script name: '{}'", script_name));
+        }
+
+        let pty_system = native_pty_system();
+        let pty_pair = pty_system
+            .openpty(PtySize {
+                rows: 30,
+                cols: 120,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| format!("Failed to open pty: {}", e))?;
+
+        #[cfg(target_os = "windows")]
+        let cmd = {
+            let mut c = CommandBuilder::new("cmd.exe");
+            c.arg("/C");
+            c.arg("npm");
+            c.arg("run");
+            c.arg(&script_name);
+            c
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let cmd = {
+            const VALID_SHELLS: &[&str] = &[
+                "/bin/bash", "/bin/sh", "/bin/zsh", "/bin/fish", "/bin/dash",
+                "/usr/bin/bash", "/usr/bin/sh", "/usr/bin/zsh", "/usr/bin/fish", "/usr/bin/dash",
+                "/usr/local/bin/bash", "/usr/local/bin/zsh", "/usr/local/bin/fish",
+                "/opt/homebrew/bin/bash", "/opt/homebrew/bin/zsh", "/opt/homebrew/bin/fish",
+            ];
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+            let shell = if VALID_SHELLS.contains(&shell.as_str()) { shell } else { "/bin/bash".to_string() };
+            let mut c = CommandBuilder::new(&shell);
+            // Single-quote the script name as defense-in-depth (already validated above).
+            let mut full = String::from("npm run '");
+            for ch in script_name.chars() {
+                if ch == '\'' { full.push_str("'\\''"); } else { full.push(ch); }
+            }
+            full.push('\'');
+            c.arg("-lc");
+            c.arg(&full);
+            c
+        };
+
+        let mut cmd = cmd;
+        if !working_directory.is_empty() {
+            cmd.cwd(&working_directory);
+        }
+
+        let _child = pty_pair.slave.spawn_command(cmd)
+            .map_err(|e| format!("Failed to spawn npm run {}: {}", script_name, e))?;
+
+        let id = Uuid::new_v4().to_string();
+        let config = TerminalConfig {
+            id: id.clone(),
+            label,
+            nickname: Some(format!("npm run {}", script_name)),
+            profile_id: None,
+            working_directory,
+            // Reuse claude_args to carry the script command — simplest fit for
+            // restore / session history without adding another schema field.
+            claude_args: vec!["__script__".into(), script_name.clone()],
+            env_vars: HashMap::new(),
+            created_at: Utc::now(),
+            status: TerminalStatus::Running,
+            color_tag: None,
+        };
+
+        let mut reader = pty_pair.master.try_clone_reader()
+            .map_err(|e| format!("Failed to clone reader: {}", e))?;
+        let writer = pty_pair.master.take_writer()
+            .map_err(|e| format!("Failed to take writer: {}", e))?;
+
+        let terminal_id = id.clone();
+        let reader_handle = std::thread::spawn(move || {
+            let mut buf = [0u8; 32 * 1024];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let data = buf[..n].to_vec();
+                        if tx.blocking_send((terminal_id.clone(), data)).is_err() { break; }
+                    }
+                    Err(e) => {
+                        let _ = tx.blocking_send((
+                            terminal_id.clone(),
+                            format!("\r\n[Error: {}]\r\n", e).into_bytes(),
+                        ));
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.terminals.insert(
+            id.clone(),
+            Terminal {
+                config: config.clone(),
+                pty_pair,
+                writer,
+                reader_handle: Some(reader_handle),
+            },
+        );
+
+        Ok(config)
+    }
+
     pub fn write(&mut self, id: &str, data: &[u8]) -> Result<(), String> {
         if let Some(terminal) = self.terminals.get_mut(id) {
             terminal

--- a/src/components/FileChangesPanel.tsx
+++ b/src/components/FileChangesPanel.tsx
@@ -67,6 +67,7 @@ export function FileChangesPanel() {
   const changesRefreshTrigger = useAppStore((s) => s.changesRefreshTrigger);
   const openWorktreeModal = useAppStore((s) => s.openWorktreeModal);
   const showGitPanel = useAppStore((s) => s.showGitPanel);
+  const setPinnedRepoPath = useAppStore((s) => s.setPinnedRepoPath);
   const activeGitInfo = activeTerminalId ? gitInfoCache.get(activeTerminalId) : null;
   const activeCwd = useMemo(() => {
     if (!activeTerminalId) return null;
@@ -87,6 +88,14 @@ export function FileChangesPanel() {
 
   // Reset selection when the active terminal changes
   useEffect(() => { setSelectedRepoPath(null); }, [activeTerminalId]);
+
+  // Publish the explicit repo pin so other panels (file tree) can follow it.
+  // Only publish when the user has actually selected a nested repo — otherwise
+  // other panels fall back to the active terminal's cwd.
+  useEffect(() => {
+    setPinnedRepoPath(selectedRepoPath);
+    return () => setPinnedRepoPath(null);
+  }, [selectedRepoPath, setPinnedRepoPath]);
 
   // Commit / push / stash state
   const [commitMessage, setCommitMessage] = useState('');
@@ -465,6 +474,7 @@ export function FileChangesPanel() {
             setExpandedFile={setExpandedFile}
             activeTerminalId={activeTerminalId}
             pathOverride={usingSelectedRepo ? selectedRepoPath : null}
+            repoRoot={activePath}
             stagingPaths={stagingPaths}
             onStage={stageFiles}
             onUnstage={unstageFiles}
@@ -482,6 +492,7 @@ export function FileChangesPanel() {
             setExpandedFile={setExpandedFile}
             activeTerminalId={activeTerminalId}
             pathOverride={usingSelectedRepo ? selectedRepoPath : null}
+            repoRoot={activePath}
             stagingPaths={stagingPaths}
             onStage={stageFiles}
             onUnstage={unstageFiles}
@@ -666,16 +677,55 @@ interface ChangeGroupProps {
   setExpandedFile: (v: string | null) => void;
   activeTerminalId: string | null;
   pathOverride: string | null;
+  repoRoot: string | null;
   stagingPaths: Set<string>;
   onStage: (files: string[]) => void;
   onUnstage: (files: string[]) => void;
   onBulk: () => void;
 }
 
+function joinRepoPath(root: string, relative: string): string {
+  // Normalize both sides to forward slashes so the result is valid on Windows
+  // (std::fs accepts either) and free of doubled-up separators when `relative`
+  // contains escapes. Git's porcelain output always uses forward slashes.
+  const cleanRoot = root.replace(/\\/g, '/').replace(/\/+$/, '');
+  const cleanRel = relative.replace(/\\/g, '/').replace(/^\/+/, '');
+  // Strip any surrounding quotes git may add for paths with special chars.
+  const unquotedRel = cleanRel.startsWith('"') && cleanRel.endsWith('"')
+    ? cleanRel.slice(1, -1)
+    : cleanRel;
+  return `${cleanRoot}/${unquotedRel}`;
+}
+
 function ChangeGroup({
   title, count, files, staged, expandedFile, setExpandedFile,
-  activeTerminalId, pathOverride, stagingPaths, onStage, onUnstage, onBulk,
+  activeTerminalId, pathOverride, repoRoot, stagingPaths, onStage, onUnstage, onBulk,
 }: ChangeGroupProps) {
+  const openDiffTab = useAppStore((s) => s.openDiffTab);
+  const triggerRefresh = useAppStore((s) => s.triggerChangesRefresh);
+  const closeFileTab = useAppStore((s) => s.closeFileTab);
+
+  const handleDiscard = useCallback(async (file: FileChange) => {
+    if (!repoRoot) return;
+    const label = file.path.split(/[\\/]/).pop() ?? file.path;
+    const verb = file.status === 'untracked' ? 'delete the untracked file' : 'discard all changes in';
+    const ok = window.confirm(`${verb === 'delete the untracked file' ? 'Delete' : 'Discard'}: ${label}?\n\n${verb} "${file.path}"? This cannot be undone.`);
+    if (!ok) return;
+    try {
+      await invoke('git_discard_file', {
+        path: repoRoot,
+        file: file.path,
+        untracked: file.status === 'untracked',
+      });
+      // If the file was open in the editor, close it — its contents no longer match disk.
+      const abs = joinRepoPath(repoRoot, file.path);
+      closeFileTab(abs);
+      toast.success('Discarded', label);
+      triggerRefresh();
+    } catch (err) {
+      toast.error('Discard failed', typeof err === 'string' ? err : 'Unknown error');
+    }
+  }, [repoRoot, triggerRefresh, closeFileTab]);
   return (
     <div className="mb-2">
       <div className="flex items-center justify-between px-2 py-1 border-b border-border/30 mb-1">
@@ -721,6 +771,30 @@ function ChangeGroup({
               <p className={`flex-1 text-[12px] font-mono truncate ${config.color}`} title={file.path}>
                 {file.path}
               </p>
+              {repoRoot && file.status !== 'deleted' && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void openDiffTab(joinRepoPath(repoRoot, file.path), repoRoot, file.path);
+                  }}
+                  className="shrink-0 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity text-text-tertiary hover:bg-white/[0.08] hover:text-text-primary"
+                  title="Open diff in editor"
+                >
+                  <FileEdit size={11} />
+                </button>
+              )}
+              {repoRoot && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleDiscard(file);
+                  }}
+                  className="shrink-0 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity text-text-tertiary hover:bg-red-500/20 hover:text-red-400"
+                  title={file.status === 'untracked' ? 'Delete untracked file' : 'Discard all changes'}
+                >
+                  <Trash2 size={11} />
+                </button>
+              )}
               <button
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/components/FileEditorView.tsx
+++ b/src/components/FileEditorView.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { Loader2, AlertCircle, Save, RefreshCw, FileCode2, GitCompareArrows } from 'lucide-react';
+import Editor, { DiffEditor, type OnMount, type DiffOnMount } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import { useAppStore } from '../store/appStore';
+import { toast } from '../store/toastStore';
+import { languageFromPath } from './monacoSetup';
+
+interface FileEditorViewProps {
+  path: string;
+}
+
+/**
+ * Inline Monaco editor for a single open file tab. Uses `path` as Monaco's
+ * model key so switching between file tabs preserves per-file cursor position,
+ * selection, and undo history — same behavior as VS Code.
+ */
+export function FileEditorView({ path }: FileEditorViewProps) {
+  const tab = useAppStore((s) => s.openFiles.find((t) => t.path === path));
+  const setFileTabContent = useAppStore((s) => s.setFileTabContent);
+  const setFileTabMode = useAppStore((s) => s.setFileTabMode);
+  const saveFileTab = useAppStore((s) => s.saveFileTab);
+  const reloadFileTab = useAppStore((s) => s.reloadFileTab);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
+
+  const dirty = tab ? tab.content !== tab.original : false;
+  const language = useMemo(() => languageFromPath(path), [path]);
+
+  // Ctrl/Cmd+S saves the active file. Only active when this path is the
+  // currently-focused file tab (the parent only mounts us for the active tab).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey;
+      if (mod && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        if (!dirty) return;
+        saveFileTab(path).catch((err) => {
+          toast.error('Save failed', typeof err === 'string' ? err : 'Unknown error');
+        });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [path, dirty, saveFileTab]);
+
+  const onMount: OnMount = (ed) => {
+    editorRef.current = ed;
+    ed.focus();
+  };
+
+  const onDiffMount: DiffOnMount = (ed) => {
+    diffEditorRef.current = ed;
+    const modified = ed.getModifiedEditor();
+    // Treat the modified (right) side as editable and pipe its changes into
+    // the store so dirty tracking and Save continue to work in diff mode.
+    modified.onDidChangeModelContent(() => {
+      setFileTabContent(path, modified.getValue());
+    });
+    modified.focus();
+  };
+
+  if (!tab) return null;
+
+  return (
+    <div className="h-full flex flex-col bg-bg-primary">
+      {/* Breadcrumb / status bar for the file */}
+      <div className="flex items-center justify-between px-3 h-7 bg-elevation-0 border-b border-[var(--ij-divider-soft)] flex-shrink-0">
+        <p className="text-text-tertiary text-[11px] font-mono truncate" title={path}>
+          {path}
+        </p>
+        <div className="flex items-center gap-1">
+          {tab.repoRoot && (
+            <button
+              onClick={() => setFileTabMode(path, tab.mode === 'diff' ? 'edit' : 'diff')}
+              className={`flex items-center gap-1 h-5 px-1.5 rounded-[4px] text-[10.5px] transition-colors ${
+                tab.mode === 'diff'
+                  ? 'bg-accent-primary/20 text-accent-primary'
+                  : 'text-text-tertiary hover:text-text-primary hover:bg-white/[0.06]'
+              }`}
+              title={tab.mode === 'diff' ? 'Switch to plain editor' : 'Show diff against HEAD'}
+            >
+              {tab.mode === 'diff' ? <FileCode2 size={10} strokeWidth={1.75} /> : <GitCompareArrows size={10} strokeWidth={1.75} />}
+              {tab.mode === 'diff' ? 'Edit' : 'Diff'}
+            </button>
+          )}
+          <button
+            onClick={() => reloadFileTab(path)}
+            disabled={tab.loading}
+            className="flex items-center gap-1 h-5 px-1.5 rounded-[4px] text-[10.5px] text-text-tertiary hover:text-text-primary hover:bg-white/[0.06] transition-colors disabled:opacity-40"
+            title="Reload from disk"
+          >
+            <RefreshCw size={10} className={tab.loading ? 'animate-spin' : ''} strokeWidth={1.75} />
+            Reload
+          </button>
+          <button
+            onClick={() => {
+              if (!dirty) return;
+              saveFileTab(path).catch((err) => {
+                toast.error('Save failed', typeof err === 'string' ? err : 'Unknown error');
+              });
+            }}
+            disabled={!dirty || tab.saving || tab.loading}
+            className="flex items-center gap-1 h-5 px-1.5 rounded-[4px] text-[10.5px] font-medium bg-accent-primary hover:bg-accent-secondary text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            title="Save (Ctrl+S)"
+          >
+            {tab.saving ? <Loader2 size={10} className="animate-spin" /> : <Save size={10} />}
+            Save
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 relative">
+        {tab.loading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-bg-primary/80 z-10">
+            <div className="flex items-center gap-2 text-text-secondary text-[12px]">
+              <Loader2 size={14} className="animate-spin" />
+              Loading…
+            </div>
+          </div>
+        )}
+        {tab.error ? (
+          <div className="flex items-start justify-center h-full p-6">
+            <div className="flex items-start gap-2 max-w-md text-red-400 text-[12.5px]">
+              <AlertCircle size={16} className="mt-0.5 flex-shrink-0" />
+              <p>{tab.error}</p>
+            </div>
+          </div>
+        ) : tab.mode === 'diff' ? (
+          <DiffEditor
+            height="100%"
+            language={language}
+            original={tab.headContent}
+            modified={tab.content}
+            onMount={onDiffMount}
+            theme="vs-dark"
+            options={{
+              fontSize: 13,
+              renderSideBySide: true,
+              automaticLayout: true,
+              readOnly: false,
+              originalEditable: false,
+              wordWrap: 'off',
+              scrollBeyondLastLine: false,
+              smoothScrolling: true,
+              padding: { top: 8, bottom: 8 },
+            }}
+          />
+        ) : (
+          <Editor
+            height="100%"
+            language={language}
+            path={path}
+            value={tab.content}
+            onChange={(v) => setFileTabContent(path, v ?? '')}
+            onMount={onMount}
+            theme="vs-dark"
+            options={{
+              fontSize: 13,
+              minimap: { enabled: true },
+              automaticLayout: true,
+              wordWrap: 'off',
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              renderWhitespace: 'selection',
+              smoothScrolling: true,
+              cursorBlinking: 'smooth',
+              padding: { top: 8, bottom: 8 },
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileTreePanel.tsx
+++ b/src/components/FileTreePanel.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ChevronRight, ChevronDown, Folder, FolderOpen, File as FileIcon, RefreshCw } from 'lucide-react';
+import { useAppStore } from '../store/appStore';
+import { useTerminalStore } from '../store/terminalStore';
+
+interface DirEntryInfo {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  is_symlink: boolean;
+  size: number;
+}
+
+interface TreeNode {
+  entry: DirEntryInfo;
+  children: TreeNode[] | null; // null = not loaded yet
+  loading: boolean;
+  expanded: boolean;
+  error: string | null;
+}
+
+function makeNode(entry: DirEntryInfo): TreeNode {
+  return { entry, children: null, loading: false, expanded: false, error: null };
+}
+
+function basename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('\\'), trimmed.lastIndexOf('/'));
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+export function FileTreePanel() {
+  const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
+  const terminals = useTerminalStore((s) => s.terminals);
+  const pinnedRepoPath = useAppStore((s) => s.pinnedRepoPath);
+  const openFileTab = useAppStore((s) => s.openFileTab);
+  const changesRefreshTrigger = useAppStore((s) => s.changesRefreshTrigger);
+
+  const activeCwd = useMemo(() => {
+    if (!activeTerminalId) return null;
+    return terminals.get(activeTerminalId)?.config.working_directory ?? null;
+  }, [activeTerminalId, terminals]);
+
+  const rootPath = pinnedRepoPath ?? activeCwd;
+
+  const [rootChildren, setRootChildren] = useState<TreeNode[] | null>(null);
+  const [rootLoading, setRootLoading] = useState(false);
+  const [rootError, setRootError] = useState<string | null>(null);
+
+  // Track expanded folders across refreshes by absolute path
+  const expandedPathsRef = useRef<Set<string>>(new Set());
+
+  const loadChildren = useCallback(async (path: string): Promise<DirEntryInfo[]> => {
+    return await invoke<DirEntryInfo[]>('list_directory', { path });
+  }, []);
+
+  const refreshRoot = useCallback(async () => {
+    if (!rootPath) {
+      setRootChildren(null);
+      setRootError(null);
+      return;
+    }
+    setRootLoading(true);
+    setRootError(null);
+    try {
+      const entries = await loadChildren(rootPath);
+      // Preserve expansion state for paths still present.
+      const existing = new Map<string, TreeNode>();
+      const collect = (nodes: TreeNode[] | null) => {
+        if (!nodes) return;
+        for (const n of nodes) {
+          existing.set(n.entry.path, n);
+          if (n.children) collect(n.children);
+        }
+      };
+      collect(rootChildren);
+
+      const nextRoot: TreeNode[] = entries.map((e) => {
+        const prev = existing.get(e.path);
+        if (prev && prev.entry.is_dir === e.is_dir) {
+          return { ...prev, entry: e };
+        }
+        return makeNode(e);
+      });
+      setRootChildren(nextRoot);
+    } catch (err) {
+      setRootError(typeof err === 'string' ? err : 'Failed to read folder');
+      setRootChildren(null);
+    } finally {
+      setRootLoading(false);
+    }
+    // rootChildren intentionally excluded — this would cause infinite reloads;
+    // refreshRoot is called on explicit triggers only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootPath, loadChildren]);
+
+  useEffect(() => {
+    expandedPathsRef.current = new Set();
+    refreshRoot();
+  }, [rootPath, changesRefreshTrigger]); // reload on terminal change and external refresh
+
+  const updateNode = useCallback((targetPath: string, updater: (n: TreeNode) => TreeNode) => {
+    setRootChildren((prev) => {
+      if (!prev) return prev;
+      const walk = (nodes: TreeNode[]): TreeNode[] =>
+        nodes.map((n) => {
+          if (n.entry.path === targetPath) return updater(n);
+          if (n.children) {
+            const nextChildren = walk(n.children);
+            if (nextChildren !== n.children) return { ...n, children: nextChildren };
+          }
+          return n;
+        });
+      return walk(prev);
+    });
+  }, []);
+
+  const toggleExpand = useCallback(async (node: TreeNode) => {
+    if (!node.entry.is_dir) return;
+    const { path } = node.entry;
+    // Collapse
+    if (node.expanded) {
+      expandedPathsRef.current.delete(path);
+      updateNode(path, (n) => ({ ...n, expanded: false }));
+      return;
+    }
+    // Expand — if children already loaded, just flip the flag
+    if (node.children) {
+      expandedPathsRef.current.add(path);
+      updateNode(path, (n) => ({ ...n, expanded: true }));
+      return;
+    }
+    // Lazy-load children
+    updateNode(path, (n) => ({ ...n, loading: true, error: null }));
+    try {
+      const entries = await loadChildren(path);
+      expandedPathsRef.current.add(path);
+      updateNode(path, (n) => ({
+        ...n,
+        loading: false,
+        expanded: true,
+        children: entries.map(makeNode),
+        error: null,
+      }));
+    } catch (err) {
+      updateNode(path, (n) => ({
+        ...n,
+        loading: false,
+        error: typeof err === 'string' ? err : 'Failed to read folder',
+      }));
+    }
+  }, [loadChildren, updateNode]);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 border-t border-[var(--ij-divider-soft)]">
+      {/* Section header */}
+      <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
+        <div className="flex items-center gap-1.5 text-text-secondary">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">Explorer</span>
+        </div>
+        <button
+          onClick={refreshRoot}
+          disabled={rootLoading}
+          className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+          title="Refresh"
+        >
+          <RefreshCw size={11} className={rootLoading ? 'animate-spin' : ''} strokeWidth={1.75} />
+        </button>
+      </div>
+
+      {/* Root path label */}
+      {rootPath && (
+        <div className="px-3 pb-1 flex-shrink-0">
+          <p className="text-text-tertiary text-[10.5px] font-mono truncate" title={rootPath}>
+            {basename(rootPath)}
+          </p>
+        </div>
+      )}
+
+      {/* Tree content */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
+        {!rootPath && (
+          <div className="px-3 py-2 text-text-tertiary text-[11px]">
+            No active terminal
+          </div>
+        )}
+        {rootPath && rootError && (
+          <div className="px-3 py-2 text-red-400 text-[11px]">{rootError}</div>
+        )}
+        {rootPath && !rootError && rootChildren === null && rootLoading && (
+          <div className="px-3 py-2 text-text-tertiary text-[11px]">Loading…</div>
+        )}
+        {rootChildren && rootChildren.length === 0 && (
+          <div className="px-3 py-2 text-text-tertiary text-[11px]">(empty folder)</div>
+        )}
+        {rootChildren && rootChildren.map((node) => (
+          <TreeRow
+            key={node.entry.path}
+            node={node}
+            depth={0}
+            onToggle={toggleExpand}
+            onOpenFile={(p) => { void openFileTab(p); }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface TreeRowProps {
+  node: TreeNode;
+  depth: number;
+  onToggle: (n: TreeNode) => void;
+  onOpenFile: (path: string) => void;
+}
+
+function TreeRow({ node, depth, onToggle, onOpenFile }: TreeRowProps) {
+  const { entry } = node;
+  const indent = 8 + depth * 12;
+  const rowClass = 'group flex items-center gap-1 h-[22px] px-1 rounded-[3px] cursor-pointer hover:bg-white/[0.045] transition-colors';
+
+  if (entry.is_dir) {
+    return (
+      <>
+        <div
+          className={rowClass}
+          style={{ paddingLeft: indent }}
+          onClick={() => onToggle(node)}
+        >
+          {node.expanded ? (
+            <ChevronDown size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
+          ) : (
+            <ChevronRight size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
+          )}
+          {node.expanded ? (
+            <FolderOpen size={13} className="text-accent-primary shrink-0" strokeWidth={1.75} />
+          ) : (
+            <Folder size={13} className="text-accent-primary shrink-0" strokeWidth={1.75} />
+          )}
+          <span className="text-[12px] text-text-primary truncate" title={entry.name}>
+            {entry.name}
+          </span>
+        </div>
+        {node.expanded && node.loading && (
+          <div className="text-text-tertiary text-[11px]" style={{ paddingLeft: indent + 24 }}>
+            Loading…
+          </div>
+        )}
+        {node.expanded && node.error && (
+          <div className="text-red-400 text-[11px]" style={{ paddingLeft: indent + 24 }}>
+            {node.error}
+          </div>
+        )}
+        {node.expanded && node.children && node.children.map((child) => (
+          <TreeRow
+            key={child.entry.path}
+            node={child}
+            depth={depth + 1}
+            onToggle={onToggle}
+            onOpenFile={onOpenFile}
+          />
+        ))}
+      </>
+    );
+  }
+
+  // File row
+  return (
+    <div
+      className={rowClass}
+      style={{ paddingLeft: indent + 12 /* align with folder names */ }}
+      onClick={() => onOpenFile(entry.path)}
+      title={entry.path}
+    >
+      <FileIcon size={12} className="text-text-tertiary shrink-0" strokeWidth={1.75} />
+      <span className="text-[12px] text-text-secondary truncate">{entry.name}</span>
+    </div>
+  );
+}

--- a/src/components/ScriptChildPane.tsx
+++ b/src/components/ScriptChildPane.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X, Package, Circle, GripHorizontal } from 'lucide-react';
+import { TerminalView } from './TerminalView';
+import type { TerminalConfig } from '../store/terminalStore';
+
+interface ScriptChildPaneProps {
+  parentId: string;
+  childId: string;
+  scriptName: string;
+  status: TerminalConfig['status'];
+  onClose: () => void;
+}
+
+/**
+ * Renders the script-child terminal below the parent terminal, VS Code style.
+ * The pane has a drag-to-resize handle at its top so the user can trade space
+ * between the parent (Claude) and the script output.
+ */
+export function ScriptChildPane({ parentId: _parentId, childId, scriptName, status, onClose }: ScriptChildPaneProps) {
+  const [height, setHeight] = useState(240); // px
+  const draggingRef = useRef(false);
+  const startYRef = useRef(0);
+  const startHeightRef = useRef(0);
+
+  const onDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    startYRef.current = e.clientY;
+    startHeightRef.current = height;
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+  }, [height]);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const delta = startYRef.current - e.clientY;
+      // Clamp height: at least 80px (header + one row), at most 800px.
+      const next = Math.min(800, Math.max(80, startHeightRef.current + delta));
+      setHeight(next);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, []);
+
+  const statusDot = status === 'Running'
+    ? 'bg-success'
+    : status === 'Error'
+      ? 'bg-error'
+      : 'bg-text-tertiary';
+
+  return (
+    <>
+      {/* Drag handle — same styling as the Sidebar splitter for consistency */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        onMouseDown={onDown}
+        className="group h-1.5 shrink-0 cursor-row-resize flex items-center justify-center bg-transparent hover:bg-accent-primary/50 active:bg-accent-primary/70 transition-colors"
+        title="Drag to resize script output"
+      >
+        <GripHorizontal size={10} className="text-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity" strokeWidth={1.5} />
+      </div>
+
+      <div
+        className="shrink-0 flex flex-col border-t border-[var(--ij-divider)] bg-bg-primary"
+        style={{ height }}
+      >
+        {/* Script terminal header */}
+        <div className="h-7 flex items-center justify-between px-3 bg-elevation-0 border-b border-[var(--ij-divider-soft)] flex-shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <Package size={12} className="text-accent-primary flex-shrink-0" strokeWidth={1.75} />
+            <span className="text-[11.5px] font-medium text-text-primary truncate">
+              npm run <span className="font-mono text-accent-primary">{scriptName}</span>
+            </span>
+            <div className="flex items-center gap-1 ml-1">
+              <Circle size={7} className={`${statusDot} rounded-full`} fill="currentColor" strokeWidth={0} />
+              <span className="text-[10px] text-text-tertiary uppercase tracking-wide">{status}</span>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-0.5 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-text-primary transition-colors"
+            title="Stop and close script"
+          >
+            <X size={13} strokeWidth={1.75} />
+          </button>
+        </div>
+
+        {/* Child xterm */}
+        <div className="flex-1 min-h-0">
+          <TerminalView terminalId={childId} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ScriptsMenu.tsx
+++ b/src/components/ScriptsMenu.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Play, ChevronDown, Square, Loader2, Package } from 'lucide-react';
+import { useTerminalStore } from '../store/terminalStore';
+import { toast } from '../store/toastStore';
+
+interface PackageScript {
+  name: string;
+  command: string;
+}
+
+interface ScriptsMenuProps {
+  terminalId: string;
+  cwd: string;
+}
+
+/**
+ * Dropdown that lists scripts from package.json in the terminal's cwd and
+ * spawns them as child terminals (visible split-below in the same tab).
+ * Auto-hides when there are no scripts — users see nothing for non-JS dirs.
+ */
+export function ScriptsMenu({ terminalId, cwd }: ScriptsMenuProps) {
+  const [scripts, setScripts] = useState<PackageScript[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [running, setRunning] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scriptChildren = useTerminalStore((s) => s.scriptChildren);
+  const terminals = useTerminalStore((s) => s.terminals);
+  const runScript = useTerminalStore((s) => s.runScript);
+  const closeScript = useTerminalStore((s) => s.closeScript);
+
+  const childId = scriptChildren.get(terminalId);
+  const childInstance = childId ? terminals.get(childId) : undefined;
+  const activeScriptName = childInstance?.scriptName ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const list = await invoke<PackageScript[]>('list_package_scripts', { cwd });
+        if (!cancelled) setScripts(list);
+      } catch {
+        if (!cancelled) setScripts([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [cwd]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const handleRun = async (scriptName: string) => {
+    setOpen(false);
+    setRunning(true);
+    try {
+      await runScript(terminalId, scriptName);
+    } catch (err) {
+      toast.error('Failed to run script', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const handleStop = async () => {
+    try {
+      await closeScript(terminalId);
+    } catch (err) {
+      toast.error('Failed to stop', typeof err === 'string' ? err : 'Unknown error');
+    }
+  };
+
+  // Silently hide when there are no scripts — don't pollute the UI for
+  // terminals that aren't in a Node project.
+  if (!loading && scripts.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className="relative">
+      {activeScriptName ? (
+        <button
+          onClick={handleStop}
+          className="flex items-center gap-1 h-6 px-2 rounded-[4px] text-[11px] bg-red-500/15 text-red-400 hover:bg-red-500/25 transition-colors"
+          title={`Stop npm run ${activeScriptName}`}
+        >
+          <Square size={11} strokeWidth={1.75} />
+          <span className="font-mono max-w-[80px] truncate">{activeScriptName}</span>
+        </button>
+      ) : (
+        <button
+          onClick={() => setOpen((v) => !v)}
+          disabled={loading || running}
+          className="flex items-center gap-1 h-6 px-2 rounded-[4px] text-[11px] text-text-secondary hover:bg-white/[0.06] hover:text-text-primary transition-colors disabled:opacity-50"
+          title="Run a package.json script"
+        >
+          {loading || running ? <Loader2 size={11} className="animate-spin" /> : <Package size={11} strokeWidth={1.75} />}
+          Scripts
+          <ChevronDown size={10} className="opacity-60" strokeWidth={1.75} />
+        </button>
+      )}
+
+      {open && scripts.length > 0 && (
+        <div className="absolute right-0 top-full mt-1 z-30 bg-elevation-3 ring-1 ring-white/[0.08] rounded-lg shadow-elevation-3 py-1 min-w-[240px] max-w-[360px] max-h-[50vh] overflow-y-auto">
+          <div className="px-3 py-1.5 text-[10.5px] uppercase tracking-wide text-text-tertiary border-b border-[var(--ij-divider-soft)] mb-1">
+            package.json scripts
+          </div>
+          {scripts.map((script) => (
+            <button
+              key={script.name}
+              onClick={() => handleRun(script.name)}
+              className="w-full text-left flex flex-col gap-0.5 px-3 py-1.5 hover:bg-white/[0.05] transition-colors"
+            >
+              <div className="flex items-center gap-1.5">
+                <Play size={10} className="text-accent-primary flex-shrink-0" strokeWidth={2} />
+                <span className="text-[12px] font-medium text-text-primary truncate">{script.name}</span>
+              </div>
+              <span className="text-[10.5px] text-text-tertiary font-mono truncate pl-[18px]" title={script.command}>
+                {script.command}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,7 +17,7 @@ interface UpdateCheckResult {
 }
 
 export function SettingsModal() {
-  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession, telemetryEnabled, setTelemetryEnabled, showGitPanel, setShowGitPanel } = useAppStore();
+  const { closeSettings, defaultClaudeArgs, setDefaultClaudeArgs, notifyOnFinish, setNotifyOnFinish, restoreSession, setRestoreSession, telemetryEnabled, setTelemetryEnabled, showGitPanel, setShowGitPanel, showFileTree, setShowFileTree } = useAppStore();
   const [claudeVersion, setClaudeVersion] = useState<string>('');
   const [latestVersion, setLatestVersion] = useState<string>('');
   const [updateAvailable, setUpdateAvailable] = useState<boolean | null>(null);
@@ -321,6 +321,33 @@ export function SettingsModal() {
                   <span
                     className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
                       notifyOnFinish ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Project tools (file tree + scripts runner) */}
+          <div>
+            <h3 className="text-text-primary text-[13px] font-medium mb-2">Project Tools</h3>
+            <div className="bg-bg-primary rounded-md ring-1 ring-border p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-text-primary text-[13px]">File tree &amp; package.json scripts</p>
+                  <p className="text-text-tertiary text-[11px] mt-0.5">
+                    Show the Explorer in the sidebar and enable the <span className="font-mono">package.json</span> scripts runner.
+                  </p>
+                </div>
+                <button
+                  onClick={() => setShowFileTree(!showFileTree)}
+                  className={`relative w-10 h-5 rounded-full flex-shrink-0 mt-0.5 transition-colors ${
+                    showFileTree ? 'bg-accent-primary' : 'bg-border-light'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                      showFileTree ? 'translate-x-5' : 'translate-x-0'
                     }`}
                   />
                 </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { Plus, Search, MoreVertical, Copy, Trash2, Edit3, Tag, Grid3X3, FolderOpen, Clock, FileText, Settings, GitBranch, GitFork, Brain, GripVertical, ChevronsLeft, ChevronsRight, UserCog } from 'lucide-react';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
 import { setDragData } from '../utils/dragDrop';
+import { FileTreePanel } from './FileTreePanel';
 
 const STATUS_COLORS = {
   Running: 'bg-success',
@@ -27,10 +28,50 @@ export function Sidebar() {
   const [draggingId, setDraggingId] = useState<string | null>(null);
 
   const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, updateLabel, updateNickname, unreadTerminalIds, gitInfoCache } = useTerminalStore();
-  const { sidebarCollapsed, toggleSidebarCollapse, openProfileModal, openNewTerminalModal, openWorkspaceModal, openWorktreeModal, openSessionHistory, openSnippetsModal, openClaudeConfig, openSessionTimeline, openMemoryEditor, addToGrid, removeFromGrid, gridTerminalIds, setGridMode } = useAppStore();
+  const { sidebarCollapsed, toggleSidebarCollapse, openProfileModal, openNewTerminalModal, openWorkspaceModal, openWorktreeModal, openSessionHistory, openSnippetsModal, openClaudeConfig, openSessionTimeline, openMemoryEditor, addToGrid, removeFromGrid, gridTerminalIds, setGridMode, showFileTree, explorerHeightRatio, setExplorerHeightRatio } = useAppStore();
+
+  // Splitter between terminal list and Explorer. Measures the stack's bounding
+  // rect during drag so the ratio is always computed relative to the sidebar's
+  // current height, not a cached value.
+  const splitStackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const onSplitterMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const el = splitStackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.height <= 0) return;
+      const y = e.clientY - rect.top;
+      // explorerHeightRatio is the explorer's share, so it's 1 - (terminalShare)
+      const terminalShare = y / rect.height;
+      setExplorerHeightRatio(1 - terminalShare);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [setExplorerHeightRatio]);
 
   const terminalList = useMemo(() =>
     Array.from(terminals.values())
+      // Script children belong under their parent in the main area, not the sidebar.
+      .filter(t => !t.scriptParentId)
       .map(t => t.config)
       .filter(t => {
         const searchLower = search.toLowerCase();
@@ -67,7 +108,7 @@ export function Sidebar() {
         </button>
         <div className="h-px w-6 bg-[var(--ij-divider-soft)] my-2" />
         <div className="flex-1 overflow-y-auto flex flex-col items-center gap-0.5 w-full px-1">
-          {Array.from(terminals.values()).map((instance) => {
+          {Array.from(terminals.values()).filter((instance) => !instance.scriptParentId).map((instance) => {
             const t = instance.config;
             const isActive = activeTerminalId === t.id;
             const hasUnread = unreadTerminalIds.has(t.id) && !isActive;
@@ -140,8 +181,13 @@ export function Sidebar() {
         </div>
       </div>
 
+      {/* Terminal list + Explorer stack (with draggable splitter between them when showFileTree) */}
+      <div ref={splitStackRef} className="flex-1 min-h-0 flex flex-col">
       {/* Terminal List */}
-      <div className="flex-1 overflow-y-auto p-1.5">
+      <div
+        className="min-h-0 overflow-y-auto p-1.5"
+        style={showFileTree ? { flex: `${1 - explorerHeightRatio} 1 0` } : { flex: '1 1 0' }}
+      >
         {terminalList.map((terminal) => (
           <div
             key={terminal.id}
@@ -389,6 +435,26 @@ export function Sidebar() {
             {search ? 'No terminals found' : 'No terminals yet'}
           </div>
         )}
+      </div>
+
+      {/* Explorer (file tree) — with a draggable splitter above it */}
+      {showFileTree && (
+        <>
+          <div
+            onMouseDown={onSplitterMouseDown}
+            role="separator"
+            aria-orientation="horizontal"
+            title="Drag to resize Explorer"
+            className="h-1 shrink-0 cursor-row-resize bg-transparent hover:bg-accent-primary/50 active:bg-accent-primary/70 transition-colors"
+          />
+          <div
+            className="min-h-0 flex flex-col"
+            style={{ flex: `${explorerHeightRatio} 1 0` }}
+          >
+            <FileTreePanel />
+          </div>
+        </>
+      )}
       </div>
 
       {/* Footer — tool links */}

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
-import { AnimatePresence, Reorder } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy } from 'lucide-react';
+import { Reorder } from 'framer-motion';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -9,14 +9,38 @@ import { TerminalGrid } from './TerminalGrid';
 import { SplitView } from './SplitView';
 import { TeleportActions } from './TeleportActions';
 import { SessionInsights } from './SessionInsights';
+import { FileEditorView } from './FileEditorView';
+import { ScriptsMenu } from './ScriptsMenu';
+import { ScriptChildPane } from './ScriptChildPane';
 import { getDragData, isTerminalDrag } from '../utils/dragDrop';
+
+function fileBasename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('\\'), trimmed.lastIndexOf('/'));
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
 export function TerminalTabs() {
-  const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache, reorderTerminals } = useTerminalStore();
-  const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode } = useAppStore();
-  const terminalList = useMemo(() => Array.from(terminals.values()).map(t => t.config), [terminals]);
+  const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache, reorderTerminals, scriptChildren, closeScript } = useTerminalStore();
+  const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree } = useAppStore();
+
+  // Selecting a terminal clears the file-tab focus (so terminal view shows),
+  // selecting a file clears the terminal focus-visual intent.
+  const focusTerminal = useCallback((id: string) => {
+    setActiveFilePath(null);
+    setActiveTerminal(id);
+  }, [setActiveFilePath, setActiveTerminal]);
+
+  const focusFile = useCallback((path: string) => {
+    setActiveFilePath(path);
+  }, [setActiveFilePath]);
+  // Script-child terminals are rendered below their parent — never as their own tab.
+  const terminalList = useMemo(
+    () => Array.from(terminals.values()).filter((t) => !t.scriptParentId).map((t) => t.config),
+    [terminals]
+  );
 
   const handleNewTab = () => {
     openNewTerminalModal();
@@ -191,20 +215,27 @@ export function TerminalTabs() {
                 className="flex-shrink-0"
               >
                 <button
-                  onClick={() => setActiveTerminal(terminal.id)}
+                  onClick={() => focusTerminal(terminal.id)}
+                  onAuxClick={(e) => {
+                    // Middle-click (mouse wheel) closes the tab — same as VS Code.
+                    if (e.button === 1) {
+                      e.preventDefault();
+                      closeTerminal(terminal.id);
+                    }
+                  }}
                   onDragOver={(e) => handleTabDragOver(e, terminal.id)}
                   onDragLeave={handleTabDragLeave}
                   onDrop={(e) => handleTabDrop(e, terminal.id)}
                   className={`group relative flex items-center gap-2 px-3 h-9 text-[12px] transition-colors ${
                     splitDropTargetId === terminal.id
                       ? 'bg-accent-primary/12 text-accent-primary'
-                      : activeTerminalId === terminal.id
+                      : activeTerminalId === terminal.id && !activeFilePath
                         ? 'bg-elevation-0 text-text-primary'
                         : 'hover:bg-white/[0.045] text-text-secondary'
                   }`}
                 >
                   {/* IntelliJ-style bottom underline for active tab */}
-                  {(activeTerminalId === terminal.id || splitDropTargetId === terminal.id) && (
+                  {((activeTerminalId === terminal.id && !activeFilePath) || splitDropTargetId === terminal.id) && (
                     <span className="absolute left-2 right-2 bottom-0 h-[2px] rounded-t bg-accent-primary" />
                   )}
                   {splitDropTargetId === terminal.id && (
@@ -295,6 +326,74 @@ export function TerminalTabs() {
             })}
           </Reorder.Group>
 
+          {/* File tabs — rendered inline next to terminal tabs, VS Code style */}
+          {openFiles.length > 0 && (
+            <>
+              {terminalList.length > 0 && (
+                <span className="w-px h-5 bg-[var(--ij-divider)] mx-0.5 flex-shrink-0" aria-hidden />
+              )}
+              <div className="flex items-center flex-shrink-0">
+                {openFiles.map((tab) => {
+                  const isActive = activeFilePath === tab.path;
+                  const dirty = tab.content !== tab.original;
+                  return (
+                    <button
+                      key={tab.path}
+                      onClick={() => focusFile(tab.path)}
+                      onAuxClick={(e) => {
+                        if (e.button !== 1) return;
+                        e.preventDefault();
+                        if (dirty) {
+                          const ok = window.confirm(`Discard unsaved changes in ${fileBasename(tab.path)}?`);
+                          if (!ok) return;
+                        }
+                        closeFileTab(tab.path);
+                      }}
+                      title={tab.path}
+                      className={`group relative flex items-center gap-1.5 px-3 h-9 text-[12px] transition-colors flex-shrink-0 ${
+                        isActive
+                          ? 'bg-elevation-0 text-text-primary'
+                          : 'hover:bg-white/[0.045] text-text-secondary'
+                      }`}
+                    >
+                      {isActive && (
+                        <span className="absolute left-2 right-2 bottom-0 h-[2px] rounded-t bg-accent-primary" />
+                      )}
+                      <FileIcon size={11} className="text-text-tertiary flex-shrink-0" strokeWidth={1.75} />
+                      <span className="max-w-[140px] truncate">{fileBasename(tab.path)}</span>
+                      <span
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (dirty) {
+                            const ok = window.confirm(`Discard unsaved changes in ${fileBasename(tab.path)}?`);
+                            if (!ok) return;
+                          }
+                          closeFileTab(tab.path);
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.stopPropagation();
+                            closeFileTab(tab.path);
+                          }
+                        }}
+                        className="p-0.5 rounded hover:bg-white/[0.08] text-text-tertiary hover:text-text-primary transition-colors flex items-center justify-center"
+                        title={dirty ? 'Unsaved changes' : 'Close'}
+                      >
+                        {dirty ? (
+                          <span className="w-2 h-2 rounded-full bg-accent-primary" />
+                        ) : (
+                          <X size={12} />
+                        )}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
           {canScrollRight && (
             <button
               onClick={() => scrollTabs('right')}
@@ -310,6 +409,16 @@ export function TerminalTabs() {
           >
             <Plus size={14} strokeWidth={1.75} />
           </button>
+        </div>
+
+        {/* Per-terminal actions: package.json scripts for the active terminal.
+            Hidden when the "Project Tools" setting is off. */}
+        <div className="flex items-center gap-1 ml-2 flex-shrink-0">
+          {showFileTree && activeTerminalId && !activeFilePath && (() => {
+            const inst = terminals.get(activeTerminalId);
+            if (!inst || inst.scriptParentId) return null;
+            return <ScriptsMenu terminalId={activeTerminalId} cwd={inst.config.working_directory} />;
+          })()}
         </div>
 
         {/* Grid Mode Toggle */}
@@ -334,15 +443,20 @@ export function TerminalTabs() {
         </div>
       </div>
 
-      {/* Terminal Content */}
+      {/* Content area — terminal stays mounted so scrollback survives the
+          switch; the file editor overlays on top when a file tab is active. */}
       <div className="flex-1 relative">
-        <AnimatePresence mode="wait">
-          {activeTerminalId ? (
+        {activeTerminalId && (() => {
+          const scriptChildId = scriptChildren.get(activeTerminalId);
+          const scriptInst = scriptChildId ? terminals.get(scriptChildId) : null;
+          return (
             <div
               key={activeTerminalId}
               className="absolute inset-0 flex flex-col"
+              style={{ visibility: activeFilePath ? 'hidden' : 'visible' }}
+              aria-hidden={!!activeFilePath}
             >
-              <div className="flex-1 min-h-0">
+              <div className="flex-1 min-h-0 flex flex-col">
                 <TerminalView terminalId={activeTerminalId} />
               </div>
               {(() => {
@@ -352,8 +466,24 @@ export function TerminalTabs() {
                 }
                 return null;
               })()}
+              {scriptInst && scriptChildId && (
+                <ScriptChildPane
+                  parentId={activeTerminalId}
+                  childId={scriptChildId}
+                  scriptName={scriptInst.scriptName ?? ''}
+                  status={scriptInst.config.status}
+                  onClose={() => { void closeScript(activeTerminalId); }}
+                />
+              )}
             </div>
-          ) : (
+          );
+        })()}
+        {activeFilePath && openFiles.some((t) => t.path === activeFilePath) && (
+          <div key={`file:${activeFilePath}`} className="absolute inset-0 z-10">
+            <FileEditorView path={activeFilePath} />
+          </div>
+        )}
+        {!activeTerminalId && !activeFilePath && (
             <div className="absolute inset-0 flex flex-col items-center justify-center text-text-secondary">
               <img
                 src={appIconUrl}
@@ -397,8 +527,7 @@ export function TerminalTabs() {
                 )}
               </div>
             </div>
-          )}
-        </AnimatePresence>
+        )}
       </div>
     </div>
   );

--- a/src/components/monacoSetup.ts
+++ b/src/components/monacoSetup.ts
@@ -1,0 +1,211 @@
+// One-time Monaco runtime setup. Imported for side effects by any component
+// that renders a Monaco editor. Repeat imports are harmless — the body runs
+// once thanks to the module cache.
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+import { useTerminalStore } from '../store/terminalStore';
+import { useAppStore } from '../store/appStore';
+import { toast } from '../store/toastStore';
+
+declare global {
+  interface Window { __monacoReady?: boolean }
+}
+
+const RUN_SCRIPT_COMMAND = 'claudeTerminal.runPackageScript';
+
+function dirname(p: string): string {
+  const normalized = p.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('/');
+  if (idx <= 0) return normalized;
+  // Preserve Windows drive letter + separator (e.g. "C:/")
+  if (normalized.length > 3 && /^[A-Za-z]:\/$/.test(normalized.slice(0, 3)) && idx === 2) {
+    return normalized.slice(0, 3);
+  }
+  return normalized.slice(0, idx);
+}
+
+function findScriptPositions(text: string): { name: string; line: number }[] {
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { return []; }
+  if (!parsed || typeof parsed !== 'object') return [];
+  const scripts = (parsed as { scripts?: unknown }).scripts;
+  if (!scripts || typeof scripts !== 'object') return [];
+  const names = Object.keys(scripts as Record<string, unknown>);
+
+  // Locate the opening brace of the top-level "scripts" block so we only match
+  // keys inside it (not a nested key that happens to share a name).
+  const scriptsKeyMatch = /"scripts"\s*:\s*\{/.exec(text);
+  if (!scriptsKeyMatch) return [];
+  const openBraceIdx = text.indexOf('{', scriptsKeyMatch.index);
+  if (openBraceIdx === -1) return [];
+
+  let depth = 0;
+  let endIdx = -1;
+  let inString = false;
+  let escape = false;
+  for (let i = openBraceIdx; i < text.length; i++) {
+    const c = text[i];
+    if (escape) { escape = false; continue; }
+    if (c === '\\') { escape = true; continue; }
+    if (c === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) { endIdx = i; break; } }
+  }
+  if (endIdx === -1) return [];
+
+  const block = text.slice(openBraceIdx, endIdx + 1);
+  const blockStart = openBraceIdx;
+
+  const results: { name: string; line: number }[] = [];
+  for (const name of names) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`"${escaped}"\\s*:`);
+    const match = re.exec(block);
+    if (!match) continue;
+    const absoluteIdx = blockStart + match.index;
+    // Line number = count of newlines before this index + 1 (1-based).
+    let line = 1;
+    for (let i = 0; i < absoluteIdx; i++) if (text[i] === '\n') line++;
+    results.push({ name, line });
+  }
+  return results;
+}
+
+function isPackageJson(uri: monaco.Uri): boolean {
+  const path = uri.path.replace(/\\/g, '/');
+  const last = path.split('/').pop()?.toLowerCase();
+  return last === 'package.json';
+}
+
+if (typeof window !== 'undefined' && !window.__monacoReady) {
+  (self as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
+    getWorker(_: string, label: string) {
+      if (label === 'json') return new jsonWorker();
+      if (label === 'css' || label === 'scss' || label === 'less') return new cssWorker();
+      if (label === 'html' || label === 'handlebars' || label === 'razor') return new htmlWorker();
+      if (label === 'typescript' || label === 'javascript') return new tsWorker();
+      return new editorWorker();
+    },
+  };
+  loader.config({ monaco });
+
+  // Register the "Run Script" command. CodeLens entries reference this via id.
+  monaco.editor.registerCommand(
+    RUN_SCRIPT_COMMAND,
+    (_accessor: unknown, scriptName: string, cwd: string) => {
+      const termStore = useTerminalStore.getState();
+      const parentId = termStore.activeTerminalId;
+      if (!parentId) {
+        toast.error('No active terminal', 'Open a Claude terminal first');
+        return;
+      }
+      termStore
+        .runScript(parentId, scriptName, cwd)
+        .then(() => {
+          // Switch focus away from the file editor so the user sees the script
+          // output below the parent terminal right away.
+          useAppStore.getState().setActiveFilePath(null);
+        })
+        .catch((err: unknown) => {
+          toast.error('Failed to run script', typeof err === 'string' ? err : 'Unknown error');
+        });
+    }
+  );
+
+  // Emit CodeLens above each entry in the `scripts` block of a package.json.
+  // The `onDidChange` event fires when model content changes so lenses stay
+  // in sync with edits.
+  const onDidChange = new monaco.Emitter<void>();
+  monaco.editor.onDidCreateModel((model) => {
+    if (!isPackageJson(model.uri)) return;
+    const sub = model.onDidChangeContent(() => onDidChange.fire());
+    model.onWillDispose(() => sub.dispose());
+  });
+
+  // Re-fire the lens change event when the user toggles Project Tools so the
+  // "▶ Run Script" lenses appear/disappear immediately.
+  useAppStore.subscribe((state, prev) => {
+    if (state.showFileTree !== prev.showFileTree) onDidChange.fire();
+  });
+
+  monaco.languages.registerCodeLensProvider('json', {
+    // Monaco's type says this should be IEvent<CodeLensProvider> but at runtime
+    // any event that fires triggers a lens refresh — `void` payload is fine.
+    onDidChange: onDidChange.event as unknown as monaco.IEvent<monaco.languages.CodeLensProvider>,
+    provideCodeLenses(model) {
+      // Gate on the Project Tools setting so the lens can be hidden globally.
+      if (!useAppStore.getState().showFileTree) {
+        return { lenses: [], dispose() {} };
+      }
+      if (!isPackageJson(model.uri)) {
+        return { lenses: [], dispose() {} };
+      }
+      const scripts = findScriptPositions(model.getValue());
+      const fsPath = model.uri.fsPath || model.uri.path.replace(/^\//, '');
+      const cwd = dirname(fsPath);
+      const lenses: monaco.languages.CodeLens[] = scripts.map((s) => ({
+        range: {
+          startLineNumber: s.line,
+          startColumn: 1,
+          endLineNumber: s.line,
+          endColumn: 1,
+        },
+        id: `run-script:${s.name}`,
+        command: {
+          id: RUN_SCRIPT_COMMAND,
+          title: '▶ Run Script',
+          arguments: [s.name, cwd],
+        },
+      }));
+      return { lenses, dispose() {} };
+    },
+    resolveCodeLens(_model, codeLens) { return codeLens; },
+  });
+
+  window.__monacoReady = true;
+}
+
+export function languageFromPath(path: string): string {
+  const lower = path.toLowerCase();
+  const ext = lower.split('.').pop() ?? '';
+  const byExt: Record<string, string> = {
+    ts: 'typescript', tsx: 'typescript',
+    js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
+    json: 'json', jsonc: 'json',
+    md: 'markdown', markdown: 'markdown',
+    rs: 'rust',
+    py: 'python',
+    go: 'go',
+    java: 'java',
+    c: 'c', h: 'c',
+    cpp: 'cpp', cc: 'cpp', cxx: 'cpp', hpp: 'cpp',
+    cs: 'csharp',
+    rb: 'ruby',
+    php: 'php',
+    swift: 'swift',
+    kt: 'kotlin', kts: 'kotlin',
+    html: 'html', htm: 'html',
+    css: 'css',
+    scss: 'scss', sass: 'scss',
+    less: 'less',
+    xml: 'xml',
+    yaml: 'yaml', yml: 'yaml',
+    toml: 'ini',
+    ini: 'ini',
+    sh: 'shell', bash: 'shell', zsh: 'shell',
+    ps1: 'powershell',
+    sql: 'sql',
+    dockerfile: 'dockerfile',
+    vue: 'html',
+    svelte: 'html',
+  };
+  if (byExt[ext]) return byExt[ext];
+  if (lower.endsWith('dockerfile')) return 'dockerfile';
+  return 'plaintext';
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,9 +1,27 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { invoke } from '@tauri-apps/api/core';
 
 export type GridLayout = '1x1' | '1x2' | '2x1' | '2x2' | '1x3' | '3x1' | '2x3' | '3x2' | '2x4' | '4x2';
 
 export type SplitOrientation = 'horizontal' | 'vertical';
+
+export interface FileTabState {
+  path: string;
+  content: string;
+  original: string;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  // 'edit' → plain Monaco editor. 'diff' → Monaco DiffEditor showing HEAD vs working copy.
+  mode: 'edit' | 'diff';
+  // HEAD version, used as the "original" side in diff mode. Empty string for
+  // new/untracked files. Always present so the user can toggle into diff mode.
+  headContent: string;
+  // Repo context for re-fetching HEAD (mode switches, reloads).
+  repoRoot: string | null;
+  relativePath: string | null;
+}
 
 interface AppState {
   sidebarOpen: boolean;
@@ -22,9 +40,20 @@ interface AppState {
   restoreSession: boolean;
   telemetryEnabled: boolean;
   showGitPanel: boolean;
+  showFileTree: boolean;
 
   // Changes panel
   changesRefreshTrigger: number;
+
+  // Shared repo selection — file changes panel pins a repo, file tree follows it
+  pinnedRepoPath: string | null;
+
+  // File tabs (Monaco editor tabs living next to terminal tabs)
+  openFiles: FileTabState[];
+  activeFilePath: string | null;
+
+  // Sidebar layout
+  explorerHeightRatio: number; // 0.15..0.85, portion of sidebar height reserved for Explorer
 
   // Grid state
   gridMode: boolean;
@@ -88,6 +117,18 @@ interface AppState {
   setRestoreSession: (enabled: boolean) => void;
   setTelemetryEnabled: (enabled: boolean) => void;
   setShowGitPanel: (enabled: boolean) => void;
+  setShowFileTree: (enabled: boolean) => void;
+  setPinnedRepoPath: (path: string | null) => void;
+  openFileTab: (path: string) => Promise<void>;
+  openDiffTab: (path: string, repoRoot: string, relativePath: string) => Promise<void>;
+  closeFileTab: (path: string) => void;
+  setActiveFilePath: (path: string | null) => void;
+  setFileTabContent: (path: string, content: string) => void;
+  setFileTabError: (path: string, error: string | null) => void;
+  setFileTabMode: (path: string, mode: 'edit' | 'diff') => void;
+  saveFileTab: (path: string) => Promise<void>;
+  reloadFileTab: (path: string) => Promise<void>;
+  setExplorerHeightRatio: (ratio: number) => void;
 
   // Grid actions
   toggleGridMode: () => void;
@@ -192,9 +233,20 @@ export const useAppStore = create<AppState>()(
       restoreSession: true,
       telemetryEnabled: true,
       showGitPanel: true,
+      showFileTree: true,
 
       // Changes panel
       changesRefreshTrigger: 0,
+
+      // Shared repo selection
+      pinnedRepoPath: null,
+
+      // File tabs
+      openFiles: [],
+      activeFilePath: null,
+
+      // Sidebar explorer ratio (default: explorer takes 45% of sidebar height)
+      explorerHeightRatio: 0.45,
 
       // Grid state
       gridMode: false,
@@ -258,6 +310,185 @@ export const useAppStore = create<AppState>()(
       setRestoreSession: (enabled) => set({ restoreSession: enabled }),
       setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
       setShowGitPanel: (enabled) => set({ showGitPanel: enabled }),
+      setShowFileTree: (enabled) => set({ showFileTree: enabled }),
+      setPinnedRepoPath: (path) => set({ pinnedRepoPath: path }),
+      setExplorerHeightRatio: (ratio) => set({
+        explorerHeightRatio: Math.max(0.15, Math.min(0.85, ratio)),
+      }),
+
+      setActiveFilePath: (path) => set({ activeFilePath: path }),
+
+      setFileTabContent: (path, content) => set((state) => ({
+        openFiles: state.openFiles.map((t) =>
+          t.path === path ? { ...t, content } : t
+        ),
+      })),
+
+      setFileTabError: (path, error) => set((state) => ({
+        openFiles: state.openFiles.map((t) =>
+          t.path === path ? { ...t, error, loading: false } : t
+        ),
+      })),
+
+      openFileTab: async (path) => {
+        const existing = (useAppStore.getState().openFiles).find((t) => t.path === path);
+        if (existing) {
+          set({ activeFilePath: path });
+          return;
+        }
+        set((state) => ({
+          openFiles: [
+            ...state.openFiles,
+            { path, content: '', original: '', loading: true, saving: false, error: null, mode: 'edit', headContent: '', repoRoot: null, relativePath: null },
+          ],
+          activeFilePath: path,
+        }));
+        try {
+          const text = await invoke<string>('read_text_file', { path });
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, content: text, original: text, loading: false, error: null } : t
+            ),
+          }));
+        } catch (err) {
+          const message = typeof err === 'string' ? err : 'Failed to read file';
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, loading: false, error: message } : t
+            ),
+          }));
+        }
+      },
+
+      openDiffTab: async (path, repoRoot, relativePath) => {
+        // If already open, just switch into diff mode (fetch HEAD if not loaded).
+        const existing = useAppStore.getState().openFiles.find((t) => t.path === path);
+        if (existing) {
+          set({ activeFilePath: path });
+          // Ensure repo context + mode are set so the toggle works.
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path
+                ? { ...t, mode: 'diff', repoRoot, relativePath }
+                : t
+            ),
+          }));
+          // If HEAD content hasn't been fetched yet, grab it.
+          if (!existing.repoRoot) {
+            try {
+              const head = await invoke<string>('get_git_head_content', { path: repoRoot, file: relativePath });
+              set((state) => ({
+                openFiles: state.openFiles.map((t) =>
+                  t.path === path ? { ...t, headContent: head } : t
+                ),
+              }));
+            } catch {
+              // Non-fatal — leave headContent empty; diff will render against "".
+            }
+          }
+          return;
+        }
+        // Fresh open: fetch both sides in parallel so the diff appears in one render.
+        set((state) => ({
+          openFiles: [
+            ...state.openFiles,
+            { path, content: '', original: '', loading: true, saving: false, error: null, mode: 'diff', headContent: '', repoRoot, relativePath },
+          ],
+          activeFilePath: path,
+        }));
+        try {
+          const [text, head] = await Promise.all([
+            invoke<string>('read_text_file', { path }),
+            invoke<string>('get_git_head_content', { path: repoRoot, file: relativePath }).catch(() => ''),
+          ]);
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, content: text, original: text, headContent: head, loading: false, error: null } : t
+            ),
+          }));
+        } catch (err) {
+          const message = typeof err === 'string' ? err : 'Failed to read file';
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, loading: false, error: message } : t
+            ),
+          }));
+        }
+      },
+
+      setFileTabMode: (path, mode) => set((state) => ({
+        openFiles: state.openFiles.map((t) =>
+          t.path === path ? { ...t, mode } : t
+        ),
+      })),
+
+      closeFileTab: (path) => set((state) => {
+        const idx = state.openFiles.findIndex((t) => t.path === path);
+        if (idx === -1) return state;
+        const nextFiles = state.openFiles.filter((t) => t.path !== path);
+        let nextActive = state.activeFilePath;
+        if (state.activeFilePath === path) {
+          // Move focus to the next tab in order, or the previous if we closed the last.
+          if (nextFiles.length === 0) {
+            nextActive = null;
+          } else {
+            const fallbackIdx = Math.min(idx, nextFiles.length - 1);
+            nextActive = nextFiles[fallbackIdx].path;
+          }
+        }
+        return { openFiles: nextFiles, activeFilePath: nextActive };
+      }),
+
+      saveFileTab: async (path) => {
+        const tab = useAppStore.getState().openFiles.find((t) => t.path === path);
+        if (!tab || tab.saving) return;
+        set((state) => ({
+          openFiles: state.openFiles.map((t) =>
+            t.path === path ? { ...t, saving: true } : t
+          ),
+        }));
+        try {
+          await invoke('write_text_file', { path, content: tab.content });
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, saving: false, original: tab.content, error: null } : t
+            ),
+            // Refresh the git changes panel so new saves show up.
+            changesRefreshTrigger: state.changesRefreshTrigger + 1,
+          }));
+        } catch (err) {
+          const message = typeof err === 'string' ? err : 'Failed to save file';
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, saving: false, error: message } : t
+            ),
+          }));
+          throw err;
+        }
+      },
+
+      reloadFileTab: async (path) => {
+        set((state) => ({
+          openFiles: state.openFiles.map((t) =>
+            t.path === path ? { ...t, loading: true, error: null } : t
+          ),
+        }));
+        try {
+          const text = await invoke<string>('read_text_file', { path });
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, content: text, original: text, loading: false, error: null } : t
+            ),
+          }));
+        } catch (err) {
+          const message = typeof err === 'string' ? err : 'Failed to read file';
+          set((state) => ({
+            openFiles: state.openFiles.map((t) =>
+              t.path === path ? { ...t, loading: false, error: message } : t
+            ),
+          }));
+        }
+      },
 
       // Grid actions
       toggleGridMode: () => set((state) => ({ gridMode: !state.gridMode })),
@@ -365,6 +596,8 @@ export const useAppStore = create<AppState>()(
         restoreSession: state.restoreSession,
         telemetryEnabled: state.telemetryEnabled,
         showGitPanel: state.showGitPanel,
+        showFileTree: state.showFileTree,
+        explorerHeightRatio: state.explorerHeightRatio,
         orchestrationOpen: state.orchestrationOpen,
         lastSeenVersion: state.lastSeenVersion,
       }),

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -30,6 +30,10 @@ interface TerminalInstance {
   isWorktree: boolean;
   loopInfo?: LoopInfo | null;
   sessionSummary?: string | null;
+  // Script-child metadata: when set, this terminal is an npm-script runner
+  // spawned below a parent terminal. Excluded from the tab list and sidebar.
+  scriptName?: string;
+  scriptParentId?: string;
 }
 
 interface TerminalState {
@@ -37,6 +41,8 @@ interface TerminalState {
   activeTerminalId: string | null;
   unreadTerminalIds: Set<string>;
   gitInfoCache: Map<string, WorktreeDetectResult>;
+  // Parent terminal ID → script child terminal ID (one child per parent).
+  scriptChildren: Map<string, string>;
 
   createTerminal: (
     label: string,
@@ -63,6 +69,14 @@ interface TerminalState {
   hasUnread: (id: string) => boolean;
   fetchGitInfo: (terminalId: string) => Promise<void>;
   reorderTerminals: (orderedIds: string[]) => void;
+
+  // Run an npm script in a child terminal tied to the given parent. Returns
+  // the new child's id. If the parent already has a script running, that
+  // child is closed first so the new one replaces it. `cwdOverride` lets the
+  // caller run the script in a directory other than the parent's cwd — used
+  // by the package.json CodeLens, where the script's cwd is the file's folder.
+  runScript: (parentId: string, scriptName: string, cwdOverride?: string) => Promise<string>;
+  closeScript: (parentId: string) => Promise<void>;
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -70,6 +84,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   activeTerminalId: null,
   unreadTerminalIds: new Set(),
   gitInfoCache: new Map(),
+  scriptChildren: new Map(),
 
   createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput) => {
     try {
@@ -116,6 +131,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   closeTerminal: async (id) => {
+    // If this terminal owns a script child, kill it first so it doesn't linger
+    // as an orphan (visible only via devtools).
+    const childId = get().scriptChildren.get(id);
+    if (childId) {
+      try { await invoke('close_terminal', { id: childId }); } catch { /* already gone */ }
+    }
+
     await invoke('close_terminal', { id });
 
     set((state) => {
@@ -126,17 +148,32 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       }
       newTerminals.delete(id);
 
+      // Also drop any script child from the terminal map.
+      if (childId) {
+        const childInst = newTerminals.get(childId);
+        if (childInst?.xterm) childInst.xterm.dispose();
+        newTerminals.delete(childId);
+      }
+
       const newUnread = new Set(state.unreadTerminalIds);
       newUnread.delete(id);
 
       const newGitCache = new Map(state.gitInfoCache);
       newGitCache.delete(id);
 
-      const remainingIds = Array.from(newTerminals.keys());
+      const newChildren = new Map(state.scriptChildren);
+      newChildren.delete(id);
+
+      // Only pick a fallback from non-child terminals; script children must
+      // never become the "active tab".
+      const remainingIds = Array.from(newTerminals.values())
+        .filter((t) => !t.scriptParentId)
+        .map((t) => t.config.id);
       return {
         terminals: newTerminals,
         unreadTerminalIds: newUnread,
         gitInfoCache: newGitCache,
+        scriptChildren: newChildren,
         activeTerminalId: state.activeTerminalId === id
           ? (remainingIds[0] || null)
           : state.activeTerminalId,
@@ -307,4 +344,57 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }
     return { terminals: next };
   }),
+
+  runScript: async (parentId, scriptName, cwdOverride) => {
+    const parent = get().terminals.get(parentId);
+    if (!parent) throw new Error('Parent terminal not found');
+
+    // Replace any existing script child for this parent so the UI always
+    // shows the most recently-requested script.
+    const existingChildId = get().scriptChildren.get(parentId);
+    if (existingChildId) {
+      await get().closeScript(parentId).catch(() => {});
+    }
+
+    const cwd = cwdOverride ?? parent.config.working_directory;
+    const config = await invoke<TerminalConfig>('create_script_terminal', {
+      cwd,
+      scriptName,
+    });
+
+    set((state) => {
+      const nextTerminals = new Map(state.terminals);
+      nextTerminals.set(config.id, {
+        config,
+        xterm: null,
+        isWorktree: false,
+        scriptName,
+        scriptParentId: parentId,
+      });
+      const nextChildren = new Map(state.scriptChildren);
+      nextChildren.set(parentId, config.id);
+      return { terminals: nextTerminals, scriptChildren: nextChildren };
+    });
+
+    return config.id;
+  },
+
+  closeScript: async (parentId) => {
+    const childId = get().scriptChildren.get(parentId);
+    if (!childId) return;
+    try {
+      await invoke('close_terminal', { id: childId });
+    } catch {
+      // Already closed — fall through to store cleanup.
+    }
+    set((state) => {
+      const nextTerminals = new Map(state.terminals);
+      const inst = nextTerminals.get(childId);
+      if (inst?.xterm) inst.xterm.dispose();
+      nextTerminals.delete(childId);
+      const nextChildren = new Map(state.scriptChildren);
+      nextChildren.delete(parentId);
+      return { terminals: nextTerminals, scriptChildren: nextChildren };
+    });
+  },
 }));


### PR DESCRIPTION
## Summary

Adds a VS Code–style file tree, inline Monaco editor, diff view for git changes, and a package.json scripts runner with split-below-terminal output.

## What's new

### Explorer & editor
- **File tree** in the left sidebar, rooted at the active terminal's cwd (or the pinned repo from File Changes). Lazy-loads children, folders-first sort. A **draggable horizontal splitter** sits between the terminal list and the Explorer; the ratio persists.
- **Monaco editor tabs** live next to terminal tabs. Click a file in the tree or the pencil in File Changes → opens as a tab. Per-path Monaco models preserve cursor / selection / undo history when switching. Terminals stay mounted behind the editor (`visibility: hidden`) so scrollback survives.
- **Middle-click** closes any tab (terminal or file); dirty files prompt first.

### Git diff + discard
- Pencil icon in **File Changes** opens a **Monaco DiffEditor** tab: HEAD version (read-only) on the left, editable working copy on the right. Toolbar toggle flips between Diff and Edit.
- HEAD content fetched via new `get_git_head_content` backend command (`git show HEAD:file`). Returns empty for new/untracked files.
- **Trash icon** on each changed-file row discards changes (`git checkout HEAD -- file` for tracked, disk-delete for untracked). Auto-closes the editor tab if the file was open.

### package.json scripts runner
- **Scripts dropdown** in the tab bar — appears when the active terminal's cwd contains a `package.json` with scripts.
- **Inline `▶ Run Script` CodeLens** above each entry inside `"scripts"` when viewing a `package.json` in the editor. Re-fires on content edits so new scripts get lenses immediately.
- Selecting a script spawns a **child PTY** running `npm run <name>` that displays **vertically below the parent in the same tab**, with a drag-to-resize handle, status dot, and X to stop. Child is filtered from the tab bar / sidebar so it's not confused with a top-level terminal. Closing the parent closes the child.

### Settings
- Single **Project Tools** toggle governs Explorer visibility plus scripts-runner UI (dropdown + CodeLens). Already-running script children are unaffected by toggling.

## Backend (Rust)

New Tauri commands, all gated through the existing `validate_path_is_trusted` check:

- `list_directory(path)` — lazy children listing (folders first)
- `read_text_file(path)` — 5 MB cap, binary/UTF-8 sniff
- `write_text_file(path, content)` — in-place save
- `get_git_head_content(path, file)` — `git show HEAD:<file>`
- `git_discard_file(path, file, untracked)` — tracked → `git checkout HEAD --`; untracked → disk delete with canonicalize-and-starts-with-repo guard
- `list_package_scripts(cwd)` — parses `package.json` scripts
- `create_script_terminal(cwd, script_name)` — spawns `npm run <script>` PTY via a new `TerminalManager::create_script_terminal` helper; emits the same `terminal-output` / `terminal-finished` events as a regular terminal so frontend plumbing is reused.

Error messages from `validate_path_is_trusted` now include the offending path for easier debugging.

## Dependencies

- `monaco-editor@0.52.0`
- `@monaco-editor/react@4.6.0`

Workers bundled via Vite `?worker` imports — works offline, no CDN.

## Test plan

- [ ] Open a terminal in a Node project; toggle **Settings → Project Tools**. Verify Explorer and Scripts menu both appear / disappear.
- [ ] In the Explorer, expand folders and open a file. Edit, Ctrl+S to save, verify the toast.
- [ ] Drag the horizontal splitter in the sidebar; verify the Explorer height persists across reload.
- [ ] Click the pencil on a changed file in File Changes → verify the DiffEditor shows HEAD vs current; edit on the right, save.
- [ ] Toggle Diff/Edit in the editor toolbar.
- [ ] Click the trash icon on a changed file → verify the file reverts (tracked) or is deleted (untracked).
- [ ] Middle-click a file tab (with no dirty edits) → closes immediately.
- [ ] Middle-click a terminal tab → closes the terminal.
- [ ] Open `package.json` in the editor → click `▶ Run Script` on a script. Verify a child pane appears below the active terminal, running that script.
- [ ] Open the **Scripts** menu in the tab bar → run a script; verify it replaces any already-running child.
- [ ] Close the parent terminal → verify the script child is also killed.
- [ ] Switch between a file tab and a terminal tab → verify scrollback is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)