### PR TITLE
fix(profile-modal): stack above New Terminal modal

### DIFF
--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -112,7 +112,7 @@ export function ProfileModal() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.15 }}
-      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50"
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[60]"
       onDoubleClick={closeProfileModal}
     >
       <motion.div


### PR DESCRIPTION
## Summary
- Raise the `ProfileModal` overlay z-index from `z-50` to `z-[60]` so it stacks above `NewTerminalModal` (`z-50`).
- Clicking **Add Profile** from the New Terminal screen now opens the editor on top; New Terminal stays mounted underneath and reloads its profile list when the editor closes (existing behavior via `prevProfileModalOpen` effect in `NewTerminalModal.tsx`).

## Test plan
- [ ] Open **New Terminal** modal
- [ ] Click **+ Add Profile** — Configuration Profiles modal appears on top of New Terminal
- [ ] Create / edit a profile, close the editor — newly created profile shows up in the New Terminal profile grid without reopening
- [ ] Double-click the Profile modal backdrop closes only the Profile modal; New Terminal remains open

🤖 Generated with [Claude Code](https://claude.com/claude-code)