### PR TITLE
Global search, per-repo shells, and File Changes UX

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2712,6 +2712,52 @@ pub async fn create_script_terminal(
     Ok(config)
 }
 
+/// Spawn an interactive shell terminal at `cwd`. No claude. The terminal
+/// behaves like create_terminal otherwise — emits `terminal-output` /
+/// `terminal-finished` events and accepts input via `write_to_terminal`.
+#[command]
+pub async fn create_shell_terminal(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    label: String,
+    cwd: String,
+) -> Result<crate::terminal::TerminalConfig, String> {
+    validate_path_is_trusted(&state, &cwd).await?;
+
+    let (tx, mut rx) = mpsc::channel::<(String, Vec<u8>)>(1000);
+
+    let config = {
+        let mut terminals = state.terminals.lock().await;
+        terminals.create_shell_terminal(label, cwd, tx)?
+    };
+
+    let terminal_id = config.id.clone();
+    let terminals_arc = state.terminals.clone();
+    let app_clone = app.clone();
+    tokio::spawn(async move {
+        while let Some((id, data)) = rx.recv().await {
+            if let Err(e) = app_clone.emit("terminal-output", serde_json::json!({
+                "id": id,
+                "data": data,
+            })) {
+                eprintln!("Failed to emit terminal-output: {}", e);
+                break;
+            }
+        }
+        if let Ok(mut manager) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            terminals_arc.lock(),
+        ).await {
+            let _ = manager.update_status(&terminal_id, crate::terminal::TerminalStatus::Stopped);
+        }
+        if let Err(e) = app_clone.emit("terminal-finished", serde_json::json!({ "id": terminal_id })) {
+            eprintln!("Failed to emit terminal-finished: {}", e);
+        }
+    });
+
+    Ok(config)
+}
+
 /// Return the HEAD version of a file as a string. Used by the diff editor to
 /// show original vs current working copy. Returns an empty string if the file
 /// has no HEAD version (e.g., newly-added or untracked).
