### PR TITLE
feat(session-restore): resume Claude conversations instead of replaying logs

### DIFF
--- a/src-tauri/src/claude_session.rs
+++ b/src-tauri/src/claude_session.rs
@@ -1,0 +1,110 @@
+//! Detect the Claude Code session id assigned to a freshly-spawned terminal.
+//!
+//! Claude Code writes each conversation to `~/.claude/projects/<encoded-cwd>/
+//! <session-uuid>.jsonl` (cwd encoded by replacing `\`, `/`, and `:` with
+//! `-`). We snapshot the existing files before spawn and then poll for new
+//! ones afterwards; the new file's stem is the session id we need to pass to
+//! `claude --resume <id>` next time the terminal is restored.
+//!
+//! Snapshotting globally (across all project dirs) rather than just our cwd
+//! dir means we still work the first time Claude is run in a new project —
+//! the encoded dir may not exist yet when we take the snapshot.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn claude_projects_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|d| d.home_dir().join(".claude").join("projects"))
+}
+
+/// Encode a working-directory path the way Claude Code names its project
+/// subdirectory. Empirically observed: `\`, `/`, `:`, and spaces all become
+/// `-` (so `C:\Dev\AlefBar - Kornish` becomes `C--Dev-AlefBar---Kornish`).
+/// Every other character is preserved.
+fn encode_cwd(cwd: &str) -> String {
+    cwd.chars()
+        .map(|c| if matches!(c, '\\' | '/' | ':' | ' ') { '-' } else { c })
+        .collect()
+}
+
+/// Set of every `.jsonl` session file currently on disk. Take this *before*
+/// spawning Claude so the diff afterwards isolates the new session.
+pub fn snapshot_session_files() -> HashSet<PathBuf> {
+    let mut out = HashSet::new();
+    let Some(root) = claude_projects_dir() else { return out };
+    let Ok(entries) = std::fs::read_dir(&root) else { return out };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Ok(files) = std::fs::read_dir(&dir) else { continue };
+        for f in files.flatten() {
+            let path = f.path();
+            if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+                out.insert(path);
+            }
+        }
+    }
+    out
+}
+
+/// Look inside the project dir for `cwd` for a `.jsonl` file that wasn't in
+/// `snapshot`. Returns the UUID stem of the newest such file. Returns `None`
+/// if the project dir doesn't exist yet, has no new files, or its entries
+/// can't be read.
+pub fn find_new_session_for_cwd(
+    snapshot: &HashSet<PathBuf>,
+    cwd: &str,
+) -> Option<String> {
+    let root = claude_projects_dir()?;
+    let dir = root.join(encode_cwd(cwd));
+    let entries = std::fs::read_dir(&dir).ok()?;
+    let mut newest: Option<(String, std::time::SystemTime)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+            continue;
+        }
+        if snapshot.contains(&path) {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+        let mtime = entry.metadata().and_then(|m| m.modified()).ok();
+        if let Some(t) = mtime {
+            if newest.as_ref().map(|(_, n)| t > *n).unwrap_or(true) {
+                newest = Some((stem.to_string(), t));
+            }
+        }
+    }
+    newest.map(|(stem, _)| stem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_windows_path() {
+        assert_eq!(encode_cwd(r"C:\Dev\Arik\claude-terminal"), "C--Dev-Arik-claude-terminal");
+    }
+
+    #[test]
+    fn encodes_unix_path() {
+        assert_eq!(encode_cwd("/Users/x/projects/foo"), "-Users-x-projects-foo");
+    }
+
+    #[test]
+    fn preserves_dashes_and_dots() {
+        assert_eq!(encode_cwd("/a/b-c.d"), "-a-b-c.d");
+    }
+
+    #[test]
+    fn encodes_spaces_around_dash() {
+        // C:\Dev\AlefBar - Kornish → C--Dev-AlefBar---Kornish
+        assert_eq!(
+            encode_cwd(r"C:\Dev\AlefBar - Kornish"),
+            "C--Dev-AlefBar---Kornish"
+        );
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -224,6 +224,16 @@ pub struct CreateTerminalRequest {
     pub env_vars: HashMap<String, String>,
     pub color_tag: Option<String>,
     pub nickname: Option<String>,
+    /// When set, the spawned `claude` is launched with `--resume <id>` to
+    /// re-attach the conversation exactly. The frontend supplies this from
+    /// the saved session-restore row when we previously captured an id.
+    #[serde(default)]
+    pub resume_session_id: Option<String>,
+    /// When true (and `resume_session_id` is unset), spawn with `--continue`
+    /// so Claude attaches to the most recent session in this cwd. Used as
+    /// the restore fallback for saves predating session-id capture.
+    #[serde(default)]
+    pub continue_recent: bool,
 }
 
 #[command]
@@ -251,6 +261,14 @@ pub async fn create_terminal(
             logs_dir.join(filename).to_string_lossy().to_string()
         };
 
+        // Snapshot Claude's project dir *before* spawning so we can later
+        // diff for the new session file. Cheap (a few dozen file paths) and
+        // synchronous — must happen before the PTY starts the claude process.
+        let session_snapshot = crate::claude_session::snapshot_session_files();
+        let resume_id = request.resume_session_id.clone();
+        let continue_recent = request.continue_recent && resume_id.is_none();
+        let working_directory = request.working_directory.clone();
+
         let config = {
             let mut terminals = state.terminals.lock().await;
             terminals.create_terminal(
@@ -262,8 +280,62 @@ pub async fn create_terminal(
                 request.nickname,
                 tx,
                 Some(log_path.clone()),
+                request.resume_session_id,
+                continue_recent,
             )?
         };
+
+        // Detect the session id Claude assigned to this terminal. We don't
+        // know when the user will send their first message (Claude only
+        // writes the .jsonl after a user turn), so the watcher runs for the
+        // full lifetime of the terminal and keeps overwriting the captured
+        // id whenever a newer .jsonl appears in the same cwd dir. That way
+        // `/clear` (which rotates the session id) is handled transparently.
+        if let Some(id) = resume_id.as_deref() {
+            eprintln!("[session-resume] spawning '{}' with --resume {}", config.label, id);
+        } else if continue_recent {
+            eprintln!("[session-resume] spawning '{}' with --continue", config.label);
+            // No detection task: `--continue` means we're attaching to the
+            // newest existing session in this cwd, so any pre-existing .jsonl
+            // would *appear* new to our snapshot. The captured id from the
+            // first user turn on the next save will still be correct for the
+            // restored conversation, so we let the watcher run on the next
+            // spawn rather than try to figure out which file we're attached
+            // to from outside.
+        } else {
+            let manager = state.terminals.clone();
+            let detect_id = config.id.clone();
+            let detect_label = config.label.clone();
+            let cwd_for_log = working_directory.clone();
+            tokio::spawn(async move {
+                let mut last_recorded: Option<String> = None;
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    // Stop watching once the terminal is gone — both saves
+                    // CPU and avoids racing close_terminal.
+                    {
+                        let m = manager.lock().await;
+                        if !m.terminals.contains_key(&detect_id) {
+                            return;
+                        }
+                    }
+                    if let Some(session_id) = crate::claude_session::find_new_session_for_cwd(
+                        &session_snapshot,
+                        &cwd_for_log,
+                    ) {
+                        if last_recorded.as_deref() != Some(&session_id) {
+                            eprintln!(
+                                "[session-detect] '{}' bound to session {} (cwd={})",
+                                detect_label, session_id, cwd_for_log
+                            );
+                            let mut m = manager.lock().await;
+                            m.update_claude_session_id(&detect_id, session_id.clone());
+                            last_recorded = Some(session_id);
+                        }
+                    }
+                }
+            });
+        }
 
         // Insert session history entry
         {
@@ -1082,7 +1154,16 @@ pub async fn get_last_session(
 ) -> Result<Option<Vec<crate::terminal::TerminalConfig>>, String> {
     wrap_cmd("get_last_session", async move {
         let db = state.db.lock().await;
-        db.load_last_session()
+        let configs = db.load_last_session()?;
+        if let Some(ref cs) = configs {
+            for c in cs {
+                eprintln!(
+                    "[session-restore] '{}' has claude_session_id = {:?}",
+                    c.label, c.claude_session_id
+                );
+            }
+        }
+        Ok(configs)
     })
     .await
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -450,6 +450,7 @@ mod tests {
             created_at: Utc::now() + Duration::seconds(offset_secs),
             status: TerminalStatus::Running,
             color_tag: None,
+            claude_session_id: None,
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod database;
 mod telemetry;
 mod error_reporter;
 mod claude_path;
+mod claude_session;
 mod pastes;
 mod changelists;
 

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -19,6 +19,12 @@ pub struct TerminalConfig {
     pub created_at: DateTime<Utc>,
     pub status: TerminalStatus,
     pub color_tag: Option<String>,
+    /// UUID of the Claude Code session this terminal is bound to, if we were
+    /// able to detect it after spawn. Persisted with the session-restore row
+    /// so the next launch can re-attach the conversation via `--resume <id>`.
+    /// `serde(default)` keeps existing rows from older builds deserializable.
+    #[serde(default)]
+    pub claude_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -74,6 +80,8 @@ impl TerminalManager {
         nickname: Option<String>,
         tx: mpsc::Sender<(String, Vec<u8>)>,
         log_file_path: Option<String>,
+        resume_session_id: Option<String>,
+        continue_recent: bool,
     ) -> Result<TerminalConfig, String> {
         // Validate claude_args: reject any argument containing shell metacharacters
         for arg in &claude_args {
@@ -84,6 +92,33 @@ impl TerminalManager {
                 ));
             }
         }
+
+        // Inject a resume flag for spawn-only — `claude_args` persisted on
+        // the config stays untouched so the next restore can re-decide which
+        // flag to inject.
+        // `--resume <id>` wins over `--continue` when we have an exact id;
+        // both are exclusive of plain (no-flag) spawn.
+        // The session id is a UUID Claude generates, but we still run it
+        // through the metacharacter check as defense-in-depth.
+        let injected: Vec<String> = if let Some(id) = resume_session_id.as_deref() {
+            if id.contains(Self::SHELL_METACHARACTERS) {
+                return Err("Invalid session id".to_string());
+            }
+            vec!["--resume".to_string(), id.to_string()]
+        } else if continue_recent {
+            vec!["--continue".to_string()]
+        } else {
+            vec![]
+        };
+        let injected_len = injected.len();
+        let claude_args: Vec<String> = if injected_len > 0 {
+            let mut v = Vec::with_capacity(claude_args.len() + injected_len);
+            v.extend(injected);
+            v.extend(claude_args);
+            v
+        } else {
+            claude_args
+        };
 
         // Filter out blocked environment variables
         let safe_env_vars: HashMap<String, String> = env_vars
@@ -178,11 +213,18 @@ impl TerminalManager {
             nickname,
             profile_id: None,
             working_directory,
-            claude_args,
+            // Persist the *user-facing* args (without our injected resume
+            // flags) so the next restore is free to re-decide.
+            claude_args: if injected_len > 0 {
+                claude_args.iter().skip(injected_len).cloned().collect()
+            } else {
+                claude_args.clone()
+            },
             env_vars: safe_env_vars,
             created_at: Utc::now(),
             status: TerminalStatus::Running,
             color_tag,
+            claude_session_id: resume_session_id,
         };
 
         let mut reader = pty_pair.master.try_clone_reader()
@@ -327,6 +369,7 @@ impl TerminalManager {
             created_at: Utc::now(),
             status: TerminalStatus::Running,
             color_tag: None,
+            claude_session_id: None,
         };
 
         let mut reader = pty_pair.master.try_clone_reader()
@@ -435,6 +478,7 @@ impl TerminalManager {
             created_at: Utc::now(),
             status: TerminalStatus::Running,
             color_tag: None,
+            claude_session_id: None,
         };
 
         let mut reader = pty_pair.master.try_clone_reader()
@@ -552,6 +596,15 @@ impl TerminalManager {
             Ok(())
         } else {
             Err("Terminal not found".to_string())
+        }
+    }
+
+    /// Attach the detected Claude session id to a live terminal. Silent
+    /// no-op when the terminal has already been closed — detection races
+    /// the user, and a stale write here shouldn't surface as an error.
+    pub fn update_claude_session_id(&mut self, id: &str, session_id: String) {
+        if let Some(terminal) = self.terminals.get_mut(id) {
+            terminal.config.claude_session_id = Some(session_id);
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,7 @@ interface SavedTerminalConfig {
   claude_args: string[];
   env_vars: Record<string, string>;
   color_tag: string | null;
+  claude_session_id?: string | null;
 }
 
 function App() {
@@ -314,6 +315,15 @@ function App() {
           // Script runner — owned by parent terminal, skip on restore.
           continue;
         } else {
+          // Restore semantics:
+          //   - If we captured a session id last run: `claude --resume <id>` —
+          //     exact attach. Claude redraws the conversation; we suppress the
+          //     painted log so the transcript isn't doubled.
+          //   - Otherwise (old save, or detection never fired): fall back to
+          //     `claude --continue` — attaches to the most recent session in
+          //     this cwd. Same suppression rule.
+          const sessionId = config.claude_session_id ?? undefined;
+          const willResume = sessionId !== undefined;
           await createTerminal(
             config.label,
             config.working_directory,
@@ -321,7 +331,9 @@ function App() {
             config.env_vars,
             config.color_tag ?? undefined,
             config.nickname ?? undefined,
-            logs[i] ?? undefined
+            willResume ? undefined : (logs[i] ?? undefined),
+            sessionId,
+            !willResume,  // continue_recent: fall back to --continue
           );
         }
       } catch (err) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -349,6 +349,7 @@ interface SavedTerminalConfig {
   claude_args: string[];
   env_vars: Record<string, string>;
   color_tag: string | null;
+  claude_session_id?: string | null;
 }
 
 // Helper to determine optimal layout based on terminal count

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -20,6 +20,11 @@ export interface TerminalConfig {
   created_at: string;
   status: 'Running' | 'Idle' | 'Error' | 'Stopped';
   color_tag: string | null;
+  /** UUID of the Claude Code conversation this terminal is bound to. Populated
+   *  by the backend a few seconds after spawn (snapshot/diff of
+   *  ~/.claude/projects/<encoded-cwd>/*.jsonl) and used by session restore to
+   *  re-attach via `claude --resume <id>`. */
+  claude_session_id?: string | null;
 }
 
 export interface LoopInfo {
@@ -63,7 +68,9 @@ interface TerminalState {
     envVars: Record<string, string>,
     colorTag?: string,
     nickname?: string,
-    restoredOutput?: string
+    restoredOutput?: string,
+    resumeSessionId?: string,
+    continueRecent?: boolean,
   ) => Promise<string>;
   createShellTerminalTab: (
     label: string,
@@ -111,7 +118,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   bottomTerminalIds: [],
   activeBottomTerminalId: null,
 
-  createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput) => {
+  createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput, resumeSessionId, continueRecent) => {
     try {
       const config = await invoke<TerminalConfig>('create_terminal', {
         request: {
@@ -121,6 +128,8 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           env_vars: envVars,
           color_tag: colorTag || null,
           nickname: nickname || null,
+          resume_session_id: resumeSessionId || null,
+          continue_recent: !!continueRecent,
         },
       });
       // Parse model, effort, worktree from claude_args


### PR DESCRIPTION
## Summary
Until now, "Restore last session" respawned each terminal in the right cwd but with a fresh `claude` process, then painted our captured PTY log on top — visually similar to the old transcript, but Claude had no memory. The user saw a wall of text and a Claude that couldn't remember any of it.

This makes restore actually reattach Claude to the previous conversation:

- **For terminals saved by this build** — capture the Claude session id from `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` while the terminal is alive. The watcher snapshots the projects tree before spawn and polls every 2s for the lifetime of the terminal, so slow first-turns and `/clear` (which rotates the id) are both handled. The id is persisted on the saved-session row.
- **On restore** — `claude --resume <id>` re-attaches exactly. For older saves with no captured id, fall back to `claude --continue` (most recent session in the cwd). Painted PTY log is suppressed in both cases — Claude redraws the conversation itself.
- **Schema** — `TerminalConfig.claude_session_id` is `serde(default)`, so old saved rows deserialize as `None`. No migration.
- **Path encoding** — handles the Windows surprises: `\`, `/`, `:`, **and spaces** all become `-` (e.g. `C:\Dev\AlefBar - Kornish` → `C--Dev-AlefBar---Kornish`). Unit tests cover the encoder.
- **Debug logs** — `[session-detect]`, `[session-restore]`, `[session-resume]` printed on stderr; invisible in release builds (`windows_subsystem = "windows"`) but valuable during `tauri dev` if a user reports an issue.

## Test plan
- [x] Verified on a fresh restore: 5 Claude terminals resumed their conversations, `npm run start` script terminal correctly skipped
- [ ] Open a fresh terminal, send Claude a message, wait ~30s, close+reopen → `[session-detect]` followed by `[session-resume] --resume <uuid>` on next restore
- [ ] `/clear` mid-session, send another message, restore → resumes the post-`/clear` conversation
- [ ] Path with spaces (e.g. `C:\Dev\AlefBar - Kornish`) resolves correctly to the encoded project dir
- [ ] Old saved row (no captured id) → `[session-resume] --continue`, Claude redraws

🤖 Generated with [Claude Code](https://claude.com/claude-code)