### PR TITLE
docs: clarify ClaudeTerminal supports both Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,28 +135,6 @@ jobs:
           # AZURE_TENANT_ID inherited from job-level env. sign-windows.ps1 no-ops when TRUSTED_SIGNING_ENABLED is unset.
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          # Apple code signing + notarization. tauri-action / tauri bundler reads
-          # these natively and skips signing when they are empty, so leaving any
-          # of the secrets unset is a safe no-op — the build still produces an
-          # unsigned .app/.dmg. To enable signing, populate all of:
-          #   APPLE_CERTIFICATE                  base64-encoded .p12
-          #   APPLE_CERTIFICATE_PASSWORD         .p12 password
-          #   APPLE_SIGNING_IDENTITY             e.g. "Developer ID Application: Acme (TEAMID)"
-          # And for notarization (App Store Connect API key — preferred):
-          #   APPLE_API_ISSUER                   App Store Connect issuer UUID
-          #   APPLE_API_KEY                      key ID (e.g. ABCD1234)
-          #   APPLE_API_KEY_PATH                 path to the .p8 private key file
-          # OR (legacy Apple ID auth):
-          #   APPLE_ID, APPLE_PASSWORD (app-specific), APPLE_TEAM_ID
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           updaterJsonKeepUniversal: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,28 @@ jobs:
           # AZURE_TENANT_ID inherited from job-level env. sign-windows.ps1 no-ops when TRUSTED_SIGNING_ENABLED is unset.
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # Apple code signing + notarization. tauri-action / tauri bundler reads
+          # these natively and skips signing when they are empty, so leaving any
+          # of the secrets unset is a safe no-op — the build still produces an
+          # unsigned .app/.dmg. To enable signing, populate all of:
+          #   APPLE_CERTIFICATE                  base64-encoded .p12
+          #   APPLE_CERTIFICATE_PASSWORD         .p12 password
+          #   APPLE_SIGNING_IDENTITY             e.g. "Developer ID Application: Acme (TEAMID)"
+          # And for notarization (App Store Connect API key — preferred):
+          #   APPLE_API_ISSUER                   App Store Connect issuer UUID
+          #   APPLE_API_KEY                      key ID (e.g. ABCD1234)
+          #   APPLE_API_KEY_PATH                 path to the .p8 private key file
+          # OR (legacy Apple ID auth):
+          #   APPLE_ID, APPLE_PASSWORD (app-specific), APPLE_TEAM_ID
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           updaterJsonKeepUniversal: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**ClaudeTerminal** is a Windows desktop application for managing multiple Claude Code CLI terminal instances from a unified interface. Built with Tauri 2.x (Rust backend) and React 18 (TypeScript frontend), it provides tabbed and grid views of parallel Claude Code sessions with PTY-based terminal emulation.
+**ClaudeTerminal** is a cross-platform desktop application (Windows and macOS) for managing multiple Claude Code CLI terminal instances from a unified interface. Built with Tauri 2.x (Rust backend) and React 18 (TypeScript frontend), it provides tabbed and grid views of parallel Claude Code sessions with PTY-based terminal emulation. The release workflow produces NSIS/MSI installers for Windows and `.dmg`/`.app` bundles for both Apple Silicon and Intel Macs.
 
 Current version: **1.21.1**
 
@@ -16,7 +16,7 @@ Current version: **1.21.1**
 - **State management**: Zustand (persisted via `zustand/middleware/persist`)
 - **Database**: SQLite via `rusqlite` (bundled) — stores profiles, workspaces, session history
 - **PTY**: `portable-pty` crate for spawning Claude Code processes
-- **Notifications**: `notify-rust` crate for Windows desktop notifications
+- **Notifications**: `notify-rust` crate for native desktop notifications (Windows Toast and macOS NSUserNotification)
 - **Auto-updates**: `tauri-plugin-updater` with signed releases from GitHub
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/platform-Windows-blue?style=flat-square" alt="Platform">
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS-blue?style=flat-square" alt="Platform">
   <img src="https://img.shields.io/badge/version-1.21.1-green?style=flat-square" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-orange?style=flat-square" alt="License">
   <img src="https://img.shields.io/badge/Tauri-2.x-purple?style=flat-square" alt="Tauri">
@@ -29,7 +29,7 @@
 
 ## Overview
 
-**ClaudeTerminal** is a sleek, modern Windows desktop application designed to help developers manage multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) terminal instances from a unified interface. Built with Tauri and React, it provides a powerful workspace for running parallel Claude Code sessions with custom configurations, real-time monitoring, and intelligent command assistance.
+**ClaudeTerminal** is a sleek, modern cross-platform desktop application (Windows and macOS) designed to help developers manage multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) terminal instances from a unified interface. Built with Tauri and React, it provides a powerful workspace for running parallel Claude Code sessions with custom configurations, real-time monitoring, and intelligent command assistance.
 
 ## Screenshots
 
@@ -124,12 +124,16 @@ Before installing ClaudeTerminal, ensure you have:
 
 ### Download
 
-Download the latest release for Windows from the [Releases page](https://github.com/talayash/claude-terminal/releases/latest):
+Download the latest release for your platform from the [Releases page](https://github.com/talayash/claude-terminal/releases/latest):
 
-| Installer Type | Description |
-|---------------|-------------|
-| [ClaudeTerminal_1.21.1_x64-setup.exe](https://github.com/talayash/claude-terminal/releases/latest/download/ClaudeTerminal_1.21.1_x64-setup.exe) | NSIS Installer (Recommended) |
-| [ClaudeTerminal_1.21.1_x64_en-US.msi](https://github.com/talayash/claude-terminal/releases/latest/download/ClaudeTerminal_1.21.1_x64_en-US.msi) | MSI Installer |
+| Platform | Installer | Description |
+|---|---|---|
+| Windows | [ClaudeTerminal_1.21.1_x64-setup.exe](https://github.com/talayash/claude-terminal/releases/latest/download/ClaudeTerminal_1.21.1_x64-setup.exe) | NSIS Installer (Recommended) |
+| Windows | [ClaudeTerminal_1.21.1_x64_en-US.msi](https://github.com/talayash/claude-terminal/releases/latest/download/ClaudeTerminal_1.21.1_x64_en-US.msi) | MSI Installer |
+| macOS (Apple Silicon) | `ClaudeTerminal_1.21.1_aarch64.dmg` | DMG for M1/M2/M3/M4 Macs |
+| macOS (Intel) | `ClaudeTerminal_1.21.1_x64.dmg` | DMG for Intel Macs |
+
+> macOS builds are currently not code-signed/notarized — first launch will require right-click → Open or approval in System Settings → Privacy & Security.
 
 ### First Launch
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-terminal",
   "version": "1.21.1",
-  "description": "Modern Windows desktop application for managing multiple Claude Code terminal instances",
+  "description": "Modern cross-platform (Windows and macOS) desktop application for managing multiple Claude Code terminal instances",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Updates docs to reflect that ClaudeTerminal is a cross-platform app, not Windows-only.

- `CLAUDE.md`, `README.md`, `package.json` description: "Windows desktop application" → "cross-platform (Windows and macOS)"
- README installer table: adds macOS Apple Silicon + Intel DMG rows
- README: notes macOS builds are unsigned (right-click → Open on first launch)
- CLAUDE.md: clarifies that `notify-rust` handles native notifications on both Windows Toast and macOS NSUserNotification

No code or CI changes — pure documentation. macOS builds continue to ship unsigned as before.

## Test plan
- [ ] Visual check of README rendering on GitHub