@@ -2892,4 +2938,264 @@ pub async fn write_text_file(
     }
     std::fs::write(&path, content.as_bytes()).map_err(|e| format!("Failed to write file: {}", e))?;
     Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SearchMatch {
+    pub line: u32,
+    pub column: u32,
+    pub line_text: String,
+    pub match_length: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FileSearchResult {
+    pub file_path: String,
+    pub relative_path: String,
+    pub matches: Vec<SearchMatch>,
+    pub name_match: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SearchSummary {
+    pub results: Vec<FileSearchResult>,
+    pub total_matches: u32,
+    pub total_files: u32,
+    pub truncated: bool,
+}
+
+const SEARCH_IGNORE_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".cache",
+    ".parcel-cache",
+    ".vscode",
+    ".idea",
+    "__pycache__",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+    "vendor",
+    "coverage",
+    ".vite",
+];
+
+const SEARCH_MAX_FILE_BYTES: u64 = 2 * 1024 * 1024; // 2 MB per file
+const SEARCH_MAX_FILES: u32 = 5000;
+const SEARCH_MAX_TOTAL_MATCHES: u32 = 5000;
+const SEARCH_MAX_PER_FILE: usize = 200;
+
+fn search_should_skip_dir(name: &str) -> bool {
+    if SEARCH_IGNORE_DIRS.iter().any(|d| *d == name) {
+        return true;
+    }
+    name.starts_with('.') && name.len() > 1
+}
+
+fn search_walk(
+    root: &std::path::Path,
+    dir: &std::path::Path,
+    query_lower: &str,
+    query_raw: &str,
+    case_sensitive: bool,
+    include_files: bool,
+    results: &mut Vec<FileSearchResult>,
+    total_matches: &mut u32,
+    files_seen: &mut u32,
+) -> bool {
+    // Returns false to signal "stop walking" when a hard cap is hit.
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return true,
+    };
+    for entry in read_dir.flatten() {
+        if *total_matches >= SEARCH_MAX_TOTAL_MATCHES || *files_seen >= SEARCH_MAX_FILES {
+            return false;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let path = entry.path();
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            if search_should_skip_dir(&name) {
+                continue;
+            }
+            if !search_walk(
+                root,
+                &path,
+                query_lower,
+                query_raw,
+                case_sensitive,
+                include_files,
+                results,
+                total_matches,
+                files_seen,
+            ) {
+                return false;
+            }
+            continue;
+        }
+        if !meta.is_file() {
+            continue;
+        }
+        *files_seen += 1;
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        // Filename match (always cheap, ignores file size).
+        let name_lower = name.to_lowercase();
+        let name_matches = if case_sensitive {
+            name.contains(query_raw)
+        } else {
+            name_lower.contains(query_lower)
+        };
+
+        // Skip content scan for huge files, but still let filename matches through.
+        let scan_content = include_files && meta.len() <= SEARCH_MAX_FILE_BYTES;
+
+        let mut matches: Vec<SearchMatch> = Vec::new();
+        if scan_content {
+            if let Ok(bytes) = std::fs::read(&path) {
+                let sniff_len = bytes.len().min(8192);
+                if !bytes[..sniff_len].contains(&0u8) {
+                    if let Ok(text) = std::str::from_utf8(&bytes) {
+                        let mut line_no: u32 = 0;
+                        for line in text.lines() {
+                            line_no += 1;
+                            if matches.len() >= SEARCH_MAX_PER_FILE {
+                                break;
+                            }
+                            let haystack_lower;
+                            let haystack: &str = if case_sensitive {
+                                line
+                            } else {
+                                haystack_lower = line.to_lowercase();
+                                &haystack_lower
+                            };
+                            let needle: &str = if case_sensitive { query_raw } else { query_lower };
+                            let mut start = 0;
+                            while let Some(idx) = haystack[start..].find(needle) {
+                                let abs_idx = start + idx;
+                                // Trim very long lines for transport.
+                                let truncated_line = if line.len() > 400 {
+                                    let cut = line.char_indices().nth(400).map(|(i, _)| i).unwrap_or(line.len());
+                                    format!("{}…", &line[..cut])
+                                } else {
+                                    line.to_string()
+                                };
+                                matches.push(SearchMatch {
+                                    line: line_no,
+                                    column: (abs_idx as u32) + 1,
+                                    line_text: truncated_line,
+                                    match_length: needle.chars().count() as u32,
+                                });
+                                *total_matches += 1;
+                                if *total_matches >= SEARCH_MAX_TOTAL_MATCHES
+                                    || matches.len() >= SEARCH_MAX_PER_FILE
+                                {
+                                    break;
+                                }
+                                start = abs_idx + needle.len().max(1);
+                                if start >= haystack.len() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !matches.is_empty() || name_matches {
+            results.push(FileSearchResult {
+                file_path: path.to_string_lossy().replace('\\', "/"),
+                relative_path: relative,
+                matches,
+                name_match: name_matches,
+            });
+        }
+    }
+    true
+}
+
+/// Search for `query` across all files under `path`. Walks the tree, skipping
+/// common ignore directories (.git, node_modules, target, …) and files that
+/// look binary. Returns matches grouped by file with line/column metadata.
+#[command]
+pub async fn search_in_files(
+    state: State<'_, AppState>,
+    path: String,
+    query: String,
+    case_sensitive: bool,
+    include_file_contents: bool,
+) -> Result<SearchSummary, String> {
+    validate_path_is_trusted(&state, &path).await?;
+
+    if query.trim().is_empty() {
+        return Ok(SearchSummary {
+            results: Vec::new(),
+            total_matches: 0,
+            total_files: 0,
+            truncated: false,
+        });
+    }
+
+    let root = std::path::PathBuf::from(&path)
+        .canonicalize()
+        .map_err(|e| format!("Invalid root: {}", e))?;
+    if !root.is_dir() {
+        return Err("Search root is not a directory".to_string());
+    }
+
+    let query_lower = query.to_lowercase();
+    let mut results: Vec<FileSearchResult> = Vec::new();
+    let mut total_matches: u32 = 0;
+    let mut files_seen: u32 = 0;
+
+    let completed = search_walk(
+        &root,
+        &root,
+        &query_lower,
+        &query,
+        case_sensitive,
+        include_file_contents,
+        &mut results,
+        &mut total_matches,
+        &mut files_seen,
+    );
+
+    // Show files with content matches first, then filename-only matches.
+    results.sort_by(|a, b| {
+        let a_only_name = a.matches.is_empty();
+        let b_only_name = b.matches.is_empty();
+        match (a_only_name, b_only_name) {
+            (false, true) => std::cmp::Ordering::Less,
+            (true, false) => std::cmp::Ordering::Greater,
+            _ => a.relative_path.to_lowercase().cmp(&b.relative_path.to_lowercase()),
+        }
+    });
+
+    Ok(SearchSummary {
+        total_files: results.len() as u32,
+        total_matches,
+        truncated: !completed,
+        results,
+    })
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -119,6 +119,8 @@ fn main() {
             commands::get_git_head_content,
             commands::list_package_scripts,
             commands::create_script_terminal,
+            commands::create_shell_terminal,
+            commands::search_in_files,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -368,6 +368,114 @@ impl TerminalManager {
         Ok(config)
     }
 
+    /// Spawn an interactive shell at `working_directory`. No `claude`, no
+    /// `npm run` — just a plain shell the user can drive (run scripts, hit
+    /// Ctrl+C to stop them, etc.). Reuses the same PTY/reader plumbing so
+    /// `write_to_terminal` and `terminal-output` events Just Work.
+    pub fn create_shell_terminal(
+        &mut self,
+        label: String,
+        working_directory: String,
+        tx: mpsc::Sender<(String, Vec<u8>)>,
+    ) -> Result<TerminalConfig, String> {
+        let pty_system = native_pty_system();
+        let pty_pair = pty_system
+            .openpty(PtySize {
+                rows: 30,
+                cols: 120,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| format!("Failed to open pty: {}", e))?;
+
+        #[cfg(target_os = "windows")]
+        let cmd = {
+            // ComSpec is whatever the user has set as their shell — typically
+            // cmd.exe but could be PowerShell. Without /C the shell stays
+            // interactive.
+            let exe = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
+            CommandBuilder::new(exe)
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let cmd = {
+            const VALID_SHELLS: &[&str] = &[
+                "/bin/bash", "/bin/sh", "/bin/zsh", "/bin/fish", "/bin/dash",
+                "/usr/bin/bash", "/usr/bin/sh", "/usr/bin/zsh", "/usr/bin/fish", "/usr/bin/dash",
+                "/usr/local/bin/bash", "/usr/local/bin/zsh", "/usr/local/bin/fish",
+                "/opt/homebrew/bin/bash", "/opt/homebrew/bin/zsh", "/opt/homebrew/bin/fish",
+            ];
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+            let shell = if VALID_SHELLS.contains(&shell.as_str()) { shell } else { "/bin/bash".to_string() };
+            let mut c = CommandBuilder::new(&shell);
+            // Login + interactive so the user gets their normal prompt.
+            c.arg("-li");
+            c
+        };
+
+        let mut cmd = cmd;
+        if !working_directory.is_empty() {
+            cmd.cwd(&working_directory);
+        }
+
+        let _child = pty_pair.slave.spawn_command(cmd)
+            .map_err(|e| format!("Failed to spawn shell: {}", e))?;
+
+        let id = Uuid::new_v4().to_string();
+        let config = TerminalConfig {
+            id: id.clone(),
+            label,
+            nickname: None,
+            profile_id: None,
+            working_directory,
+            // Tag this terminal so persistence/restore can recognise it as a
+            // plain shell — same trick create_script_terminal uses.
+            claude_args: vec!["__shell__".into()],
+            env_vars: HashMap::new(),
+            created_at: Utc::now(),
+            status: TerminalStatus::Running,
+            color_tag: None,
+        };
+
+        let mut reader = pty_pair.master.try_clone_reader()
+            .map_err(|e| format!("Failed to clone reader: {}", e))?;
+        let writer = pty_pair.master.take_writer()
+            .map_err(|e| format!("Failed to take writer: {}", e))?;
+
+        let terminal_id = id.clone();
+        let reader_handle = std::thread::spawn(move || {
+            let mut buf = [0u8; 32 * 1024];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let data = buf[..n].to_vec();
+                        if tx.blocking_send((terminal_id.clone(), data)).is_err() { break; }
+                    }
+                    Err(e) => {
+                        let _ = tx.blocking_send((
+                            terminal_id.clone(),
+                            format!("\r\n[Error: {}]\r\n", e).into_bytes(),
+                        ));
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.terminals.insert(
+            id.clone(),
+            Terminal {
+                config: config.clone(),
+                pty_pair,
+                writer,
+                reader_handle: Some(reader_handle),
+            },
+        );
+
+        Ok(config)
+    }
+
     pub fn write(&mut self, id: &str, data: &[u8]) -> Result<(), String> {
         if let Some(terminal) = self.terminals.get_mut(id) {
             terminal

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AutoUpdater } from './components/AutoUpdater';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ClaudeConfigModal } from './components/ClaudeConfigModal';
 import { OrchestrationPanel } from './components/OrchestrationPanel';
+import { GlobalSearchModal } from './components/GlobalSearchModal';
 import { SessionTimeline } from './components/SessionTimeline';
 import { MemoryEditor } from './components/MemoryEditor';
 import { StatusBar } from './components/StatusBar';
@@ -84,7 +85,7 @@ interface SavedTerminalConfig {
 }
 
 function App() {
-  const { sidebarOpen, sidebarCollapsed, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, worktreeModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, whatsNewOpen, claudeConfigOpen, sessionTimelineOpen, memoryEditorOpen, notifyOnFinish, restoreSession, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
+  const { sidebarOpen, sidebarCollapsed, hintsOpen, changesOpen, orchestrationOpen, settingsOpen, profileModalOpen, newTerminalModalOpen, workspaceModalOpen, worktreeModalOpen, sessionHistoryOpen, snippetsModalOpen, commandPaletteOpen, globalSearchOpen, whatsNewOpen, claudeConfigOpen, sessionTimelineOpen, memoryEditorOpen, notifyOnFinish, restoreSession, triggerChangesRefresh, showRestoreBanner, pendingRestoreConfigs, setShowRestoreBanner, setPendingRestoreConfigs, lastSeenVersion, setLastSeenVersion, openWhatsNew } = useAppStore();
   const { handleTerminalOutput, updateTerminalStatus, setLoopMode, setSessionSummary, createTerminal } = useTerminalStore();
   const [showSetup, setShowSetup] = useState<boolean | null>(null);
   const { notify } = useNotification();
@@ -409,6 +410,9 @@ function App() {
             {memoryEditorOpen && <MemoryEditor />}
           </AnimatePresence>
           {commandPaletteOpen && <CommandPalette />}
+          <AnimatePresence>
+            {globalSearchOpen && <GlobalSearchModal />}
+          </AnimatePresence>
         </>
       )}
 

--- a/src/components/BottomTerminalPane.tsx
+++ b/src/components/BottomTerminalPane.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X, GripHorizontal, Plus, TerminalSquare, ChevronDown } from 'lucide-react';
+import { useTerminalStore } from '../store/terminalStore';
+import { TerminalView } from './TerminalView';
+
+const STATUS_DOT: Record<string, string> = {
+  Running: 'bg-success',
+  Idle: 'bg-warning',
+  Error: 'bg-error',
+  Stopped: 'bg-text-tertiary',
+};
+
+/**
+ * Bottom terminal pane — a tabbed area below the main terminal view that
+ * hosts plain interactive shells (no claude). One tab per shell, drag-to-
+ * resize handle on top, +/x to add and remove tabs. Mirrors the placement
+ * of ScriptChildPane but is global (not scoped to a parent terminal) and
+ * stays mounted across active-terminal switches.
+ */
+export function BottomTerminalPane() {
+  const bottomTerminalIds = useTerminalStore((s) => s.bottomTerminalIds);
+  const activeBottomTerminalId = useTerminalStore((s) => s.activeBottomTerminalId);
+  const terminals = useTerminalStore((s) => s.terminals);
+  const setActiveBottomTerminal = useTerminalStore((s) => s.setActiveBottomTerminal);
+  const closeShellTerminal = useTerminalStore((s) => s.closeShellTerminal);
+  const openShellTerminal = useTerminalStore((s) => s.openShellTerminal);
+  const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
+
+  const [height, setHeight] = useState(280);
+  const [collapsed, setCollapsed] = useState(false);
+  const draggingRef = useRef(false);
+  const startYRef = useRef(0);
+  const startHeightRef = useRef(0);
+
+  const onDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      draggingRef.current = true;
+      startYRef.current = e.clientY;
+      startHeightRef.current = height;
+      document.body.style.cursor = 'row-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [height],
+  );
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const delta = startYRef.current - e.clientY;
+      const next = Math.min(800, Math.max(80, startHeightRef.current + delta));
+      setHeight(next);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, []);
+
+  const handleAddShell = useCallback(async () => {
+    // The "+" button opens another shell at the same cwd as the currently-
+    // active bottom shell (or the main active terminal as a fallback).
+    let cwd: string | null = null;
+    let label = 'Shell';
+    if (activeBottomTerminalId) {
+      const inst = terminals.get(activeBottomTerminalId);
+      if (inst) {
+        cwd = inst.config.working_directory;
+        label = inst.config.label;
+      }
+    }
+    if (!cwd && activeTerminalId) {
+      const inst = terminals.get(activeTerminalId);
+      if (inst) {
+        cwd = inst.config.working_directory;
+        label = inst.config.label;
+      }
+    }
+    if (!cwd) return;
+    try {
+      await openShellTerminal(label, cwd);
+    } catch {
+      /* errors surface via toast in callers; nothing more to do here */
+    }
+  }, [activeBottomTerminalId, activeTerminalId, terminals, openShellTerminal]);
+
+  if (bottomTerminalIds.length === 0) return null;
+
+  return (
+    <>
+      {/* Drag handle — same styling as the ScriptChildPane handle */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        onMouseDown={onDragStart}
+        className="group h-1.5 shrink-0 cursor-row-resize flex items-center justify-center bg-transparent hover:bg-accent-primary/50 active:bg-accent-primary/70 transition-colors"
+        title="Drag to resize bottom terminals"
+      >
+        <GripHorizontal
+          size={10}
+          className="text-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+          strokeWidth={1.5}
+        />
+      </div>
+
+      <div
+        className="shrink-0 flex flex-col border-t border-[var(--ij-divider)] bg-bg-primary"
+        style={{ height: collapsed ? 28 : height }}
+      >
+        {/* Tab strip */}
+        <div className="h-7 flex items-center border-b border-[var(--ij-divider-soft)] bg-elevation-0 flex-shrink-0">
+          <div className="flex-1 min-w-0 flex items-center overflow-x-auto">
+            {bottomTerminalIds.map((id) => {
+              const inst = terminals.get(id);
+              if (!inst) return null;
+              const isActive = id === activeBottomTerminalId;
+              const dotClass = STATUS_DOT[inst.config.status] ?? 'bg-text-tertiary';
+              return (
+                <div
+                  key={id}
+                  onClick={() => {
+                    setActiveBottomTerminal(id);
+                    if (collapsed) setCollapsed(false);
+                  }}
+                  className={`group/tab flex items-center gap-1.5 h-7 px-2.5 cursor-pointer border-r border-[var(--ij-divider-soft)] text-[11.5px] flex-shrink-0 transition-colors ${
+                    isActive
+                      ? 'bg-bg-primary text-text-primary'
+                      : 'text-text-secondary hover:bg-white/[0.04] hover:text-text-primary'
+                  }`}
+                  title={inst.config.working_directory}
+                >
+                  <TerminalSquare size={11} strokeWidth={1.75} className="text-accent-primary flex-shrink-0" />
+                  <span className="truncate max-w-[180px]">{inst.config.label}</span>
+                  <span
+                    className={`w-[6px] h-[6px] rounded-full flex-shrink-0 ${dotClass}`}
+                    title={inst.config.status}
+                  />
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void closeShellTerminal(id);
+                    }}
+                    className="ml-0.5 p-0.5 rounded hover:bg-white/[0.1] text-text-tertiary hover:text-text-primary opacity-0 group-hover/tab:opacity-100 transition-opacity"
+                    title="Close terminal"
+                  >
+                    <X size={11} strokeWidth={1.75} />
+                  </button>
+                </div>
+              );
+            })}
+            <button
+              onClick={handleAddShell}
+              className="h-7 px-2 flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-white/[0.04] transition-colors flex-shrink-0"
+              title="New shell terminal at the active terminal's working directory"
+            >
+              <Plus size={12} strokeWidth={2} />
+            </button>
+          </div>
+          <button
+            onClick={() => setCollapsed((v) => !v)}
+            className="h-7 px-2 flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-white/[0.04] transition-colors flex-shrink-0 border-l border-[var(--ij-divider-soft)]"
+            title={collapsed ? 'Expand bottom terminals' : 'Collapse bottom terminals'}
+          >
+            <ChevronDown
+              size={12}
+              strokeWidth={1.75}
+              className={`transition-transform ${collapsed ? '' : 'rotate-180'}`}
+            />
+          </button>
+        </div>
+
+        {/* Active terminal view — only one is mounted at a time. Each tab has
+            its own xterm instance via TerminalView, scrollback survives by
+            being driven from the store buffers. */}
+        {!collapsed && (
+          <div className="flex-1 min-h-0 relative">
+            {bottomTerminalIds.map((id) => (
+              <div
+                key={id}
+                className="absolute inset-0"
+                style={{ display: id === activeBottomTerminalId ? 'block' : 'none' }}
+              >
+                <TerminalView terminalId={id} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/FileChangesPanel.tsx
+++ b/src/components/FileChangesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef, createContext, useContext } from 'react';
-import { RefreshCw, GitBranch, GitFork, FilePlus, FileEdit, FileX, FileQuestion, ArrowRightLeft, FolderOpen, ChevronRight, ChevronDown, CircleDot, ArrowUp, ArrowDown, Upload, Archive, Package, Loader2, Trash2, Download, Plus, Minus, Check, Search as SearchIcon, Pin, PinOff, GitPullRequestArrow } from 'lucide-react';
+import { RefreshCw, GitBranch, GitFork, FilePlus, FileEdit, FileX, FileQuestion, ArrowRightLeft, FolderOpen, ChevronRight, ChevronDown, CircleDot, ArrowUp, ArrowDown, Upload, Archive, Package, Loader2, Trash2, Download, Plus, Minus, Check, Search as SearchIcon, Pin, PinOff, GitPullRequestArrow, TerminalSquare } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -68,6 +68,8 @@ export function FileChangesPanel() {
   const openWorktreeModal = useAppStore((s) => s.openWorktreeModal);
   const showGitPanel = useAppStore((s) => s.showGitPanel);
   const setPinnedRepoPath = useAppStore((s) => s.setPinnedRepoPath);
+  const repositoriesHeightRatio = useAppStore((s) => s.repositoriesHeightRatio);
+  const setRepositoriesHeightRatio = useAppStore((s) => s.setRepositoriesHeightRatio);
   const activeGitInfo = activeTerminalId ? gitInfoCache.get(activeTerminalId) : null;
   const activeCwd = useMemo(() => {
     if (!activeTerminalId) return null;
@@ -101,6 +103,7 @@ export function FileChangesPanel() {
   const [commitMessage, setCommitMessage] = useState('');
   const [committing, setCommitting] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [pullingTop, setPullingTop] = useState(false);
   const [stashing, setStashing] = useState(false);
   const [stashes, setStashes] = useState<StashEntry[]>([]);
   const [stashesExpanded, setStashesExpanded] = useState(false);
@@ -231,6 +234,56 @@ export function FileChangesPanel() {
     }
   }, [activePath, triggerChangesRefreshAction]);
 
+  // Quick pull — pull from upstream (or origin/<current-branch>) into the
+  // currently targeted repo's branch. Mirrors VS Code's "Pull" button.
+  const handleQuickPull = useCallback(async () => {
+    if (!activePath || !result?.is_git_repo) return;
+    setPullingTop(true);
+    try {
+      const upstream = await invoke<string | null>('get_upstream_branch', { path: activePath });
+      let remote: string | null = null;
+      let branch: string | null = null;
+      if (upstream) {
+        const idx = upstream.indexOf('/');
+        if (idx > 0 && idx < upstream.length - 1) {
+          remote = upstream.slice(0, idx);
+          branch = upstream.slice(idx + 1);
+        }
+      }
+      if (!remote || !branch) {
+        // Fallback: check for origin/<current-branch>
+        const refs = await invoke<string[]>('get_repo_remote_refs', { path: activePath });
+        const fallback = result.branch ? `origin/${result.branch}` : null;
+        if (fallback && refs.includes(fallback)) {
+          remote = 'origin';
+          branch = result.branch!;
+        } else {
+          toast.error(
+            'Pull',
+            'No upstream branch set. Use the branch menu in the Repositories list to pick a remote branch.',
+          );
+          return;
+        }
+      }
+      const msg = await invoke<string>('git_pull_branch', {
+        path: activePath,
+        remote,
+        branch,
+        strategy: 'merge',
+      });
+      const firstLine = msg.split('\n').find((l) => l.trim().length > 0) ?? 'Pulled';
+      toast.success(`Pulled from ${remote}/${branch}`, firstLine);
+      if (activeTerminalId && activeCwd && pathsEqual(activeCwd, activePath)) {
+        await useTerminalStore.getState().fetchGitInfo(activeTerminalId);
+      }
+      triggerChangesRefreshAction();
+    } catch (err) {
+      toast.error('Pull failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setPullingTop(false);
+    }
+  }, [activePath, result?.is_git_repo, result?.branch, activeTerminalId, activeCwd, triggerChangesRefreshAction]);
+
   const handleStash = useCallback(async () => {
     if (!activePath) return;
     setStashing(true);
@@ -298,6 +351,43 @@ export function FileChangesPanel() {
   const hasStaged = stagedChanges.length > 0;
   const hasUnstaged = unstagedChanges.length > 0;
 
+  // Splitter between Repositories and Changes — mirrors the Sidebar/Explorer
+  // splitter so the user can give either section more room.
+  const splitStackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const onSplitterMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const el = splitStackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.height <= 0) return;
+      const y = e.clientY - rect.top;
+      setRepositoriesHeightRatio(y / rect.height);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [setRepositoriesHeightRatio]);
+
+  const showResizable = showGitPanel && activeTerminalId && reposExpanded;
+
   return (
     <RepoSelectionContext.Provider value={{ selectedRepoPath, activePath, setSelectedRepoPath }}>
     <div className="h-full bg-bg-secondary border-l border-border flex flex-col">
@@ -305,13 +395,29 @@ export function FileChangesPanel() {
       <div className="p-3 border-b border-border">
         <div className="flex items-center justify-between mb-1">
           <h3 className="text-text-primary text-[13px] font-semibold">File Changes</h3>
-          <button
-            onClick={fetchChanges}
-            disabled={loading || !activeTerminalId}
-            className="p-1 rounded hover:bg-white/[0.04] text-text-secondary transition-colors disabled:opacity-40"
-          >
-            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
-          </button>
+          <div className="flex items-center gap-0.5">
+            <button
+              onClick={handleQuickPull}
+              disabled={pullingTop || !activeTerminalId || !result?.is_git_repo}
+              className="flex items-center gap-1 h-6 px-1.5 rounded text-[11px] text-accent-primary hover:bg-accent-primary/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+              title="Pull from upstream (or origin/<current branch>) into the current branch"
+            >
+              {pullingTop ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <GitPullRequestArrow size={12} strokeWidth={2} />
+              )}
+              <span>Pull</span>
+            </button>
+            <button
+              onClick={fetchChanges}
+              disabled={loading || !activeTerminalId}
+              className="p-1 rounded hover:bg-white/[0.04] text-text-secondary transition-colors disabled:opacity-40"
+              title="Refresh"
+            >
+              <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            </button>
+          </div>
         </div>
         {result?.branch && (
           <div className="flex items-center gap-1.5 text-text-secondary">
@@ -356,149 +462,177 @@ export function FileChangesPanel() {
         )}
       </div>
 
-      {/* Repositories section — root repo + worktree + nested sub-repos */}
-      {showGitPanel && activeTerminalId && (
-        <div className="border-b border-border">
-          <div className="flex items-center justify-between h-[26px] px-3">
-            <button
-              onClick={() => setReposExpanded((v) => !v)}
-              className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors flex-1 min-w-0 text-left"
-            >
-              {reposExpanded ? (
-                <ChevronDown size={12} strokeWidth={1.75} className="flex-shrink-0" />
-              ) : (
-                <ChevronRight size={12} strokeWidth={1.75} className="flex-shrink-0" />
-              )}
-              <span className="text-[10.5px] font-semibold uppercase tracking-[0.06em] flex-shrink-0">
-                Repositories
-              </span>
-              <span className="text-text-tertiary text-[11px]">
-                {repos.length > 0 ? `(${repos.length})` : reposLoading ? '…' : ''}
-              </span>
-            </button>
-            <button
-              onClick={() => activeCwd && fetchRepos(activeCwd)}
-              className={`w-5 h-5 flex items-center justify-center rounded-[3px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors ${
-                reposLoading ? 'animate-spin' : ''
-              }`}
-              title="Rescan"
-            >
-              <RefreshCw size={11} strokeWidth={1.75} />
-            </button>
+      {/* Resizable stack: Repositories (top) ⇕ Changes (bottom) */}
+      <div ref={splitStackRef} className="flex-1 min-h-0 flex flex-col">
+        {/* Repositories section — root repo + worktree + nested sub-repos */}
+        {showGitPanel && activeTerminalId && (
+          <div
+            className="border-b border-border flex flex-col min-h-0"
+            style={
+              showResizable
+                ? { flex: `${repositoriesHeightRatio} 1 0` }
+                : undefined
+            }
+          >
+            <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
+              <button
+                onClick={() => setReposExpanded((v) => !v)}
+                className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors flex-1 min-w-0 text-left"
+              >
+                {reposExpanded ? (
+                  <ChevronDown size={12} strokeWidth={1.75} className="flex-shrink-0" />
+                ) : (
+                  <ChevronRight size={12} strokeWidth={1.75} className="flex-shrink-0" />
+                )}
+                <span className="text-[10.5px] font-semibold uppercase tracking-[0.06em] flex-shrink-0">
+                  Repositories
+                </span>
+                <span className="text-text-tertiary text-[11px]">
+                  {repos.length > 0 ? `(${repos.length})` : reposLoading ? '…' : ''}
+                </span>
+              </button>
+              <button
+                onClick={() => activeCwd && fetchRepos(activeCwd)}
+                className={`w-5 h-5 flex items-center justify-center rounded-[3px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors ${
+                  reposLoading ? 'animate-spin' : ''
+                }`}
+                title="Rescan"
+              >
+                <RefreshCw size={11} strokeWidth={1.75} />
+              </button>
+            </div>
+            {reposExpanded && (
+              <div className="px-2 pb-2 space-y-0.5 flex-1 min-h-0 overflow-y-auto">
+                {!reposLoading && repos.length === 0 && (
+                  <div className="text-text-tertiary text-[11px] px-2 py-1">
+                    No Git repositories detected
+                  </div>
+                )}
+                {repos.filter((r) => r.is_main_repo).map((r) => (
+                  <RepoRow key={r.path} repo={r} />
+                ))}
+
+
+                {linkedWorktrees.length > 0 && (
+                  <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
+                    Worktrees ({linkedWorktrees.length})
+                  </div>
+                )}
+                {linkedWorktrees.map((wt) => (
+                  <WorktreeRow
+                    key={wt.path}
+                    wt={wt}
+                    isActive={activeCwd != null && pathsEqual(activeCwd, wt.path)}
+                  />
+                ))}
+
+                {repos.some((r) => !r.is_main_repo) && (
+                  <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
+                    Nested ({repos.filter((r) => !r.is_main_repo).length})
+                  </div>
+                )}
+                {repos.filter((r) => !r.is_main_repo).map((r) => (
+                  <RepoRow key={r.path} repo={r} />
+                ))}
+              </div>
+            )}
           </div>
-          {reposExpanded && (
-            <div className="px-2 pb-2 space-y-0.5">
-              {!reposLoading && repos.length === 0 && (
-                <div className="text-text-tertiary text-[11px] px-2 py-1">
-                  No Git repositories detected
-                </div>
-              )}
-              {repos.filter((r) => r.is_main_repo).map((r) => (
-                <RepoRow key={r.path} repo={r} />
-              ))}
+        )}
 
+        {/* Drag handle — only meaningful when both sections share the column */}
+        {showResizable && (
+          <div
+            onMouseDown={onSplitterMouseDown}
+            role="separator"
+            aria-orientation="horizontal"
+            title="Drag to resize Repositories / Changes"
+            className="h-1 shrink-0 cursor-row-resize bg-transparent hover:bg-accent-primary/50 active:bg-accent-primary/70 transition-colors"
+          />
+        )}
 
-              {linkedWorktrees.length > 0 && (
-                <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
-                  Worktrees ({linkedWorktrees.length})
-                </div>
-              )}
-              {linkedWorktrees.map((wt) => (
-                <WorktreeRow
-                  key={wt.path}
-                  wt={wt}
-                  isActive={activeCwd != null && pathsEqual(activeCwd, wt.path)}
-                />
-              ))}
-
-              {repos.some((r) => !r.is_main_repo) && (
-                <div className="text-text-tertiary text-[10px] uppercase tracking-wide px-2 pt-1.5">
-                  Nested ({repos.filter((r) => !r.is_main_repo).length})
-                </div>
-              )}
-              {repos.filter((r) => !r.is_main_repo).map((r) => (
-                <RepoRow key={r.path} repo={r} />
-              ))}
+        {/* Content */}
+        <div
+          className="overflow-y-auto p-1.5 min-h-0"
+          style={
+            showResizable
+              ? { flex: `${1 - repositoriesHeightRatio} 1 0` }
+              : { flex: '1 1 0' }
+          }
+        >
+          {!activeTerminalId && (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-text-tertiary text-[12px]">No terminal selected</p>
             </div>
           )}
+
+          {activeTerminalId && error && (
+            <div className="p-3">
+              <p className="text-red-400 text-[12px]">{error}</p>
+            </div>
+          )}
+
+          {activeTerminalId && result && !result.is_git_repo && (
+            <div className="flex items-center justify-center h-full px-4 text-center">
+              <p className="text-text-tertiary text-[12px]">
+                Not a git repository.
+                {repos.length > 0 && (
+                  <>
+                    <br />
+                    Pin a nested repository above to commit, push, and manage it here.
+                  </>
+                )}
+              </p>
+            </div>
+          )}
+
+          {activeTerminalId && result && result.is_git_repo && result.changes.length === 0 && !result.error && (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-text-tertiary text-[12px]">No uncommitted changes</p>
+            </div>
+          )}
+
+          {activeTerminalId && result?.error && (
+            <div className="p-3">
+              <p className="text-red-400 text-[12px]">{result.error}</p>
+            </div>
+          )}
+
+          {hasStaged && (
+            <ChangeGroup
+              title="Staged"
+              count={stagedChanges.length}
+              files={stagedChanges}
+              staged={true}
+              expandedFile={expandedFile}
+              setExpandedFile={setExpandedFile}
+              activeTerminalId={activeTerminalId}
+              pathOverride={usingSelectedRepo ? selectedRepoPath : null}
+              repoRoot={activePath}
+              stagingPaths={stagingPaths}
+              onStage={stageFiles}
+              onUnstage={unstageFiles}
+              onBulk={() => unstageFiles(stagedChanges.map((f) => f.path))}
+            />
+          )}
+
+          {hasUnstaged && (
+            <ChangeGroup
+              title="Changes"
+              count={unstagedChanges.length}
+              files={unstagedChanges}
+              staged={false}
+              expandedFile={expandedFile}
+              setExpandedFile={setExpandedFile}
+              activeTerminalId={activeTerminalId}
+              pathOverride={usingSelectedRepo ? selectedRepoPath : null}
+              repoRoot={activePath}
+              stagingPaths={stagingPaths}
+              onStage={stageFiles}
+              onUnstage={unstageFiles}
+              onBulk={() => stageFiles(unstagedChanges.map((f) => f.path))}
+            />
+          )}
         </div>
-      )}
-
-      {/* Content */}
-      <div className="flex-1 overflow-y-auto p-1.5">
-        {!activeTerminalId && (
-          <div className="flex items-center justify-center h-full">
-            <p className="text-text-tertiary text-[12px]">No terminal selected</p>
-          </div>
-        )}
-
-        {activeTerminalId && error && (
-          <div className="p-3">
-            <p className="text-red-400 text-[12px]">{error}</p>
-          </div>
-        )}
-
-        {activeTerminalId && result && !result.is_git_repo && (
-          <div className="flex items-center justify-center h-full px-4 text-center">
-            <p className="text-text-tertiary text-[12px]">
-              Not a git repository.
-              {repos.length > 0 && (
-                <>
-                  <br />
-                  Pin a nested repository above to commit, push, and manage it here.
-                </>
-              )}
-            </p>
-          </div>
-        )}
-
-        {activeTerminalId && result && result.is_git_repo && result.changes.length === 0 && !result.error && (
-          <div className="flex items-center justify-center h-full">
-            <p className="text-text-tertiary text-[12px]">No uncommitted changes</p>
-          </div>
-        )}
-
-        {activeTerminalId && result?.error && (
-          <div className="p-3">
-            <p className="text-red-400 text-[12px]">{result.error}</p>
-          </div>
-        )}
-
-        {hasStaged && (
-          <ChangeGroup
-            title="Staged"
-            count={stagedChanges.length}
-            files={stagedChanges}
-            staged={true}
-            expandedFile={expandedFile}
-            setExpandedFile={setExpandedFile}
-            activeTerminalId={activeTerminalId}
-            pathOverride={usingSelectedRepo ? selectedRepoPath : null}
-            repoRoot={activePath}
-            stagingPaths={stagingPaths}
-            onStage={stageFiles}
-            onUnstage={unstageFiles}
-            onBulk={() => unstageFiles(stagedChanges.map((f) => f.path))}
-          />
-        )}
-
-        {hasUnstaged && (
-          <ChangeGroup
-            title="Changes"
-            count={unstagedChanges.length}
-            files={unstagedChanges}
-            staged={false}
-            expandedFile={expandedFile}
-            setExpandedFile={setExpandedFile}
-            activeTerminalId={activeTerminalId}
-            pathOverride={usingSelectedRepo ? selectedRepoPath : null}
-            repoRoot={activePath}
-            stagingPaths={stagingPaths}
-            onStage={stageFiles}
-            onUnstage={unstageFiles}
-            onBulk={() => stageFiles(unstagedChanges.map((f) => f.path))}
-          />
-        )}
       </div>
 
       {/* Stashes — collapsible list, only when there are stashes */}
@@ -1047,6 +1181,23 @@ function RepoRow({ repo }: { repo: ScannedGitRepo }) {
     setSelectedRepoPath(isPinned ? null : repo.path);
   };
 
+  const [openingTerminal, setOpeningTerminal] = useState(false);
+  const openTerminalHere = useCallback(async () => {
+    if (openingTerminal) return;
+    setOpeningTerminal(true);
+    try {
+      const baseLabel = repo.is_main_repo
+        ? (repo.path.replace(/^.*[\\/]/, '') || 'repo')
+        : (repo.relative_path || repo.path.replace(/^.*[\\/]/, ''));
+      await useTerminalStore.getState().openShellTerminal(baseLabel, repo.path);
+      toast.success('Shell opened', `${baseLabel} — ${repo.path}`);
+    } catch (err) {
+      toast.error('Open terminal failed', typeof err === 'string' ? err : 'Unknown error');
+    } finally {
+      setOpeningTerminal(false);
+    }
+  }, [openingTerminal, repo.path, repo.relative_path, repo.is_main_repo]);
+
   return (
     <div
       className={`group relative rounded-[3px] ${
@@ -1092,6 +1243,21 @@ function RepoRow({ repo }: { repo: ScannedGitRepo }) {
               {repo.is_worktree ? ' · worktree' : ''}
             </div>
           </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={openTerminalHere}
+          disabled={openingTerminal}
+          className="flex-shrink-0 w-6 h-6 mt-0.5 flex items-center justify-center rounded-[3px] transition-colors text-text-tertiary hover:bg-accent-primary/15 hover:text-accent-primary disabled:opacity-40"
+          title={`Open shell here\nLaunches a plain interactive shell (no Claude) at\n${repo.path}\nin the bottom terminal pane.`}
+          aria-label={`Open shell in ${repo.path}`}
+        >
+          {openingTerminal ? (
+            <Loader2 size={11} className="animate-spin" />
+          ) : (
+            <TerminalSquare size={11} strokeWidth={1.75} />
+          )}
         </button>
 
         <button

--- a/src/components/GlobalSearchModal.tsx
+++ b/src/components/GlobalSearchModal.tsx
@@ -1,0 +1,419 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  Search as SearchIcon,
+  X,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+  CaseSensitive,
+  FileCode2,
+  AlertCircle,
+} from 'lucide-react';
+import { useAppStore } from '../store/appStore';
+import { useTerminalStore } from '../store/terminalStore';
+
+interface SearchMatch {
+  line: number;
+  column: number;
+  line_text: string;
+  match_length: number;
+}
+
+interface FileSearchResult {
+  file_path: string;
+  relative_path: string;
+  matches: SearchMatch[];
+  name_match: boolean;
+}
+
+interface SearchSummary {
+  results: FileSearchResult[];
+  total_matches: number;
+  total_files: number;
+  truncated: boolean;
+}
+
+// Render a line preview with the matched substring highlighted.
+function HighlightedLine({
+  text,
+  column,
+  matchLength,
+}: {
+  text: string;
+  column: number;
+  matchLength: number;
+}) {
+  const start = Math.max(0, column - 1);
+  const end = Math.min(text.length, start + matchLength);
+  if (end <= start) {
+    return <span>{text}</span>;
+  }
+  // Trim long lines around the match for readability
+  const previewStart = Math.max(0, start - 80);
+  const before = previewStart > 0 ? '…' + text.slice(previewStart, start) : text.slice(0, start);
+  const matched = text.slice(start, end);
+  const after = text.slice(end);
+  return (
+    <>
+      <span className="text-text-tertiary">{before}</span>
+      <span className="bg-accent-primary/30 text-text-primary rounded-[2px] px-[1px]">
+        {matched}
+      </span>
+      <span className="text-text-tertiary">{after}</span>
+    </>
+  );
+}
+
+export function GlobalSearchModal() {
+  const closeGlobalSearch = useAppStore((s) => s.closeGlobalSearch);
+  const openFileTab = useAppStore((s) => s.openFileTab);
+  const pinnedRepoPath = useAppStore((s) => s.pinnedRepoPath);
+  const activeCwd = useTerminalStore((s) => {
+    const id = s.activeTerminalId;
+    return id ? s.terminals.get(id)?.config.working_directory ?? null : null;
+  });
+
+  const searchRoot = pinnedRepoPath ?? activeCwd;
+
+  const [query, setQuery] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [summary, setSummary] = useState<SearchSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<{ fileIdx: number; matchIdx: number }>({
+    fileIdx: 0,
+    matchIdx: 0,
+  });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  // Token to ignore stale debounced searches
+  const searchToken = useRef(0);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (!searchRoot) return;
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setSummary(null);
+      setError(null);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const myToken = ++searchToken.current;
+    const handle = setTimeout(async () => {
+      try {
+        const res = await invoke<SearchSummary>('search_in_files', {
+          path: searchRoot,
+          query: trimmed,
+          caseSensitive,
+          includeFileContents: true,
+        });
+        if (myToken !== searchToken.current) return;
+        setSummary(res);
+        setError(null);
+        setCollapsedFiles(new Set());
+        setSelected({ fileIdx: 0, matchIdx: 0 });
+      } catch (err) {
+        if (myToken !== searchToken.current) return;
+        setError(typeof err === 'string' ? err : 'Search failed');
+        setSummary(null);
+      } finally {
+        if (myToken === searchToken.current) setSearching(false);
+      }
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [query, caseSensitive, searchRoot]);
+
+  const results = summary?.results ?? [];
+
+  // Build a flat list of (fileIdx, matchIdx) entries that respects collapsed
+  // groups, so arrow keys move between visible matches in document order.
+  const flatNav = useMemo(() => {
+    const out: { fileIdx: number; matchIdx: number }[] = [];
+    results.forEach((file, fileIdx) => {
+      if (collapsedFiles.has(file.file_path)) return;
+      file.matches.forEach((_, matchIdx) => {
+        out.push({ fileIdx, matchIdx });
+      });
+      if (file.matches.length === 0) {
+        // File has only a name match — represent it as a single entry
+        out.push({ fileIdx, matchIdx: -1 });
+      }
+    });
+    return out;
+  }, [results, collapsedFiles]);
+
+  const flatIndex = useMemo(() => {
+    return flatNav.findIndex(
+      (e) => e.fileIdx === selected.fileIdx && e.matchIdx === selected.matchIdx,
+    );
+  }, [flatNav, selected]);
+
+  const openMatch = useCallback(
+    async (file: FileSearchResult) => {
+      try {
+        await openFileTab(file.file_path);
+        closeGlobalSearch();
+      } catch {
+        /* errors surface via the file tab itself */
+      }
+    },
+    [openFileTab, closeGlobalSearch],
+  );
+
+  const toggleFile = (filePath: string) => {
+    setCollapsedFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(filePath)) next.delete(filePath);
+      else next.add(filePath);
+      return next;
+    });
+  };
+
+  const moveSelection = (delta: number) => {
+    if (flatNav.length === 0) return;
+    const idx = flatIndex < 0 ? 0 : flatIndex;
+    const next = (idx + delta + flatNav.length) % flatNav.length;
+    setSelected(flatNav[next]);
+    // Scroll into view
+    requestAnimationFrame(() => {
+      const el = listRef.current?.querySelector<HTMLElement>(
+        `[data-nav="${flatNav[next].fileIdx}-${flatNav[next].matchIdx}"]`,
+      );
+      el?.scrollIntoView({ block: 'nearest' });
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeGlobalSearch();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveSelection(1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveSelection(-1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const file = results[selected.fileIdx];
+      if (file) openMatch(file);
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.12 }}
+      className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-start justify-center pt-[8vh]"
+      onMouseDown={(e) => {
+        // Click on backdrop (not modal) closes
+        if (e.target === e.currentTarget) closeGlobalSearch();
+      }}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.97, y: -8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.97, y: -8 }}
+        transition={{ duration: 0.15, ease: 'easeOut' }}
+        className="w-full max-w-[820px] mx-4 bg-elevation-3 ring-1 ring-white/[0.08] rounded-xl shadow-elevation-3 overflow-hidden flex flex-col"
+        style={{ maxHeight: '80vh' }}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <div className="flex items-center gap-2 text-text-primary text-[13px] font-semibold">
+            <SearchIcon size={14} className="text-accent-primary" />
+            Search in Files
+          </div>
+          <button
+            onClick={closeGlobalSearch}
+            className="p-1 rounded hover:bg-white/[0.06] text-text-tertiary hover:text-text-primary transition-colors"
+            title="Close (Esc)"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Search input row */}
+        <div className="px-4 py-3 border-b border-border">
+          <div className="relative flex items-center">
+            <SearchIcon
+              size={13}
+              className="absolute left-3 text-text-tertiary"
+              strokeWidth={1.75}
+            />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search across the workspace…"
+              className="w-full bg-elevation-1 ring-1 ring-inset ring-border rounded-md h-9 pl-9 pr-24 text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-accent-primary/60"
+            />
+            <div className="absolute right-2 flex items-center gap-1">
+              <button
+                onClick={() => setCaseSensitive((v) => !v)}
+                className={`h-7 w-7 flex items-center justify-center rounded transition-colors ${
+                  caseSensitive
+                    ? 'bg-accent-primary/20 text-accent-primary ring-1 ring-inset ring-accent-primary/40'
+                    : 'text-text-tertiary hover:bg-white/[0.06] hover:text-text-secondary'
+                }`}
+                title="Match case (Aa)"
+                tabIndex={-1}
+              >
+                <CaseSensitive size={14} strokeWidth={1.75} />
+              </button>
+            </div>
+          </div>
+
+          {/* Status line */}
+          <div className="mt-2 flex items-center justify-between text-[11px]">
+            <div className="text-text-tertiary truncate" title={searchRoot ?? ''}>
+              {searchRoot ? (
+                <>
+                  in <span className="font-mono text-text-secondary">{searchRoot}</span>
+                </>
+              ) : (
+                'No active workspace — open a terminal first'
+              )}
+            </div>
+            <div className="text-text-tertiary flex items-center gap-2">
+              {searching && <Loader2 size={11} className="animate-spin" />}
+              {summary && !searching && (
+                <span>
+                  {summary.total_matches} match
+                  {summary.total_matches === 1 ? '' : 'es'} in {summary.total_files} file
+                  {summary.total_files === 1 ? '' : 's'}
+                  {summary.truncated && ' (truncated)'}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Results */}
+        <div ref={listRef} className="flex-1 overflow-y-auto py-1.5">
+          {error && (
+            <div className="flex items-center gap-2 px-4 py-3 text-[12px] text-error">
+              <AlertCircle size={13} />
+              {error}
+            </div>
+          )}
+
+          {!error && !searching && summary && summary.results.length === 0 && query.trim() && (
+            <div className="px-4 py-6 text-center text-text-tertiary text-[12px]">
+              No matches found
+            </div>
+          )}
+
+          {!error && !query.trim() && (
+            <div className="px-4 py-6 text-center text-text-tertiary text-[12px]">
+              Type to search file names and contents across the workspace.
+            </div>
+          )}
+
+          {!error &&
+            results.map((file, fileIdx) => {
+              const collapsed = collapsedFiles.has(file.file_path);
+              const fileSelected = selected.fileIdx === fileIdx && selected.matchIdx === -1;
+              return (
+                <div key={file.file_path} className="mb-0.5">
+                  <button
+                    data-nav={`${fileIdx}--1`}
+                    onClick={() => toggleFile(file.file_path)}
+                    onDoubleClick={() => openMatch(file)}
+                    className={`w-full flex items-center gap-1.5 px-3 py-1 text-left transition-colors ${
+                      fileSelected
+                        ? 'bg-accent-primary/10'
+                        : 'hover:bg-white/[0.04]'
+                    }`}
+                  >
+                    {collapsed ? (
+                      <ChevronRight size={11} className="text-text-tertiary flex-shrink-0" strokeWidth={1.75} />
+                    ) : (
+                      <ChevronDown size={11} className="text-text-tertiary flex-shrink-0" strokeWidth={1.75} />
+                    )}
+                    <FileCode2 size={11} className="text-text-tertiary flex-shrink-0" strokeWidth={1.75} />
+                    <span className="text-[12px] text-text-primary font-mono truncate" title={file.relative_path}>
+                      {file.relative_path}
+                    </span>
+                    {file.name_match && (
+                      <span className="text-[9px] uppercase tracking-wider text-accent-primary bg-accent-primary/15 px-1 rounded flex-shrink-0">
+                        name
+                      </span>
+                    )}
+                    <span className="text-text-tertiary text-[10.5px] flex-shrink-0 ml-auto">
+                      {file.matches.length || (file.name_match ? '·' : 0)}
+                    </span>
+                  </button>
+
+                  {!collapsed && (
+                    <div className="ml-5 border-l border-border">
+                      {file.matches.map((m, matchIdx) => {
+                        const isSelected =
+                          selected.fileIdx === fileIdx && selected.matchIdx === matchIdx;
+                        return (
+                          <button
+                            key={`${m.line}-${matchIdx}`}
+                            data-nav={`${fileIdx}-${matchIdx}`}
+                            onClick={() => {
+                              setSelected({ fileIdx, matchIdx });
+                              openMatch(file);
+                            }}
+                            onMouseEnter={() => setSelected({ fileIdx, matchIdx })}
+                            className={`w-full flex items-baseline gap-2 px-3 py-0.5 text-left transition-colors ${
+                              isSelected ? 'bg-accent-primary/12' : 'hover:bg-white/[0.04]'
+                            }`}
+                          >
+                            <span className="text-text-tertiary text-[10.5px] font-mono flex-shrink-0 w-8 text-right tabular-nums">
+                              {m.line}
+                            </span>
+                            <span className="text-[12px] font-mono truncate flex-1 min-w-0">
+                              <HighlightedLine
+                                text={m.line_text}
+                                column={m.column}
+                                matchLength={m.match_length}
+                              />
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-border flex items-center gap-4 text-[10px] text-text-tertiary">
+          <span>
+            <kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">↑↓</kbd> navigate
+          </span>
+          <span>
+            <kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">↵</kbd> open file
+          </span>
+          <span>
+            <kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">esc</kbd> close
+          </span>
+          <span className="ml-auto">
+            <kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">Aa</kbd> match case
+          </span>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,8 +70,10 @@ export function Sidebar() {
 
   const terminalList = useMemo(() =>
     Array.from(terminals.values())
-      // Script children belong under their parent in the main area, not the sidebar.
-      .filter(t => !t.scriptParentId)
+      // Script children belong under their parent in the main area, and
+      // bottom-pane shells belong in the BottomTerminalPane — neither
+      // appears in the sidebar.
+      .filter(t => !t.scriptParentId && !t.isShellTerminal)
       .map(t => t.config)
       .filter(t => {
         const searchLower = search.toLowerCase();

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -12,6 +12,7 @@ import { SessionInsights } from './SessionInsights';
 import { FileEditorView } from './FileEditorView';
 import { ScriptsMenu } from './ScriptsMenu';
 import { ScriptChildPane } from './ScriptChildPane';
+import { BottomTerminalPane } from './BottomTerminalPane';
 import { getDragData, isTerminalDrag } from '../utils/dragDrop';
 
 function fileBasename(p: string): string {
@@ -36,9 +37,14 @@ export function TerminalTabs() {
   const focusFile = useCallback((path: string) => {
     setActiveFilePath(path);
   }, [setActiveFilePath]);
-  // Script-child terminals are rendered below their parent — never as their own tab.
+  // Script-child terminals are rendered below their parent and bottom-pane
+  // shells are rendered in BottomTerminalPane — neither belongs in the main
+  // tab bar.
   const terminalList = useMemo(
-    () => Array.from(terminals.values()).filter((t) => !t.scriptParentId).map((t) => t.config),
+    () =>
+      Array.from(terminals.values())
+        .filter((t) => !t.scriptParentId && !t.isShellTerminal)
+        .map((t) => t.config),
     [terminals]
   );
 
@@ -529,6 +535,8 @@ export function TerminalTabs() {
             </div>
         )}
       </div>
+
+      <BottomTerminalPane />
     </div>
   );
 }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -132,13 +132,21 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
     // Auto-focus so keyboard input works immediately without requiring a click
     terminal.focus();
 
-    // Re-focus xterm if its textarea loses focus to nothing (body/canvas),
-    // which happens in WebView2 after PTY output triggers React re-renders
-    // or when clicking the terminal canvas directly.
+    // Re-focus xterm if its textarea loses focus to nothing (body) or to its
+    // OWN canvas — that combo happens in WebView2 after PTY output triggers
+    // React re-renders or when the user clicks the terminal canvas directly.
+    // We must NOT refocus if focus moved to a sibling terminal's canvas (e.g.
+    // the script-child pane), or to any input/textarea elsewhere — otherwise
+    // the user can't type into the other terminal.
+    const container = containerRef.current;
     const handleBlur = () => {
       requestAnimationFrame(() => {
         const focused = document.activeElement;
-        if (!focused || focused === document.body || focused.tagName === 'CANVAS') {
+        if (!focused || focused === document.body) {
+          terminal.focus();
+          return;
+        }
+        if (focused.tagName === 'CANVAS' && container && container.contains(focused)) {
           terminal.focus();
         }
       });
@@ -149,8 +157,9 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       const isCtrl = e.ctrlKey || e.metaKey;
 
-      // Ctrl+Shift+F: Toggle search
-      if (isCtrl && e.shiftKey && e.key === 'F' && e.type === 'keydown') {
+      // Ctrl+F: Toggle in-terminal search (Ctrl+Shift+F is reserved for the
+      // global file/content search — see useKeyboardShortcuts).
+      if (isCtrl && !e.shiftKey && e.key === 'f' && e.type === 'keydown') {
         e.preventDefault();
         toggleSearch();
         return false;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -64,7 +64,11 @@ export function useKeyboardShortcuts() {
         }
       }
 
-      // Ctrl+Shift+F is handled inside TerminalView for search
+      // Global file/content search (VS Code style): Ctrl+Shift+F
+      if (ctrl && shift && e.key === 'F') {
+        e.preventDefault();
+        useAppStore.getState().toggleGlobalSearch();
+      }
 
       if (ctrl && e.key === 'b') {
         e.preventDefault();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -55,6 +55,12 @@ interface AppState {
   // Sidebar layout
   explorerHeightRatio: number; // 0.15..0.85, portion of sidebar height reserved for Explorer
 
+  // File Changes panel split: Repositories (top) vs Changes (bottom)
+  repositoriesHeightRatio: number; // 0.15..0.85
+
+  // Global Search (Ctrl+Shift+F)
+  globalSearchOpen: boolean;
+
   // Grid state
   gridMode: boolean;
   gridTerminalIds: string[];
@@ -129,6 +135,12 @@ interface AppState {
   saveFileTab: (path: string) => Promise<void>;
   reloadFileTab: (path: string) => Promise<void>;
   setExplorerHeightRatio: (ratio: number) => void;
+  setRepositoriesHeightRatio: (ratio: number) => void;
+
+  // Global Search actions (Ctrl+Shift+F)
+  openGlobalSearch: () => void;
+  closeGlobalSearch: () => void;
+  toggleGlobalSearch: () => void;
 
   // Grid actions
   toggleGridMode: () => void;
@@ -248,6 +260,12 @@ export const useAppStore = create<AppState>()(
       // Sidebar explorer ratio (default: explorer takes 45% of sidebar height)
       explorerHeightRatio: 0.45,
 
+      // File Changes split (default: repositories takes 35% of available column)
+      repositoriesHeightRatio: 0.35,
+
+      // Global Search (Ctrl+Shift+F)
+      globalSearchOpen: false,
+
       // Grid state
       gridMode: false,
       gridTerminalIds: [],
@@ -315,6 +333,13 @@ export const useAppStore = create<AppState>()(
       setExplorerHeightRatio: (ratio) => set({
         explorerHeightRatio: Math.max(0.15, Math.min(0.85, ratio)),
       }),
+      setRepositoriesHeightRatio: (ratio) => set({
+        repositoriesHeightRatio: Math.max(0.15, Math.min(0.85, ratio)),
+      }),
+
+      openGlobalSearch: () => set({ globalSearchOpen: true }),
+      closeGlobalSearch: () => set({ globalSearchOpen: false }),
+      toggleGlobalSearch: () => set((state) => ({ globalSearchOpen: !state.globalSearchOpen })),
 
       setActiveFilePath: (path) => set({ activeFilePath: path }),
 
@@ -598,6 +623,7 @@ export const useAppStore = create<AppState>()(
         showGitPanel: state.showGitPanel,
         showFileTree: state.showFileTree,
         explorerHeightRatio: state.explorerHeightRatio,
+        repositoriesHeightRatio: state.repositoriesHeightRatio,
         orchestrationOpen: state.orchestrationOpen,
         lastSeenVersion: state.lastSeenVersion,
       }),

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -34,6 +34,9 @@ interface TerminalInstance {
   // spawned below a parent terminal. Excluded from the tab list and sidebar.
   scriptName?: string;
   scriptParentId?: string;
+  // Plain interactive shell at a directory (no claude). Renders in the bottom
+  // BottomTerminalPane, not the main tab bar / sidebar.
+  isShellTerminal?: boolean;
 }
 
 interface TerminalState {
@@ -43,6 +46,9 @@ interface TerminalState {
   gitInfoCache: Map<string, WorktreeDetectResult>;
   // Parent terminal ID → script child terminal ID (one child per parent).
   scriptChildren: Map<string, string>;
+  // Bottom pane (interactive shells the user opens from the Repositories list).
+  bottomTerminalIds: string[];
+  activeBottomTerminalId: string | null;
 
   createTerminal: (
     label: string,
@@ -77,6 +83,11 @@ interface TerminalState {
   // by the package.json CodeLens, where the script's cwd is the file's folder.
   runScript: (parentId: string, scriptName: string, cwdOverride?: string) => Promise<string>;
   closeScript: (parentId: string) => Promise<void>;
+
+  // Bottom shell-terminal pane
+  openShellTerminal: (label: string, cwd: string) => Promise<string>;
+  closeShellTerminal: (id: string) => Promise<void>;
+  setActiveBottomTerminal: (id: string | null) => void;
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -85,6 +96,8 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   unreadTerminalIds: new Set(),
   gitInfoCache: new Map(),
   scriptChildren: new Map(),
+  bottomTerminalIds: [],
+  activeBottomTerminalId: null,
 
   createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput) => {
     try {
@@ -164,10 +177,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newChildren = new Map(state.scriptChildren);
       newChildren.delete(id);
 
-      // Only pick a fallback from non-child terminals; script children must
-      // never become the "active tab".
+      // Only pick a fallback from terminals that actually appear in the main
+      // tab bar — script children and bottom-pane shells must never become
+      // the "active tab".
       const remainingIds = Array.from(newTerminals.values())
-        .filter((t) => !t.scriptParentId)
+        .filter((t) => !t.scriptParentId && !t.isShellTerminal)
         .map((t) => t.config.id);
       return {
         terminals: newTerminals,
@@ -397,4 +411,55 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       return { terminals: nextTerminals, scriptChildren: nextChildren };
     });
   },
+
+  openShellTerminal: async (label, cwd) => {
+    const config = await invoke<TerminalConfig>('create_shell_terminal', { label, cwd });
+    set((state) => {
+      const nextTerminals = new Map(state.terminals);
+      nextTerminals.set(config.id, {
+        config,
+        xterm: null,
+        isWorktree: false,
+        isShellTerminal: true,
+      });
+      return {
+        terminals: nextTerminals,
+        bottomTerminalIds: [...state.bottomTerminalIds, config.id],
+        activeBottomTerminalId: config.id,
+      };
+    });
+    return config.id;
+  },
+
+  closeShellTerminal: async (id) => {
+    try {
+      await invoke('close_terminal', { id });
+    } catch {
+      // Already gone — fall through to store cleanup.
+    }
+    set((state) => {
+      const nextTerminals = new Map(state.terminals);
+      const inst = nextTerminals.get(id);
+      if (inst?.xterm) inst.xterm.dispose();
+      nextTerminals.delete(id);
+      const nextIds = state.bottomTerminalIds.filter((x) => x !== id);
+      let nextActive: string | null = state.activeBottomTerminalId;
+      if (nextActive === id) {
+        const removedIdx = state.bottomTerminalIds.indexOf(id);
+        if (nextIds.length === 0) {
+          nextActive = null;
+        } else {
+          const fallbackIdx = Math.min(Math.max(removedIdx, 0), nextIds.length - 1);
+          nextActive = nextIds[fallbackIdx];
+        }
+      }
+      return {
+        terminals: nextTerminals,
+        bottomTerminalIds: nextIds,
+        activeBottomTerminalId: nextActive,
+      };
+    });
+  },
+
+  setActiveBottomTerminal: (id) => set({ activeBottomTerminalId: id }),
 }));


### PR DESCRIPTION
## Summary

- **Ctrl+Shift+F global search** — VS Code–style modal with filename + content matching across the workspace. Skips `.git`, `node_modules`, `target`, `dist`, etc.; binary-sniffs files; debounced; arrow-key nav; Enter opens the file. Backed by a new `search_in_files` Rust command. Terminal-internal search moves to Ctrl+F.
- **Quick "Pull from origin"** in the File Changes header — uses the upstream branch when set, otherwise falls back to `origin/<current-branch>`.
- **Resizable Repositories ⇕ Changes** inside the File Changes panel, with a draggable splitter (ratio persisted).
- **Per-repo plain shells** — each scanned/pinned repo row gets a terminal-icon button that opens a no-claude interactive shell at that path in a new tabbed `BottomTerminalPane` (drag-to-resize, +/x per tab, collapse toggle). Backed by a new `create_shell_terminal` Rust command (`cmd.exe` on Windows, `$SHELL -li` on Unix).
- **Focus-steal fix** in `TerminalView` so script-child / sibling terminals can keep focus when clicked (Ctrl+C, typing route to the focused pane).

## Test plan

- [ ] Press Ctrl+Shift+F — modal opens, results group by file, arrow keys navigate, Enter opens the file.
- [ ] Press Ctrl+F inside a terminal — in-terminal search bar appears (formerly Ctrl+Shift+F).
- [ ] Click "Pull" in the File Changes header — pulls upstream with no uncommitted changes; shows a clear error otherwise.
- [ ] Drag the splitter between Repositories and Changes — ratio survives a reload.
- [ ] Click the terminal icon on a pinned repo row — bottom pane appears with a shell prompt at that repo's path. Open another → tabs appear. Type a long-running command and Ctrl+C to confirm input/interrupt work.
- [ ] Run an `npm run` script from the active terminal's Scripts menu — `ScriptChildPane` still opens below the parent and accepts input.
- [ ] Switch focus between the parent terminal, its script child, and a bottom shell — keystrokes route to the focused pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)