### PR TITLE
feat(sessions): browse + resume past Claude conversations from the sidebar

### DIFF
--- a/src-tauri/src/claude_session.rs
+++ b/src-tauri/src/claude_session.rs
@@ -10,11 +10,26 @@
 //! dir means we still work the first time Claude is run in a new project —
 //! the encoded dir may not exist yet when we take the snapshot.
 
+use serde::Serialize;
 use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 fn claude_projects_dir() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|d| d.home_dir().join(".claude").join("projects"))
+}
+
+/// Summary of one session for the sidebar list. We keep this small —
+/// timestamps and a preview are enough for the user to pick the right
+/// conversation. Full content is loaded on demand when the user resumes.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaudeSessionInfo {
+    pub id: String,
+    pub modified_at: String,
+    /// Excerpt of the first user message in the conversation; `None` if we
+    /// couldn't find one in the first few JSONL lines (e.g. empty file or
+    /// a format we don't recognise).
+    pub preview: Option<String>,
 }
 
 /// Encode a working-directory path the way Claude Code names its project
@@ -78,6 +93,74 @@ pub fn find_new_session_for_cwd(
         }
     }
     newest.map(|(stem, _)| stem)
+}
+
+/// Read the first few lines of a session JSONL and extract a short excerpt
+/// from the first user message. Returns `None` if no user message is found
+/// in the scanned window. Defensive across the two content shapes Claude
+/// uses (string vs list of content blocks).
+fn read_first_user_preview(path: &std::path::Path, max_lines: usize, max_chars: usize) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().take(max_lines).flatten() {
+        let v: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Each entry has a "type" tag. We only care about user turns.
+        if v.get("type").and_then(|t| t.as_str()) != Some("user") {
+            continue;
+        }
+        let msg = v.get("message")?;
+        let content = msg.get("content")?;
+        // Two shapes: a plain string, or an array of content blocks where
+        // each block has a `text` field for text parts. Take the first text
+        // we can find.
+        let text: Option<String> = match content {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Array(parts) => parts
+                .iter()
+                .find_map(|p| p.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())),
+            _ => None,
+        };
+        let mut t = text?;
+        // Collapse whitespace + truncate so the sidebar row stays compact.
+        t = t.split_whitespace().collect::<Vec<_>>().join(" ");
+        if t.chars().count() > max_chars {
+            t = t.chars().take(max_chars).collect::<String>() + "…";
+        }
+        if t.is_empty() {
+            return None;
+        }
+        return Some(t);
+    }
+    None
+}
+
+/// List every `.jsonl` session file Claude has stored for the given cwd,
+/// sorted newest-first. Returns an empty list when the project dir doesn't
+/// exist yet — first-run in a new folder is a normal state.
+pub fn list_sessions_for_cwd(cwd: &str) -> Vec<ClaudeSessionInfo> {
+    let mut out: Vec<(ClaudeSessionInfo, std::time::SystemTime)> = Vec::new();
+    let Some(root) = claude_projects_dir() else { return Vec::new() };
+    let dir = root.join(encode_cwd(cwd));
+    let Ok(entries) = std::fs::read_dir(&dir) else { return Vec::new() };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+            let Ok(meta) = entry.metadata() else { continue };
+            let Ok(modified) = meta.modified() else { continue };
+            let modified_at = chrono::DateTime::<chrono::Utc>::from(modified).to_rfc3339();
+            let preview = read_first_user_preview(&path, 20, 120);
+            out.push((
+                ClaudeSessionInfo { id: stem.to_string(), modified_at, preview },
+                modified,
+            ));
+        }
+    }
+    out.sort_by(|a, b| b.1.cmp(&a.1));
+    out.into_iter().map(|(info, _)| info).collect()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -870,6 +870,22 @@ pub async fn open_external_url(url: String) -> Result<(), String> {
     .await
 }
 
+/// List Claude session `.jsonl` files for a given cwd. Returns newest-first;
+/// each entry has the session id (UUID stem), file mtime, and a short
+/// excerpt of the first user message for previewing in the sidebar.
+#[command]
+pub async fn list_claude_sessions(
+    cwd: String,
+) -> Result<Vec<crate::claude_session::ClaudeSessionInfo>, String> {
+    wrap_cmd("list_claude_sessions", async move {
+        if cwd.is_empty() || cwd.contains('\0') {
+            return Err("Invalid cwd".to_string());
+        }
+        Ok(crate::claude_session::list_sessions_for_cwd(&cwd))
+    })
+    .await
+}
+
 /// Reject paths with null bytes or that resolve to a parent of themselves
 /// (basic sanity gate shared by the file-tree mutation commands).
 fn validate_path(s: &str) -> Result<(), String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
             commands::install_claude_code,
             commands::open_external_url,
             commands::reveal_in_file_manager,
