### PR TITLE
feat: /errors slash command + ct-analytics errors endpoint

### DIFF
--- a/.claude/commands/errors.md
+++ b/.claude/commands/errors.md
@@ -1,0 +1,123 @@
+# Retrieve end-user error reports from ct-analytics
+
+You are pulling end-user error/exception reports stored by the `ct-analytics` Cloudflare Worker (D1 table `errors`) and writing a human-readable summary inline. Errors are populated by `POST /error_report` from three sources: `rust_panic`, `rust_command`, `frontend`. Retention is 90 days.
+
+## Arguments
+
+`$ARGUMENTS` — Window in days (e.g. `1`, `7`, `30`). Plain integer or with trailing `d` (e.g. `7d`). Defaults to **7** if empty. Clamped to [1, 90].
+
+## Step 1: Resolve the window
+
+1. Parse `$ARGUMENTS`. Strip a trailing `d` if present. Coerce to integer. If empty or invalid, use `7`.
+2. Clamp to [1, 90].
+3. Tell the user the resolved window (e.g. "Pulling errors for the last 7 days...").
+
+## Step 2: Try the Worker endpoint first (preferred)
+
+1. Resolve the stats token, in this order:
+   - `$env:CT_STATS_TOKEN` if set
+   - Otherwise, retrieve `STATS_TOKEN` from your auto-memory at `ct_analytics_tokens.md` (memory type `reference`, slug `ct-analytics-tokens`). Do **not** print the token to the user or include it in any saved file.
+2. If a token is available, call:
+   ```
+   GET https://ct-analytics.claude-terminal.workers.dev/errors/summary?days={N}&limit=20
+   Header: x-ct-token: {STATS_TOKEN}
+   ```
+   On Windows PowerShell, use `Invoke-RestMethod` with `-Headers @{ 'x-ct-token' = $token }` and capture to a variable; do **not** echo the token.
+3. If the request returns HTTP 200 with JSON, parse it and skip to Step 4.
+4. If the request returns 404 (endpoint not deployed yet), tell the user the Worker needs a one-time deploy and offer to run it:
+   ```
+   Run from workers/ct-analytics/: npx wrangler deploy
+   ```
+   Ask before running. If they decline, fall through to Step 3.
+5. If the request fails for any other reason (no token, non-2xx, network error), fall through to Step 3.
+
+## Step 3: Fallback — query D1 directly via wrangler
+
+Run wrangler from `workers/ct-analytics/` against the production D1 (`--remote`). Use `--json` so the output is parseable. Run all queries; capture stdout per query.
+
+The five queries (replace `{SINCE}` with `'-{N} days'`):
+
+```sql
+-- totals
+SELECT COUNT(*) AS total,
+       COUNT(DISTINCT installation_id) AS affected_installations,
+       COUNT(DISTINCT fingerprint) AS unique_fingerprints
+FROM errors WHERE ts >= datetime('now', {SINCE});
+
+-- top groups
+SELECT fingerprint, COUNT(*) AS occurrences,
+       COUNT(DISTINCT installation_id) AS users,
+       MAX(ts) AS last_seen, MIN(ts) AS first_seen,
+       MAX(source) AS source, MAX(kind) AS kind,
+       MAX(message) AS message, MAX(stack) AS stack,
+       GROUP_CONCAT(DISTINCT app_version) AS versions
+FROM errors WHERE ts >= datetime('now', {SINCE})
+GROUP BY fingerprint ORDER BY occurrences DESC LIMIT 20;
+
+-- by source
+SELECT source, COUNT(*) AS count FROM errors
+WHERE ts >= datetime('now', {SINCE}) GROUP BY source ORDER BY count DESC;
+
+-- by version
+SELECT app_version AS version, COUNT(*) AS count FROM errors
+WHERE ts >= datetime('now', {SINCE}) GROUP BY app_version ORDER BY count DESC;
+
+-- by os
+SELECT os, COUNT(*) AS count FROM errors
+WHERE ts >= datetime('now', {SINCE}) GROUP BY os ORDER BY count DESC;
+```
+
+Invocation pattern (single line; queries can be `;`-separated in a single `--command` call, but it's cleaner to run one query per invocation and `--json` each result):
+
+```
+npx wrangler d1 execute ct-analytics-db --remote --json --command "<query>"
+```
+
+If wrangler is not authenticated, it will fail with an auth error — tell the user to run `npx wrangler login` and abort.
+
+## Step 4: Format and print the summary inline
+
+Print **only** to chat (no files written). Use this structure:
+
+```
+## Error report — last {N} days  (as of {generated_at})
+
+**Totals**: {total_errors} events from {affected_installations} installations across {unique_fingerprints} unique fingerprints.
+
+**By source**: rust_panic={c}, rust_command={c}, frontend={c}
+**By version**: 1.21.0={c}, 1.20.5={c}, ...   (top 5)
+**By OS**: windows={c}, ...
+**Daily volume**: {date}={c}, ... (or sparkline if many days)
+
+### Top issues
+
+1. **[source] [kind]** — {occurrences} events, {users} users, versions={versions}
+   First seen: {first_seen}  Last seen: {last_seen}
+   Fingerprint: `{fingerprint}`
+   Message: {message}
+   Stack (first 6 lines, indented):
+       {stack lines}
+
+2. ...
+```
+
+Show up to 10 top issues by default (the Worker returns 20; trim for display). Truncate each message to ~200 chars and each stack to first 6 non-empty lines. If `kind` is null, omit it.
+
+## Step 5: Write the human summary
+
+After the structured listing, add a `### Summary` section in prose (3–6 sentences). It must:
+
+- Call out the single highest-impact issue (most users affected, not just most occurrences).
+- Note any version that is over-represented vs. its share of DAU (suggests a regression introduced in that version).
+- Note any source that dominates (e.g., "Most errors come from `rust_panic` — likely a single recurring crash" vs. "Spread across all three sources").
+- If a fingerprint appears only in one specific version, flag it as likely-introduced-in-that-version.
+- If totals are zero or trivially low (<5), say so plainly and don't fabricate analysis.
+
+End with **one** concrete next step the user might take (e.g., "Reproduce fingerprint `abc123` on 1.21.0 against the `terminal.rs` PTY reader — message references that file").
+
+## Notes
+
+- Never print or save the `STATS_TOKEN` value.
+- Do not write any report file — output is inline only.
+- The Worker endpoint must be deployed at least once before HTTPS path works. If `/errors/summary` 404s on production but exists in the code, run `npx wrangler deploy` from `workers/ct-analytics/`.
+- If the user passes anything that looks like a version (e.g. `since-v1.21.0`), tell them this command only supports day windows and ask them to use a day count instead.

--- a/workers/ct-analytics/src/index.ts
+++ b/workers/ct-analytics/src/index.ts
@@ -17,6 +17,7 @@
  *   GET  /stats                  legacy dashboard payload (back-compat)
  *   GET  /stats/live             active in last 15 min, by version/os/country
  *   GET  /stats/history?days=30&metric=dau|heartbeats|update_checks|version|os|country
+ *   GET  /errors/summary?days=7&limit=20   top error groups + by source/version/os/day
  */
 
 interface Env {
@@ -381,6 +382,77 @@ async function handleStatsLive(env: Env): Promise<Response> {
   );
 }
 
+async function handleErrorsSummary(url: URL, env: Env): Promise<Response> {
+  const days = Math.min(
+    Math.max(parseInt(url.searchParams.get('days') ?? '7', 10) || 7, 1),
+    ERROR_RETENTION_DAYS,
+  );
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '20', 10) || 20, 1), 100);
+  const since = `-${days} days`;
+
+  const [totals, groupsRes, bySourceRes, byVersionRes, byOsRes, byDayRes] = await Promise.all([
+    env.DB.prepare(
+      "SELECT COUNT(*) AS total, COUNT(DISTINCT installation_id) AS affected_installations, COUNT(DISTINCT fingerprint) AS unique_fingerprints FROM errors WHERE ts >= datetime('now', ?)",
+    )
+      .bind(since)
+      .first<{ total: number; affected_installations: number; unique_fingerprints: number }>(),
+    env.DB.prepare(
+      "SELECT fingerprint, COUNT(*) AS occurrences, COUNT(DISTINCT installation_id) AS users, " +
+        'MAX(ts) AS last_seen, MIN(ts) AS first_seen, ' +
+        'MAX(source) AS source, MAX(kind) AS kind, MAX(message) AS message, MAX(stack) AS stack, ' +
+        'GROUP_CONCAT(DISTINCT app_version) AS versions ' +
+        "FROM errors WHERE ts >= datetime('now', ?) " +
+        'GROUP BY fingerprint ORDER BY occurrences DESC LIMIT ?',
+    )
+      .bind(since, limit)
+      .all<{
+        fingerprint: string;
+        occurrences: number;
+        users: number;
+        last_seen: string;
+        first_seen: string;
+        source: string;
+        kind: string | null;
+        message: string;
+        stack: string | null;
+        versions: string;
+      }>(),
+    env.DB.prepare(
+      "SELECT source, COUNT(*) AS count FROM errors WHERE ts >= datetime('now', ?) GROUP BY source ORDER BY count DESC",
+    )
+      .bind(since)
+      .all<{ source: string; count: number }>(),
+    env.DB.prepare(
+      "SELECT app_version AS version, COUNT(*) AS count FROM errors WHERE ts >= datetime('now', ?) GROUP BY app_version ORDER BY count DESC",
+    )
+      .bind(since)
+      .all<{ version: string; count: number }>(),
+    env.DB.prepare(
+      "SELECT os, COUNT(*) AS count FROM errors WHERE ts >= datetime('now', ?) GROUP BY os ORDER BY count DESC",
+    )
+      .bind(since)
+      .all<{ os: string; count: number }>(),
+    env.DB.prepare(
+      "SELECT substr(ts, 1, 10) AS date, COUNT(*) AS count FROM errors WHERE ts >= datetime('now', ?) GROUP BY substr(ts, 1, 10) ORDER BY date",
+    )
+      .bind(since)
+      .all<{ date: string; count: number }>(),
+  ]);
+
+  return json({
+    window_days: days,
+    generated_at: new Date().toISOString(),
+    total_errors: totals?.total ?? 0,
+    affected_installations: totals?.affected_installations ?? 0,
+    unique_fingerprints: totals?.unique_fingerprints ?? 0,
+    top_groups: groupsRes.results ?? [],
+    by_source: bySourceRes.results ?? [],
+    by_version: byVersionRes.results ?? [],
+    by_os: byOsRes.results ?? [],
+    by_day: byDayRes.results ?? [],
+  });
+}
+
 async function handleStatsHistory(url: URL, env: Env): Promise<Response> {
   const days = Math.min(Math.max(parseInt(url.searchParams.get('days') ?? '30', 10) || 30, 1), MAX_HISTORY_DAYS);
   const metric = url.searchParams.get('metric') ?? 'dau';
@@ -463,6 +535,11 @@ export default {
         const denied = requireToken(request, env.STATS_TOKEN);
         if (denied) return denied;
         return await handleStatsHistory(url, env);
+      }
+      if (request.method === 'GET' && url.pathname === '/errors/summary') {
+        const denied = requireToken(request, env.STATS_TOKEN);
+        if (denied) return denied;
+        return await handleErrorsSummary(url, env);
       }
     } catch (err) {
       console.error('[fetch] unhandled error:', err);


### PR DESCRIPTION
## Summary

- New `/errors [days]` slash command (`.claude/commands/errors.md`) — pulls end-user error/exception reports from the ct-analytics D1 `errors` table and writes an inline summary (top groups, breakdowns by source/version/os/day, prose analysis). Default 7-day window, accepts 1-90.
- New `GET /errors/summary?days=N&limit=20` route on the ct-analytics Worker (`workers/ct-analytics/src/index.ts`), STATS_TOKEN-gated. Returns totals, top groups (with sample message/stack/versions), and by_source/by_version/by_os/by_day breakdowns.
- Worker is already deployed to production (`https://ct-analytics.claude-terminal.workers.dev`) — endpoint verified live.

The command tries the Worker endpoint first (using `$env:CT_STATS_TOKEN` or the developer-side token), and falls back to `wrangler d1 execute --remote` if HTTPS fails. The token is never printed or written to files.

## Test plan

- [x] `npx tsc --noEmit` clean in `workers/ct-analytics/`
- [x] `npx wrangler deploy` successful — endpoint live
- [x] `GET /errors/summary?days=7&limit=3` returns valid JSON with real error data
- [ ] Run `/errors` (7d default) — confirm inline summary format
- [ ] Run `/errors 30` — confirm window override works
- [ ] Run `/errors` with `$env:CT_STATS_TOKEN` unset — confirm fallback to wrangler path

🤖 Generated with [Claude Code](https://claude.com/claude-code)