+            commands::list_claude_sessions,
             commands::rename_path,
             commands::trash_path,
             commands::move_into_dir,

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -104,7 +104,11 @@ impl TerminalManager {
             if id.contains(Self::SHELL_METACHARACTERS) {
                 return Err("Invalid session id".to_string());
             }
-            vec!["--resume".to_string(), id.to_string()]
+            // `--resume` is `[value]` in Claude's help (optional argument), so
+            // Commander.js parses `--resume <id>` as "open picker" plus `<id>`
+            // as a stray positional. The `=` form is the only safe way to
+            // bind an optional argument.
+            vec![format!("--resume={}", id)]
         } else if continue_recent {
             vec!["--continue".to_string()]
         } else {

--- a/src/components/FileTreePanel.tsx
+++ b/src/components/FileTreePanel.tsx
@@ -94,6 +94,8 @@ export function FileTreePanel() {
   const openFileTab = useAppStore((s) => s.openFileTab);
   const changesRefreshTrigger = useAppStore((s) => s.changesRefreshTrigger);
   const triggerChangesRefresh = useAppStore((s) => s.triggerChangesRefresh);
+  const collapsed = useAppStore((s) => s.explorerCollapsed);
+  const toggleCollapsed = useAppStore((s) => s.toggleExplorerCollapsed);
 
   const activeCwd = useMemo(() => {
     if (!activeTerminalId) return null;
@@ -507,24 +509,35 @@ export function FileTreePanel() {
   }, [contextMenu, rootPath, clipboard, openFileTab, refreshFolder, doReveal, doPaste, doCopyPath, doCopyRelativePath]);
 
   return (
-    <div className="flex flex-col h-full min-h-0 border-t border-[var(--ij-divider-soft)]">
+    <div className="flex flex-col h-full min-h-0 overflow-hidden">
       {/* Section header */}
       <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
-        <div className="flex items-center gap-1.5 text-text-secondary">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">Explorer</span>
-        </div>
         <button
-          onClick={refreshRoot}
-          disabled={rootLoading}
-          className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
-          title="Refresh"
+          onClick={toggleCollapsed}
+          className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors"
+          title={collapsed ? 'Expand Explorer' : 'Collapse Explorer'}
         >
-          <RefreshCw size={11} className={rootLoading ? 'animate-spin' : ''} strokeWidth={1.75} />
+          {collapsed ? (
+            <ChevronRight size={11} strokeWidth={2} />
+          ) : (
+            <ChevronDown size={11} strokeWidth={2} />
+          )}
+          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">Explorer</span>
         </button>
+        {!collapsed && (
+          <button
+            onClick={refreshRoot}
+            disabled={rootLoading}
+            className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+            title="Refresh"
+          >
+            <RefreshCw size={11} className={rootLoading ? 'animate-spin' : ''} strokeWidth={1.75} />
+          </button>
+        )}
       </div>
 
       {/* Root path label */}
-      {rootPath && (
+      {!collapsed && rootPath && (
         <div
           className="px-3 pb-1 flex-shrink-0 cursor-default"
           onContextMenu={(e) => openContextMenu(e, rootPath, true)}
@@ -536,7 +549,7 @@ export function FileTreePanel() {
       )}
 
       {/* Tree content */}
-      <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
+      {!collapsed && <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
         {!rootPath && (
           <div className="px-3 py-2 text-text-tertiary text-[11px]">
             No active terminal
@@ -565,7 +578,7 @@ export function FileTreePanel() {
             onRenameCancel={() => setRenamingPath(null)}
           />
         ))}
-      </div>
+      </div>}
 
       {/* Right-click context menu */}
       {contextMenu && menuItems.length > 0 && (

--- a/src/components/SessionsPanel.tsx
+++ b/src/components/SessionsPanel.tsx
@@ -1,0 +1,410 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  ChevronRight,
+  ChevronDown,
+  RefreshCw,
+  MessageSquare,
+  ExternalLink,
+  ArrowRightCircle,
+  FolderOpen,
+} from 'lucide-react';
+import { homeDir } from '@tauri-apps/api/path';
+import { useAppStore } from '../store/appStore';
+import { useTerminalStore } from '../store/terminalStore';
+import { toast } from '../store/toastStore';
+
+const isMac = navigator.platform.toUpperCase().includes('MAC');
+const REVEAL_LABEL = isMac ? 'Reveal in Finder' : 'Show in File Explorer';
+
+interface ClaudeSessionInfo {
+  id: string;
+  modified_at: string;
+  preview: string | null;
+}
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  session: ClaudeSessionInfo;
+}
+
+function basename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('\\'), trimmed.lastIndexOf('/'));
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+/** Pick a Windows-friendly encoded folder name for `~/.claude/projects/<X>`.
+ *  Mirrors the Rust encoder (`\`, `/`, `:`, space → `-`). Used to assemble
+ *  the absolute `.jsonl` path the user can reveal in Explorer. */
+function encodeCwd(cwd: string): string {
+  return cwd.replace(/[\\/:\s]/g, '-');
+}
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const diffSec = Math.round((Date.now() - then) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function SessionsPanel() {
+  const collapsed = useAppStore((s) => s.sessionsCollapsed);
+  const toggleCollapsed = useAppStore((s) => s.toggleSessionsCollapsed);
+  const pinnedRepoPath = useAppStore((s) => s.pinnedRepoPath);
+  const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
+  const terminals = useTerminalStore((s) => s.terminals);
+  const createTerminal = useTerminalStore((s) => s.createTerminal);
+  const closeTerminal = useTerminalStore((s) => s.closeTerminal);
+
+  const activeTerminal = activeTerminalId ? terminals.get(activeTerminalId) : null;
+  const activeCwd = activeTerminal?.config.working_directory ?? null;
+  const activeSessionId = activeTerminal?.config.claude_session_id ?? null;
+
+  // The Explorer's pinned repo wins, mirroring FileTreePanel.
+  const cwd = pinnedRepoPath ?? activeCwd;
+
+  const [sessions, setSessions] = useState<ClaudeSessionInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    if (!cwd) {
+      setSessions([]);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await invoke<ClaudeSessionInfo[]>('list_claude_sessions', { cwd });
+      setSessions(data);
+    } catch (err) {
+      setError(typeof err === 'string' ? err : 'Failed to list sessions');
+      setSessions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [cwd]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    fetchSessions();
+  }, [cwd, collapsed, fetchSessions]);
+
+  // Close the context menu on outside click / Escape.
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && target.closest('[data-context-menu="sessions"]')) return;
+      setContextMenu(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null);
+    };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [contextMenu]);
+
+  const openInNewTab = useCallback(async (session: ClaudeSessionInfo) => {
+    if (!cwd) return;
+    const label = `Resumed ${session.id.slice(0, 8)}`;
+    try {
+      await createTerminal(
+        label,
+        cwd,
+        [],          // no extra args — user can re-add flags via the New Terminal dialog
+        {},
+        undefined,
+        undefined,
+        undefined,
+        session.id,  // resumeSessionId → backend prepends --resume <id>
+      );
+    } catch (err) {
+      toast.error('Could not open session', String(err));
+    }
+  }, [cwd, createTerminal]);
+
+  const resumeInCurrentTerminal = useCallback(async (session: ClaudeSessionInfo) => {
+    if (!cwd || !activeTerminalId || !activeTerminal) return;
+    const ok = window.confirm(
+      `Replace the current Claude in "${activeTerminal.config.nickname || activeTerminal.config.label}" with session ${session.id.slice(0, 8)}?\n\n` +
+        `If Claude is mid-response, that work will be cancelled. The session you're leaving is saved on disk and resumable.`,
+    );
+    if (!ok) return;
+    // Snapshot the current terminal's user-facing config so the replacement
+    // keeps the same label / nickname / color and isn't visually a new tab.
+    const cfg = activeTerminal.config;
+    try {
+      await closeTerminal(activeTerminalId);
+      await createTerminal(
+        cfg.label,
+        cfg.working_directory,
+        cfg.claude_args,
+        cfg.env_vars,
+        cfg.color_tag ?? undefined,
+        cfg.nickname ?? undefined,
+        undefined,
+        session.id,
+      );
+    } catch (err) {
+      toast.error('Could not resume session', String(err));
+    }
+  }, [cwd, activeTerminalId, activeTerminal, closeTerminal, createTerminal]);
+
+  const revealJsonl = useCallback(async (session: ClaudeSessionInfo) => {
+    if (!cwd) return;
+    try {
+      const home = await homeDir();
+      const sep = home.includes('\\') ? '\\' : '/';
+      const path = [home.replace(/[\\/]+$/, ''), '.claude', 'projects', encodeCwd(cwd), `${session.id}.jsonl`].join(sep);
+      await invoke('reveal_in_file_manager', { path });
+    } catch (err) {
+      toast.error('Reveal failed', String(err));
+    }
+  }, [cwd]);
+
+  const openContextMenu = useCallback((e: React.MouseEvent, session: ClaudeSessionInfo) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const margin = 4;
+    const menuWidth = 220;
+    const menuHeight = 140;
+    const x = Math.min(e.clientX, window.innerWidth - menuWidth - margin);
+    const y = Math.min(e.clientY, window.innerHeight - menuHeight - margin);
+    setContextMenu({ x: Math.max(margin, x), y: Math.max(margin, y), session });
+  }, []);
+
+  const headerCwdLabel = useMemo(() => {
+    if (!cwd) return '';
+    return basename(cwd);
+  }, [cwd]);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
+        <button
+          onClick={toggleCollapsed}
+          className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors"
+          title={collapsed ? 'Expand Sessions' : 'Collapse Sessions'}
+        >
+          {collapsed ? (
+            <ChevronRight size={11} strokeWidth={2} />
+          ) : (
+            <ChevronDown size={11} strokeWidth={2} />
+          )}
+          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">
+            Sessions
+          </span>
+          {sessions.length > 0 && !collapsed && (
+            <span className="text-text-tertiary text-[10.5px] tabular-nums">
+              {sessions.length}
+            </span>
+          )}
+        </button>
+        {!collapsed && (
+          <button
+            onClick={fetchSessions}
+            disabled={loading}
+            className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+            title="Refresh"
+          >
+            <RefreshCw size={11} className={loading ? 'animate-spin' : ''} strokeWidth={1.75} />
+          </button>
+        )}
+      </div>
+
+      {/* Body — only when expanded */}
+      {!collapsed && (
+        <>
+          {cwd ? (
+            <div className="px-3 pb-1 flex-shrink-0">
+              <p className="text-text-tertiary text-[10.5px] font-mono truncate" title={cwd}>
+                {headerCwdLabel}
+              </p>
+            </div>
+          ) : (
+            <div className="px-3 py-2 text-text-tertiary text-[11px]">No active terminal</div>
+          )}
+
+          {cwd && (
+            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pb-1">
+              {error && (
+                <div className="px-3 py-2 text-red-400 text-[11px]">{error}</div>
+              )}
+              {!error && sessions.length === 0 && !loading && (
+                <div className="px-3 py-2 text-text-tertiary text-[11px]">
+                  No saved sessions in this folder yet.
+                </div>
+              )}
+              {sessions.map((s) => {
+                const isActive = activeSessionId === s.id;
+                return (
+                  <SessionRow
+                    key={s.id}
+                    session={s}
+                    active={isActive}
+                    onOpenInNewTab={openInNewTab}
+                    onContextMenu={openContextMenu}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Context menu */}
+      {contextMenu && (
+        <SessionContextMenu
+          state={contextMenu}
+          activeSessionId={activeSessionId}
+          hasActiveTerminal={!!activeTerminalId}
+          onOpenInNewTab={openInNewTab}
+          onResumeInCurrent={resumeInCurrentTerminal}
+          onReveal={revealJsonl}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface SessionRowProps {
+  session: ClaudeSessionInfo;
+  active: boolean;
+  onOpenInNewTab: (s: ClaudeSessionInfo) => void;
+  onContextMenu: (e: React.MouseEvent, s: ClaudeSessionInfo) => void;
+}
+
+function SessionRow({ session, active, onOpenInNewTab, onContextMenu }: SessionRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => { if (!active) onOpenInNewTab(session); }}
+      onContextMenu={(e) => onContextMenu(e, session)}
+      title={session.preview || session.id}
+      className={`w-full text-left px-3 py-1.5 group flex items-start gap-2 transition-colors ${
+        active
+          ? 'bg-accent-primary/10'
+          : 'hover:bg-white/[0.045]'
+      }`}
+    >
+      <MessageSquare
+        size={11}
+        strokeWidth={1.75}
+        className={`mt-0.5 shrink-0 ${active ? 'text-accent-primary' : 'text-text-tertiary'}`}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline justify-between gap-2">
+          <span
+            className={`text-[12px] truncate ${
+              active ? 'text-accent-primary font-medium' : 'text-text-primary'
+            }`}
+          >
+            {session.preview || `Session ${session.id.slice(0, 8)}`}
+          </span>
+          <span className="text-[10.5px] text-text-tertiary tabular-nums shrink-0">
+            {formatRelativeTime(session.modified_at)}
+          </span>
+        </div>
+        {session.preview && (
+          <div className="text-[10.5px] text-text-tertiary font-mono truncate">
+            {session.id.slice(0, 8)}{active && ' · active'}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+interface SessionContextMenuProps {
+  state: ContextMenuState;
+  activeSessionId: string | null;
+  hasActiveTerminal: boolean;
+  onOpenInNewTab: (s: ClaudeSessionInfo) => void;
+  onResumeInCurrent: (s: ClaudeSessionInfo) => void;
+  onReveal: (s: ClaudeSessionInfo) => void;
+  onClose: () => void;
+}
+
+function SessionContextMenu({
+  state,
+  activeSessionId,
+  hasActiveTerminal,
+  onOpenInNewTab,
+  onResumeInCurrent,
+  onReveal,
+  onClose,
+}: SessionContextMenuProps) {
+  const { x, y, session } = state;
+  const isActive = activeSessionId === session.id;
+  return (
+    <div
+      role="menu"
+      data-context-menu="sessions"
+      className="fixed z-[80] min-w-[220px] bg-bg-elevated ring-1 ring-white/[0.08] rounded-md shadow-elevation-4 py-1 select-none"
+      style={{ left: x, top: y }}
+    >
+      <MenuItem
+        icon={<ExternalLink size={13} strokeWidth={1.75} />}
+        label="Open in new tab"
+        disabled={isActive}
+        onClick={() => { onClose(); onOpenInNewTab(session); }}
+      />
+      <MenuItem
+        icon={<ArrowRightCircle size={13} strokeWidth={1.75} />}
+        label="Resume in current terminal"
+        disabled={!hasActiveTerminal || isActive}
+        onClick={() => { onClose(); onResumeInCurrent(session); }}
+      />
+      <div className="my-1 border-t border-white/[0.06]" />
+      <MenuItem
+        icon={<FolderOpen size={13} strokeWidth={1.75} />}
+        label={REVEAL_LABEL}
+        onClick={() => { onClose(); onReveal(session); }}
+      />
+    </div>
+  );
+}
+
+interface MenuItemProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function MenuItem({ icon, label, onClick, disabled }: MenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-left text-[12px] transition-colors ${
+        disabled
+          ? 'text-text-tertiary/50 cursor-not-allowed'
+          : 'text-text-primary hover:bg-white/[0.06]'
+      }`}
+    >
+      <span className={disabled ? 'opacity-50' : 'text-text-tertiary'}>{icon}</span>
+      <span className="flex-1">{label}</span>
+    </button>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,51 @@
+import { useCallback, useEffect, useRef } from 'react';
 import { ChevronsLeft, ChevronsRight, FolderTree } from 'lucide-react';
 import { useAppStore } from '../store/appStore';
 import { FileTreePanel } from './FileTreePanel';
+import { SessionsPanel } from './SessionsPanel';
 
 export function Sidebar() {
-  const { sidebarCollapsed, toggleSidebarCollapse, showFileTree } = useAppStore();
+  const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
+  const toggleSidebarCollapse = useAppStore((s) => s.toggleSidebarCollapse);
+  const showFileTree = useAppStore((s) => s.showFileTree);
+  const sessionsCollapsed = useAppStore((s) => s.sessionsCollapsed);
+  const explorerCollapsed = useAppStore((s) => s.explorerCollapsed);
+  const sessionsHeightRatio = useAppStore((s) => s.sessionsHeightRatio);
+  const setSessionsHeightRatio = useAppStore((s) => s.setSessionsHeightRatio);
+
+  const stackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+
+  const onSplitterMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!draggingRef.current) return;
+      const el = stackRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.height <= 0) return;
+      const y = e.clientY - rect.top;
+      setSessionsHeightRatio(y / rect.height);
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [setSessionsHeightRatio]);
 
   if (sidebarCollapsed) {
     return (
@@ -22,6 +64,26 @@ export function Sidebar() {
     );
   }
 
+  // Layout rules for the stacked Sessions / Explorer sections:
+  // - A collapsed section is auto-sized to just its header (flex-shrink-0).
+  // - When both are expanded, they share space by `sessionsHeightRatio`; a
+  //   thin drag handle between them updates the ratio live.
+  // - When one is collapsed and the other isn't, the expanded one takes all
+  //   remaining space.
+  const sessionsExpanded = !sessionsCollapsed;
+  const explorerExpanded = !explorerCollapsed && showFileTree;
+  const bothExpanded = sessionsExpanded && explorerExpanded;
+  const sessionsStyle: React.CSSProperties = !sessionsExpanded
+    ? { flex: '0 0 auto' }
+    : bothExpanded
+    ? { flex: `${sessionsHeightRatio} 1 0`, minHeight: 80 }
+    : { flex: '1 1 0' };
+  const explorerStyle: React.CSSProperties = !explorerExpanded
+    ? { flex: '0 0 auto' }
+    : bothExpanded
+    ? { flex: `${1 - sessionsHeightRatio} 1 0`, minHeight: 80 }
+    : { flex: '1 1 0' };
+
   return (
     <div className="h-full bg-elevation-1 border-r border-[var(--ij-divider)] flex flex-col">
       <div className="flex items-center justify-between h-[30px] px-3 border-b border-[var(--ij-divider-soft)]">
@@ -38,16 +100,35 @@ export function Sidebar() {
         </button>
       </div>
 
-      <div className="flex-1 min-h-0 flex flex-col">
-        {showFileTree ? (
-          <FileTreePanel />
-        ) : (
-          <div className="flex-1 flex items-center justify-center px-4 text-center">
-            <p className="text-text-tertiary text-[12px]">
-              Explorer is disabled. Enable it in Settings &rarr; Appearance &amp; Behavior.
-            </p>
-          </div>
+      <div ref={stackRef} className="flex-1 min-h-0 flex flex-col">
+        <div
+          style={sessionsStyle}
+          className="flex flex-col min-h-0 overflow-hidden border-b border-[var(--ij-divider-soft)]"
+        >
+          <SessionsPanel />
+        </div>
+
+        {bothExpanded && (
+          <div
+            onMouseDown={onSplitterMouseDown}
+            role="separator"
+            aria-orientation="horizontal"
+            title="Drag to resize Sessions / Explorer"
+            className="h-1 shrink-0 cursor-row-resize bg-transparent hover:bg-accent-primary/50 active:bg-accent-primary/70 transition-colors"
+          />
         )}
+
+        <div style={explorerStyle} className="flex flex-col min-h-0 overflow-hidden">
+          {showFileTree ? (
+            <FileTreePanel />
+          ) : (
+            <div className="flex-1 flex items-center justify-center px-4 text-center">
+              <p className="text-text-tertiary text-[12px]">
+                Explorer is disabled. Enable it in Settings &rarr; Appearance &amp; Behavior.
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -122,6 +122,12 @@ interface AppState {
   // Sidebar layout
   explorerHeightRatio: number; // 0.15..0.85, portion of sidebar height reserved for Explorer
   toolsCollapsed: boolean; // sidebar footer (Workspaces/Snippets/etc.) — collapsed gives Explorer more height
+  // Persistent collapse state for the two stacked sidebar sections.
+  sessionsCollapsed: boolean;
+  explorerCollapsed: boolean;
+  // Portion of the (Sessions + Explorer) column reserved for Sessions when
+  // both sections are expanded. 0.15..0.85; the rest goes to Explorer.
+  sessionsHeightRatio: number;
 
   // File Changes panel split: Repositories (top) vs Changes (bottom)
   repositoriesHeightRatio: number; // 0.15..0.85
@@ -266,6 +272,9 @@ interface AppState {
   setExplorerHeightRatio: (ratio: number) => void;
   setRepositoriesHeightRatio: (ratio: number) => void;
   toggleToolsCollapsed: () => void;
+  toggleSessionsCollapsed: () => void;
+  toggleExplorerCollapsed: () => void;
+  setSessionsHeightRatio: (ratio: number) => void;
 
   // Global Search actions (Ctrl+Shift+F)
   openGlobalSearch: () => void;
@@ -453,6 +462,11 @@ export const useAppStore = create<AppState>()(
       // Tools footer collapsed by default — surfaces more explorer space; user
       // can expand on demand to reach Workspaces / Snippets / Profiles / etc.
       toolsCollapsed: true,
+      // Sessions section starts collapsed so the Explorer (the more frequent
+      // tool) keeps its current screen real estate by default. Users opt-in.
+      sessionsCollapsed: true,
+      explorerCollapsed: false,
+      sessionsHeightRatio: 0.35,
 
       // File Changes split (default: repositories takes 35% of available column)
       repositoriesHeightRatio: 0.35,
@@ -603,6 +617,10 @@ export const useAppStore = create<AppState>()(
         repositoriesHeightRatio: Math.max(0.15, Math.min(0.85, ratio)),
       }),
       toggleToolsCollapsed: () => set((state) => ({ toolsCollapsed: !state.toolsCollapsed })),
+      toggleSessionsCollapsed: () => set((state) => ({ sessionsCollapsed: !state.sessionsCollapsed })),
+      toggleExplorerCollapsed: () => set((state) => ({ explorerCollapsed: !state.explorerCollapsed })),
+      setSessionsHeightRatio: (ratio) =>
+        set({ sessionsHeightRatio: Math.max(0.15, Math.min(0.85, ratio)) }),
 
       openGlobalSearch: () => set({ globalSearchOpen: true }),
       closeGlobalSearch: () => set({ globalSearchOpen: false }),
@@ -915,6 +933,9 @@ export const useAppStore = create<AppState>()(
         terminalBidi: state.terminalBidi,
         explorerHeightRatio: state.explorerHeightRatio,
         toolsCollapsed: state.toolsCollapsed,
+        sessionsCollapsed: state.sessionsCollapsed,
+        explorerCollapsed: state.explorerCollapsed,
+        sessionsHeightRatio: state.sessionsHeightRatio,
         repositoriesHeightRatio: state.repositoriesHeightRatio,
         orchestrationOpen: state.orchestrationOpen,
         lastSeenVersion: state.lastSeenVersion,


### PR DESCRIPTION
## Summary
New **Sessions** panel above the Explorer that lists every Claude conversation stored under `~/.claude/projects/<encoded-cwd>/` for the active terminal's cwd, sorted newest-first with a preview of the user's opening message.

| Action | Behavior |
|---|---|
| Click a row | Opens that conversation in a new terminal tab via `claude --resume=<id>`. The new terminal records the session id, so subsequent restores re-attach exactly. |
| Right-click → Open in new tab | Same as click. |
| Right-click → Resume in current terminal | Kills the active Claude (with confirm), respawns in the same tab slot bound to the chosen session. |
| Right-click → Reveal `.jsonl` | Opens File Explorer / Finder pointed at the session file. |
| Active row | Highlighted blue when its id matches the active terminal's `claude_session_id`. |

## Layout
- Sessions and Explorer are now stacked **collapsible** sections.
- When both expanded, they share the column via a **drag-resize** handle (`sessionsHeightRatio` 0.15..0.85, persisted).
- One collapsed → the other takes the full column.
- Defaults: Sessions collapsed, Explorer expanded — keeps the file tree's existing real estate; users opt in to the new panel.

## Bug fix bundled
`claude --resume <id>` was being parsed by Commander.js as "open the picker" plus `<id>` as a stray positional prompt — Claude showed its first-run **theme picker** instead of resuming. Switch to `--resume=<id>` (the equals form Commander needs for `[value]` optional flags). `--continue` was already unaffected.

## Backend
New `list_claude_sessions(cwd)` Tauri command — scans the encoded project dir, returns `{ id, modified_at, preview }` sorted by mtime DESC. Preview parses the first 20 JSONL lines for the first `type:user` entry and handles both string and array shapes of `message.content`.

## Test plan
- [x] `--resume=<id>` actually resumes (was producing the theme picker before this PR)
- [ ] Sessions list reflects newest-first ordering and previews match real first user messages
- [ ] Drag handle between Sessions / Explorer resizes both proportionally; collapsed section stays at its header height
- [ ] Right-click → "Resume in current terminal" confirms and replaces the running Claude
- [ ] "Reveal .jsonl" opens File Explorer with the file selected
- [ ] Empty cwd (no sessions yet) shows "No saved sessions in this folder yet."

🤖 Generated with [Claude Code](https://claude.com/claude-code)