### PR TITLE
Session state + smart notifications (and neutral header UI)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-session-state-smart-notifications.md
+++ b/docs/superpowers/plans/2026-06-01-session-state-smart-notifications.md
@@ -1,0 +1,996 @@
+# Session State + Smart Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Infer per-terminal Claude state (busy / waiting-for-decision / idle / stopped) from xterm's parsed buffer, surface it in tab indicators and an Agent View, and fire native notifications only when a session is blocked waiting for the user.
+
+**Architecture:** A pure classifier (`classifySettled`) reads the bottom rows of xterm's already-parsed buffer and decides waiting-vs-idle. A single 500ms global poller hook computes each Claude terminal's state (busy from the existing `lastOutputAt` timer; waiting/idle from the classifier when output has settled), writes it to Zustand only on transitions, and fires an attention notification on entry into `waiting` unless the user is already looking at that session. UI reads the state map to render a shared `StateDot` in tabs and the Agent View (the upgraded Recent Terminals dropdown).
+
+**Tech Stack:** React 18 + TypeScript, Zustand, xterm.js (`@xterm/xterm`), Tauri 2 window API (`@tauri-apps/api/window`), Vitest for unit tests.
+
+---
+
+## Background facts (read before starting)
+
+- **Activity tracking already exists.** `src/lib/terminalActivity.ts` keeps a module-level `Map<id, lastOutputAt>` updated on every output chunk (deliberately bypassing Zustand to avoid re-renders). Read it with `getLastOutputAt(id)`. We reuse this for the `busy` state.
+- **xterm persists for all tabs.** `terminalStore.handleTerminalOutput` writes to `instance.xterm` regardless of which tab is active, so background terminals have a live, parsed buffer we can read.
+- **Reduce-motion is global CSS.** `index.css` disables all animation under `:root[data-reduce-motion="true"]`. The pulsing dot therefore needs no per-component reduce-motion handling.
+- **DND/sound settings exist but are not enforced anywhere yet.** `appStore` has `dndStart`, `dndEnd` (both `"HH:MM"`), and `notificationSoundEnabled`. The current finish notification (`App.tsx`) ignores them. Our gate is the first enforcement.
+- **Test runner:** Vitest. Run a single file with `npx vitest run <path>`. Existing example: `src/lib/terminalActivity.test.ts`.
+- **Claude terminals only.** Skip instances where `isShellTerminal` or `scriptParentId` is set.
+
+## File Structure
+
+- Create `src/lib/terminalState.ts` — pure classifier + `SessionState` type + pattern lists. One responsibility: turn screen text into a state verdict.
+- Create `src/lib/terminalState.test.ts` — classifier unit tests.
+- Create `src/lib/notificationGate.ts` — pure `isWithinDnd()` + best-effort `playNotificationSound()`.
+- Create `src/lib/notificationGate.test.ts` — DND-window unit tests.
+- Create `src/hooks/useWindowFocused.ts` — boolean app-window focus via Tauri.
+- Create `src/hooks/useSessionStateDetection.ts` — the global poller; owns buffer reading + transition/notification logic.
+- Create `src/components/StateDot.tsx` — shared state dot, used by tabs, Agent View, grid.
+- Modify `src/store/terminalStore.ts` — add `terminalStates` map + `setTerminalState` + cleanup.
+- Modify `src/components/TerminalTabs.tsx` — replace binary working dot with `StateDot`.
+- Modify `src/components/titlebar/RecentTerminalsMenu.tsx` — Agent View: state pills, waiting-first sort, count badge on the icon.
+- Modify `src/App.tsx` — mount `useSessionStateDetection()`.
+
+---
+
+## Task 1: SessionState type + pure classifier
+
+**Files:**
+- Create: `src/lib/terminalState.ts`
+- Test: `src/lib/terminalState.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/terminalState.test.ts
+import { describe, it, expect } from 'vitest';
+import { classifySettled } from './terminalState';
+
+describe('classifySettled', () => {
+  it('flags a "Do you want to proceed?" permission prompt as waiting', () => {
+    const lines = [
+      'Do you want to proceed?',
+      '❯ 1. Yes',
+      '  2. No, tell Claude what to do differently',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('flags an AskUserQuestion numbered menu as waiting', () => {
+    const lines = [
+      'Which approach should I take?',
+      '❯ 1. Rewrite the module',
+      '  2. Patch in place',
+      '  3. Leave it',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('flags the folder-trust prompt as waiting', () => {
+    const lines = [
+      'Do you trust the files in this folder?',
+      '❯ 1. Yes, proceed',
+      '  2. No, exit',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('treats the plain idle input box as idle', () => {
+    const lines = [
+      '╭───────────────────────────────╮',
+      '│ >                             │',
+      '╰───────────────────────────────╯',
+      '  ? for shortcuts',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+
+  it('does not raise waiting on a finished response that contains a numbered list', () => {
+    const lines = [
+      'Here are the steps I took:',
+      '1. Updated the parser',
+      '2. Added a test',
+      '╭───────────────────────────────╮',
+      '│ >                             │',
+      '╰───────────────────────────────╯',
+      '  ? for shortcuts',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+
+  it('treats mid-stream prose with no prompt as idle (never a false alarm)', () => {
+    const lines = [
+      '● Running the test suite…',
+      '  Updated src/foo.ts with 3 additions',
+      'Now I will check the output.',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/terminalState.test.ts`
+Expected: FAIL — "Failed to resolve import './terminalState'" / `classifySettled is not a function`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/lib/terminalState.ts
+
+/** Inferred state of a Claude Code terminal. */
+export type SessionState = 'busy' | 'waiting' | 'idle' | 'stopped';
+
+/**
+ * Phrases that unambiguously mean Claude is blocked waiting for a decision.
+ * Kept as an exported, versioned list so they are cheap to tune as Claude
+ * Code's prompt UI changes. Matched against the joined, trimmed tail text.
+ */
+export const WAITING_PATTERNS: RegExp[] = [
+  /Do you want to proceed\??/i,
+  /Do you trust the files in this folder\??/i,
+  /\(y\/n\)/i,
+  /\[y\/N\]/,
+];
+
+/**
+ * Markers that mean the plain input box is on screen — i.e. Claude is idle and
+ * ready for a new prompt, even if a numbered list from the last response is
+ * still visible above the box.
+ */
+const IDLE_MARKERS: RegExp[] = [
+  /\?\s+for\s+shortcuts/i,
+  /^[│|]?\s*>\s*$/,
+];
+
+/** A selectable option line, e.g. "❯ 1. Yes" or "2. No". */
+const OPTION_LINE = /^(?:❯\s*)?\d+\.\s+\S/;
+
+/**
+ * Decide whether settled terminal output represents a blocking prompt
+ * (`waiting`) or a ready input box (`idle`). Only called once output has gone
+ * quiet — `busy` is handled by the caller via the activity timer.
+ *
+ * Bias: when uncertain, return `idle`. A missed prompt is a minor annoyance;
+ * a false "needs attention" alarm erodes trust in the whole feature.
+ */
+export function classifySettled(lines: string[]): 'waiting' | 'idle' {
+  const trimmed = lines.map((l) => l.trim());
+  const joined = trimmed.join('\n');
+
+  // 1. Explicit blocking phrases win immediately.
+  for (const re of WAITING_PATTERNS) {
+    if (re.test(joined)) return 'waiting';
+  }
+
+  // 2. If the plain input box is visible, Claude is idle regardless of any
+  //    numbered list left over from its last response.
+  if (IDLE_MARKERS.some((re) => trimmed.some((l) => re.test(l)))) return 'idle';
+
+  // 3. Two or more option lines = a selection menu (AskUserQuestion / picker).
+  const optionLines = trimmed.filter((l) => OPTION_LINE.test(l));
+  if (optionLines.length >= 2) return 'waiting';
+
+  return 'idle';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/terminalState.test.ts`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/terminalState.ts src/lib/terminalState.test.ts
+git commit -m "feat: pure classifier for Claude terminal session state"
+```
+
+---
+
+## Task 2: Notification gate (DND window + sound)
+
+**Files:**
+- Create: `src/lib/notificationGate.ts`
+- Test: `src/lib/notificationGate.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/notificationGate.test.ts
+import { describe, it, expect } from 'vitest';
+import { isWithinDnd } from './notificationGate';
+
+function at(hh: number, mm: number): Date {
+  const d = new Date(2026, 5, 1, hh, mm, 0, 0);
+  return d;
+}
+
+describe('isWithinDnd', () => {
+  it('returns false when start equals end (window disabled)', () => {
+    expect(isWithinDnd('00:00', '00:00', at(3, 0))).toBe(false);
+  });
+
+  it('handles a same-day window (09:00–17:00)', () => {
+    expect(isWithinDnd('09:00', '17:00', at(12, 0))).toBe(true);
+    expect(isWithinDnd('09:00', '17:00', at(8, 59))).toBe(false);
+    expect(isWithinDnd('09:00', '17:00', at(17, 0))).toBe(false); // end exclusive
+  });
+
+  it('handles an overnight window (22:00–08:00)', () => {
+    expect(isWithinDnd('22:00', '08:00', at(23, 30))).toBe(true);
+    expect(isWithinDnd('22:00', '08:00', at(2, 0))).toBe(true);
+    expect(isWithinDnd('22:00', '08:00', at(8, 0))).toBe(false); // end exclusive
+    expect(isWithinDnd('22:00', '08:00', at(12, 0))).toBe(false);
+  });
+
+  it('treats malformed times as disabled (returns false)', () => {
+    expect(isWithinDnd('bad', '08:00', at(2, 0))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/notificationGate.test.ts`
+Expected: FAIL — cannot resolve `./notificationGate` / `isWithinDnd is not a function`.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/lib/notificationGate.ts
+
+function toMinutes(hhmm: string): number | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
+  if (!m) return null;
+  return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+}
+
+/**
+ * True if `now` falls inside the Do-Not-Disturb window [start, end).
+ * Supports same-day (start < end) and overnight (start > end) windows.
+ * A zero-length or malformed window is treated as disabled (false).
+ */
+export function isWithinDnd(start: string, end: string, now: Date): boolean {
+  const s = toMinutes(start);
+  const e = toMinutes(end);
+  if (s === null || e === null || s === e) return false;
+  const cur = now.getHours() * 60 + now.getMinutes();
+  return s < e ? cur >= s && cur < e : cur >= s || cur < e;
+}
+
+/**
+ * Best-effort short beep for users who enable notification sound. Uses a brief
+ * Web Audio oscillator so we don't ship an audio asset. Silently no-ops if the
+ * AudioContext is unavailable or blocked.
+ */
+export function playNotificationSound(): void {
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = 880;
+    gain.gain.value = 0.05;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.12);
+    osc.onended = () => ctx.close();
+  } catch {
+    /* sound is best-effort; never throw into the poller */
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/notificationGate.test.ts`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/notificationGate.ts src/lib/notificationGate.test.ts
+git commit -m "feat: DND-window gate and notification sound helper"
+```
+
+---
+
+## Task 3: terminalStore session-state map
+
+**Files:**
+- Modify: `src/store/terminalStore.ts`
+- Test: `src/store/terminalStore.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test (append to the existing file)**
+
+```typescript
+// src/store/terminalStore.test.ts — append inside the file
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTerminalStore } from './terminalStore';
+
+describe('terminalStore session state', () => {
+  beforeEach(() => {
+    useTerminalStore.setState({ terminalStates: new Map() });
+  });
+
+  it('setTerminalState stores a state', () => {
+    useTerminalStore.getState().setTerminalState('a', 'waiting');
+    expect(useTerminalStore.getState().terminalStates.get('a')).toBe('waiting');
+  });
+
+  it('setTerminalState is a no-op (same map reference) when unchanged', () => {
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    const before = useTerminalStore.getState().terminalStates;
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    expect(useTerminalStore.getState().terminalStates).toBe(before);
+  });
+
+  it('setTerminalState replaces the map when the value changes', () => {
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    const before = useTerminalStore.getState().terminalStates;
+    useTerminalStore.getState().setTerminalState('a', 'idle');
+    expect(useTerminalStore.getState().terminalStates).not.toBe(before);
+    expect(useTerminalStore.getState().terminalStates.get('a')).toBe('idle');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/store/terminalStore.test.ts -t "session state"`
+Expected: FAIL — `terminalStates` undefined / `setTerminalState is not a function`.
+
+- [ ] **Step 3a: Add the import (top of `src/store/terminalStore.ts`)**
+
+Find line 5:
+```typescript
+import { markTerminalActive, clearTerminalActivity } from '../lib/terminalActivity';
+```
+Add immediately after it:
+```typescript
+import type { SessionState } from '../lib/terminalState';
+```
+
+- [ ] **Step 3b: Extend the `TerminalState` interface**
+
+Find (around line 56):
+```typescript
+  unreadTerminalIds: Set<string>;
+```
+Add immediately after it:
+```typescript
+  // Inferred Claude session state per terminal (busy/waiting/idle/stopped).
+  // Written only on transitions by the detection poller — never on the
+  // streaming hot path — so subscribers re-render only when state changes.
+  terminalStates: Map<string, SessionState>;
+```
+
+Then find the action declarations block (near `hasUnread: (id: string) => boolean;`, around line 94) and add after it:
+```typescript
+  setTerminalState: (id: string, state: SessionState) => void;
+```
+
+- [ ] **Step 3c: Initialize the map**
+
+Find (around line 115):
+```typescript
+  unreadTerminalIds: new Set(),
+```
+Add immediately after it:
+```typescript
+  terminalStates: new Map(),
+```
+
+- [ ] **Step 3d: Implement `setTerminalState`**
+
+Find the `hasUnread` implementation (around line 417):
+```typescript
+  hasUnread: (id) => {
+    return get().unreadTerminalIds.has(id);
+  },
+```
+Add immediately after it:
+```typescript
+
+  setTerminalState: (id, state) => {
+    // Short-circuit before set() so unchanged states cause zero re-renders.
+    if (get().terminalStates.get(id) === state) return;
+    set((s) => {
+      const next = new Map(s.terminalStates);
+      next.set(id, state);
+      return { terminalStates: next };
+    });
+  },
+```
+
+- [ ] **Step 3e: Clean up on close**
+
+Find in `closeTerminal` (around line 258):
+```typescript
+      const newGitCache = new Map(state.gitInfoCache);
+      newGitCache.delete(id);
+```
+Add immediately after it:
+```typescript
+      const newStates = new Map(state.terminalStates);
+      newStates.delete(id);
+      if (childId) newStates.delete(childId);
+```
+Then find the return object in the same function (around line 270) and add `terminalStates: newStates,` after the `unreadTerminalIds: newUnread,` line:
+```typescript
+      return {
+        terminals: newTerminals,
+        unreadTerminalIds: newUnread,
+        terminalStates: newStates,
+        gitInfoCache: newGitCache,
+        scriptChildren: newChildren,
+        activeTerminalId: state.activeTerminalId === id
+          ? (remainingIds[0] || null)
+          : state.activeTerminalId,
+      };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/store/terminalStore.test.ts -t "session state"`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/terminalStore.ts src/store/terminalStore.test.ts
+git commit -m "feat: track per-terminal session state in terminalStore"
+```
+
+---
+
+## Task 4: Window-focus hook
+
+**Files:**
+- Create: `src/hooks/useWindowFocused.ts`
+
+No unit test — this is a thin Tauri event binding verified via the manual check in Task 9.
+
+- [ ] **Step 1: Write the implementation**
+
+```typescript
+// src/hooks/useWindowFocused.ts
+// Tracks whether the app window currently has focus, used by the session-state
+// notification rule to suppress alerts for a session the user is looking at.
+
+import { useEffect, useState } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+
+export function useWindowFocused(): boolean {
+  const [focused, setFocused] = useState(true);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    let unlisten: (() => void) | undefined;
+
+    win.isFocused().then(setFocused).catch(() => { /* default true */ });
+    win
+      .onFocusChanged(({ payload }) => setFocused(payload))
+      .then((fn) => { unlisten = fn; })
+      .catch(() => { /* ignore */ });
+
+    return () => { unlisten?.(); };
+  }, []);
+
+  return focused;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no errors). If `getCurrentWindow` is not found, confirm the import path against the installed `@tauri-apps/api` version — in Tauri 2 it is `@tauri-apps/api/window`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useWindowFocused.ts
+git commit -m "feat: useWindowFocused hook for notification suppression"
+```
+
+---
+
+## Task 5: Shared StateDot component
+
+**Files:**
+- Create: `src/components/StateDot.tsx`
+
+Reduce-motion is handled globally by CSS (`:root[data-reduce-motion="true"]`), so the
+pulse class `ct-working-dot` auto-disables — no prop needed.
+
+- [ ] **Step 1: Write the implementation**
+
+```tsx
+// src/components/StateDot.tsx
+import type { SessionState } from '../lib/terminalState';
+
+const DOT: Record<SessionState, { cls: string; pulse: boolean; title: string }> = {
+  busy:    { cls: 'bg-success',          pulse: true,  title: 'Claude is working…' },
+  waiting: { cls: 'bg-amber-400',        pulse: true,  title: 'Claude needs your input' },
+  idle:    { cls: 'bg-text-tertiary/40', pulse: false, title: 'Idle' },
+  stopped: { cls: 'bg-text-tertiary',    pulse: false, title: 'Stopped' },
+};
+
+export function StateDot({ state, size = 8 }: { state: SessionState; size?: number }) {
+  const d = DOT[state];
+  return (
+    <span
+      className={`rounded-full flex-shrink-0 ${d.cls} ${d.pulse ? 'ct-working-dot' : ''}`}
+      style={{ width: size, height: size }}
+      title={d.title}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. (If `bg-amber-400` is not recognized by the Tailwind config, substitute the project's amber token; verify by grepping `amber` in `src/` — `TerminalTabs.tsx` already uses `text-amber`-style tokens via the changelog's accent set.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/StateDot.tsx
+git commit -m "feat: shared StateDot component for session state"
+```
+
+---
+
+## Task 6: Detection poller hook
+
+**Files:**
+- Create: `src/hooks/useSessionStateDetection.ts`
+
+This hook owns the xterm buffer read (impure, xterm-specific) and the
+transition→notification logic. The pure decision lives in `classifySettled`
+(Task 1) and `isWithinDnd` (Task 2), already tested.
+
+- [ ] **Step 1: Write the implementation**
+
+```typescript
+// src/hooks/useSessionStateDetection.ts
+// Single global poller that infers each Claude terminal's session state every
+// 500ms and fires an attention notification when a session becomes blocked
+// waiting for the user. Mounted once (see App.tsx).
+
+import { useEffect, useRef } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import { useTerminalStore } from '../store/terminalStore';
+import { useAppStore } from '../store/appStore';
+import { getLastOutputAt } from '../lib/terminalActivity';
+import { classifySettled, type SessionState } from '../lib/terminalState';
+import { isWithinDnd, playNotificationSound } from '../lib/notificationGate';
+import { useNotification } from './useNotification';
+import { useWindowFocused } from './useWindowFocused';
+
+const POLL_INTERVAL_MS = 500;
+const BUSY_WINDOW_MS = 600;
+const BUFFER_TAIL_ROWS = 15;
+
+/** Read the bottom `rows` lines of xterm's already-parsed buffer as clean text. */
+function readBufferTail(term: Terminal, rows: number): string[] {
+  const buf = term.buffer.active;
+  const end = buf.length;
+  const start = Math.max(0, end - rows);
+  const out: string[] = [];
+  for (let i = start; i < end; i++) {
+    const line = buf.getLine(i);
+    out.push(line ? line.translateToString(true) : '');
+  }
+  return out;
+}
+
+export function useSessionStateDetection(): void {
+  const { notify } = useNotification();
+  const windowFocused = useWindowFocused();
+
+  // Keep focus readable inside the interval without re-creating it.
+  const focusedRef = useRef(windowFocused);
+  focusedRef.current = windowFocused;
+
+  // Terminals we've already notified for the current waiting episode.
+  const notifiedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const store = useTerminalStore.getState();
+      const app = useAppStore.getState();
+      const now = Date.now();
+
+      for (const [id, inst] of store.terminals) {
+        // Claude terminals only — skip plain shells and script children.
+        if (inst.scriptParentId || inst.isShellTerminal) continue;
+
+        // Exited process: pin to stopped and re-arm notifications.
+        if (inst.config.status === 'Stopped') {
+          store.setTerminalState(id, 'stopped');
+          notifiedRef.current.delete(id);
+          continue;
+        }
+
+        let state: SessionState;
+        const last = getLastOutputAt(id);
+        if (last != null && now - last < BUSY_WINDOW_MS) {
+          state = 'busy';
+        } else if (inst.xterm) {
+          state = classifySettled(readBufferTail(inst.xterm, BUFFER_TAIL_ROWS));
+        } else {
+          // No mounted buffer to read — keep the last known state.
+          state = store.terminalStates.get(id) ?? 'idle';
+        }
+
+        const prev = store.terminalStates.get(id);
+        store.setTerminalState(id, state);
+
+        if (state === 'waiting') {
+          const lookingAtIt = id === store.activeTerminalId && focusedRef.current;
+          const dnd = isWithinDnd(app.dndStart, app.dndEnd, new Date());
+          if (prev !== 'waiting' && !lookingAtIt && !dnd && !notifiedRef.current.has(id)) {
+            const name = inst.config.nickname || inst.config.label;
+            notify('Claude needs your input', `${name} is waiting for your response.`);
+            if (app.notificationSoundEnabled) playNotificationSound();
+            notifiedRef.current.add(id);
+          }
+        } else {
+          // Left the waiting episode — re-arm for the next prompt.
+          notifiedRef.current.delete(id);
+        }
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [notify]);
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. Common fixes: ensure `Terminal` is imported as a type from `@xterm/xterm`; confirm `app.dndStart`, `app.dndEnd`, `app.notificationSoundEnabled` exist on the app store (they do — see `src/store/appStore.ts`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useSessionStateDetection.ts
+git commit -m "feat: session-state detection poller with attention notifications"
+```
+
+---
+
+## Task 7: Mount the poller
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Add the import**
+
+Find (around line 34):
+```typescript
+import { useNotification } from './hooks/useNotification';
+```
+Add immediately after it:
+```typescript
+import { useSessionStateDetection } from './hooks/useSessionStateDetection';
+```
+
+- [ ] **Step 2: Call the hook**
+
+Find (around line 110):
+```typescript
+  useKeyboardShortcuts();
+```
+Add immediately after it:
+```typescript
+  useSessionStateDetection();
+```
+
+- [ ] **Step 3: Type-check and build**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: mount session-state detection poller in App"
+```
+
+---
+
+## Task 8: Tab indicator uses StateDot
+
+**Files:**
+- Modify: `src/components/TerminalTabs.tsx`
+
+Replaces the binary time-based working dot (`isWorking`) with the four-state
+`StateDot`. The unread dot (blue) is kept as-is.
+
+- [ ] **Step 1: Add imports**
+
+Find (around line 17):
+```typescript
+import { getLastOutputAt } from '../lib/terminalActivity';
+```
+Add immediately after it:
+```typescript
+import { StateDot } from './StateDot';
+import type { SessionState } from '../lib/terminalState';
+```
+
+- [ ] **Step 2: Subscribe to the state map**
+
+Find (line 28):
+```typescript
+  const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache, reorderTerminals, scriptChildren, closeScript } = useTerminalStore();
+```
+Add a separate selector immediately after it (a focused selector re-renders the
+tab strip only when the state map changes):
+```typescript
+  const terminalStates = useTerminalStore((s) => s.terminalStates);
+```
+
+- [ ] **Step 3: Replace the per-tab dot logic**
+
+Find (around lines 217–218):
+```typescript
+              const lastOutputAt = getLastOutputAt(terminal.id);
+              const isWorking = lastOutputAt != null && now - lastOutputAt < 2000;
+```
+Replace with:
+```typescript
+              const lastOutputAt = getLastOutputAt(terminal.id);
+              const liveBusy = lastOutputAt != null && now - lastOutputAt < 2000;
+              // Prefer the poller's classified state; fall back to the live
+              // activity timer so the dot lights up instantly on first output
+              // before the first poll tick lands.
+              const sessionState: SessionState =
+                terminalStates.get(terminal.id) ?? (liveBusy ? 'busy' : 'idle');
+              const isWorking = sessionState === 'busy';
+```
+
+- [ ] **Step 4: Render StateDot for non-idle states**
+
+Find the working-dot block (around lines 257–262):
+```tsx
+                  {isWorking && (
+                    <div
+                      className="ct-working-dot w-2 h-2 rounded-full bg-success flex-shrink-0 text-success"
+                      title="Claude is working&hellip;"
+                    />
+                  )}
+```
+Replace with:
+```tsx
+                  {sessionState !== 'idle' && (
+                    <StateDot state={sessionState} />
+                  )}
+```
+
+(The `ct-working-tab` class on line 245 stays as-is — it keys off `isWorking`,
+which now means `sessionState === 'busy'`.)
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS. If `now` becomes unused after this change, leave it — it is still used by `useNowTick()` to drive the 500ms re-render; do not remove the `useNowTick` call.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/TerminalTabs.tsx
+git commit -m "feat: four-state session dot on terminal tabs"
+```
+
+---
+
+## Task 9: Agent View (upgrade Recent Terminals dropdown)
+
+**Files:**
+- Modify: `src/components/titlebar/RecentTerminalsMenu.tsx`
+
+Adds: a state pill per row, waiting-first sort, and an amber count badge on the
+Layers icon when any session is waiting.
+
+- [ ] **Step 1: Add imports**
+
+Find (line 4):
+```typescript
+import { useAppStore } from '../../store/appStore';
+```
+Add immediately after it:
+```typescript
+import { StateDot } from '../StateDot';
+import type { SessionState } from '../../lib/terminalState';
+
+const STATE_ORDER: Record<SessionState, number> = { waiting: 0, busy: 1, idle: 2, stopped: 3 };
+const STATE_LABEL: Record<SessionState, string> = {
+  waiting: 'Waiting', busy: 'Working', idle: 'Idle', stopped: 'Stopped',
+};
+```
+
+- [ ] **Step 2: Read the state map and compute the waiting count**
+
+Find (line 16):
+```typescript
+  const { terminals, activeTerminalId, setActiveTerminal, gitInfoCache } = useTerminalStore();
+```
+Add immediately after it:
+```typescript
+  const terminalStates = useTerminalStore((s) => s.terminalStates);
+```
+
+- [ ] **Step 3: Sort items waiting-first and expose count**
+
+Replace the `items` memo (lines 19–24):
+```typescript
+  const items = useMemo(() => {
+    return Array.from(terminals.values())
+      .filter((t) => !t.scriptParentId && !t.isShellTerminal)
+      .sort((a, b) => (a.config.created_at < b.config.created_at ? 1 : -1))
+      .slice(0, 20);
+  }, [terminals]);
+```
+with:
+```typescript
+  const items = useMemo(() => {
+    const list = Array.from(terminals.values())
+      .filter((t) => !t.scriptParentId && !t.isShellTerminal);
+    return list
+      .sort((a, b) => {
+        const sa = STATE_ORDER[terminalStates.get(a.config.id) ?? 'idle'];
+        const sb = STATE_ORDER[terminalStates.get(b.config.id) ?? 'idle'];
+        if (sa !== sb) return sa - sb;                       // waiting first
+        return a.config.created_at < b.config.created_at ? 1 : -1; // then recent
+      })
+      .slice(0, 20);
+  }, [terminals, terminalStates]);
+
+  const waitingCount = useMemo(
+    () =>
+      Array.from(terminals.values()).filter(
+        (t) =>
+          !t.scriptParentId &&
+          !t.isShellTerminal &&
+          terminalStates.get(t.config.id) === 'waiting',
+      ).length,
+    [terminals, terminalStates],
+  );
+```
+
+- [ ] **Step 4: Add the count badge to the toolbar button**
+
+Find the button's icon block (lines 52–53):
+```tsx
+        <Layers size={13} strokeWidth={2} className="text-pink-400" />
+        <ChevronDown size={10} strokeWidth={2} className="text-text-tertiary" />
+```
+Replace with:
+```tsx
+        <span className="relative inline-flex">
+          <Layers size={13} strokeWidth={2} className="text-pink-400" />
+          {waitingCount > 0 && (
+            <span
+              className="absolute -top-1.5 -right-1.5 min-w-[14px] h-[14px] px-[3px] rounded-full bg-amber-400 text-black text-[9px] font-bold leading-[14px] text-center"
+              title={`${waitingCount} session(s) waiting for input`}
+            >
+              {waitingCount}
+            </span>
+          )}
+        </span>
+        <ChevronDown size={10} strokeWidth={2} className="text-text-tertiary" />
+```
+
+- [ ] **Step 5: Show the state in each row**
+
+Find the row's status dot (line 76):
+```tsx
+                  <span className={`mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${STATUS_DOT[t.config.status]}`} />
+```
+Replace with:
+```tsx
+                  <span className="mt-1.5">
+                    <StateDot state={terminalStates.get(t.config.id) ?? 'idle'} size={6} />
+                  </span>
+```
+Then find the terminal name span (lines 79–81) and add a state-label pill after the closing `</span>` of the name, inside the `flex items-center gap-1.5` row:
+```tsx
+                      <span className="text-[12px] font-medium truncate text-text-primary">
+                        {t.config.nickname || t.config.label}
+                      </span>
+                      <span className="text-[9px] text-text-tertiary flex-shrink-0">
+                        {STATE_LABEL[terminalStates.get(t.config.id) ?? 'idle']}
+                      </span>
+```
+
+- [ ] **Step 6: Remove the now-unused STATUS_DOT constant**
+
+Find and delete (lines 6–11):
+```typescript
+const STATUS_DOT: Record<string, string> = {
+  Running: 'bg-success',
+  Idle: 'bg-warning',
+  Error: 'bg-error',
+  Stopped: 'bg-text-tertiary',
+};
+```
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no unused-symbol errors for `STATUS_DOT`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/titlebar/RecentTerminalsMenu.tsx
+git commit -m "feat: Agent View — state pills, waiting-first sort, count badge"
+```
+
+---
+
+## Task 10: Calibration + end-to-end verification
+
+This task has no code of its own — it validates the heuristics against the real
+Claude Code build and confirms the feature works end to end.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `npx vitest run`
+Expected: PASS, including the new `terminalState`, `notificationGate`, and `terminalStore` tests.
+
+- [ ] **Step 2: Type-check the whole project**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Launch the app**
+
+Run: `npm run tauri dev`
+
+- [ ] **Step 4: Calibrate the classifier against the live build**
+
+In a Claude terminal, trigger each prompt and confirm the tab dot and Agent View:
+- Ask Claude to do something needing a permission decision (e.g. run a tool that prompts) → tab dot turns **amber**, Agent View row shows **Waiting** and sorts to top, icon badge shows the count.
+- Let a normal turn finish (sits at the input box) → dot goes faint, row shows **Idle** (no notification).
+- While Claude streams → dot is **green** (Busy).
+- Close/exit Claude → row shows **Stopped**.
+
+If a real prompt is misclassified, capture the offending bottom-rows text and adjust `WAITING_PATTERNS` / `IDLE_MARKERS` in `src/lib/terminalState.ts`, add a fixture to `terminalState.test.ts` reproducing it, and re-run `npx vitest run src/lib/terminalState.test.ts`.
+
+- [ ] **Step 5: Verify the notification rule**
+
+- Background the app (or switch to another tab) and trigger a waiting prompt → exactly one native notification fires.
+- With the waiting session as the active tab **and** the window focused → no notification.
+- Set a DND window covering "now" in Settings → Notifications → no notification fires while waiting.
+
+- [ ] **Step 6: Commit any calibration changes**
+
+```bash
+git add src/lib/terminalState.ts src/lib/terminalState.test.ts
+git commit -m "test: calibrate session-state patterns against live Claude build"
+```
+
+---
+
+## Self-review notes (author check — already applied)
+
+- **Spec coverage:** 4-state model (Tasks 1, 6); xterm-buffer detection (Tasks 1, 6); store with no-op-on-unchanged (Task 3); tab dots (Task 8); Agent View on Recent Terminals with waiting-first sort + count badge (Task 9); attention-only notification with focus suppression + dedup + DND (Tasks 2, 6); no idle ping (Task 6 only notifies on `waiting`); plain-shell exclusion (Task 6); reduce-motion via global CSS (Task 5); tests for classifier, gate, store (Tasks 1–3). All spec sections map to a task.
+- **Spec discrepancy resolved:** the spec said "reuse existing DND/sound gating" — none existed, so Task 2 builds it. The existing finish-notification path in `App.tsx` is intentionally left unchanged (out of scope).
+- **Type consistency:** `SessionState` is defined once in `terminalState.ts` and imported everywhere; `classifySettled`, `setTerminalState`, `isWithinDnd`, `playNotificationSound`, `StateDot`, `useWindowFocused`, `useSessionStateDetection` names match across all tasks.
+- **Open verification (Task 9 Step 4 / Task 6):** confirm inactive-tab `TerminalView` keeps its xterm mounted; if any path disposes it the poller already falls back to last-known state.

--- a/docs/superpowers/specs/2026-06-01-session-state-smart-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-01-session-state-smart-notifications-design.md
@@ -1,0 +1,184 @@
+# Session State + Smart Notifications — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); ready for implementation planning
+**Area:** Frontend (React/TypeScript/xterm.js) + minimal app-window focus wiring
+
+## Problem
+
+ClaudeTerminal can tell you a terminal is *producing output* (the green "working" dot
+in `TerminalTabs.tsx`, driven by a purely time-based `lastOutputAt < 2000ms` check), and
+it tells you when a Claude **process exits** (`terminal-finished` → toast + optional
+notification). It cannot tell you the one thing that matters most when running several
+sessions in parallel: **which session is blocked waiting for your answer** versus merely
+churning versus finished-its-turn-and-idle.
+
+Research (verified against Anthropic primary docs and peer tools) found this is the single
+most-validated gap: Claude Code shipped "Agent View" (running / blocked-on-you / done) and
+CCManager markets per-session busy/waiting/idle indicators specifically against tools that
+lack them. Separately, users repeatedly ask (CC issues #12048, #13830, #13024) to be
+notified **only when Claude genuinely needs attention**, not on every completion, which
+causes alert fatigue.
+
+Claude Code exposes **no machine-readable state signal**, so state must be *inferred* from
+terminal output — the same approach CCManager uses.
+
+## Goals
+
+- Detect and surface per-terminal Claude state: **Busy · Waiting-for-decision · Idle · Stopped**.
+- Fire a native notification **only** when a session enters Waiting-for-decision and the
+  user isn't already looking at it.
+- Build on existing infrastructure (`lastOutputAt` activity tracking, `unreadTerminalIds`,
+  `send_notification` / `useNotification`, the title-bar Recent Terminals dropdown, the
+  Settings DND-hours + sound options).
+
+## Non-goals (YAGNI)
+
+- No "turn complete / idle" notification (attention-only by decision).
+- No backend/Rust detection — detection is frontend-side using xterm's parsed buffer.
+- No new standalone sidebar panel — the Agent View reuses the existing Recent Terminals dropdown.
+- No machine-readable IPC with Claude Code (none exists); heuristic classification is accepted.
+- No multi-CLI / non-Claude support.
+
+## State model
+
+Four states, tracked **only for Claude terminals** (excluded: plain-shell terminals,
+script children, bottom-pane shells — identified via `isShellTerminal` / `scriptParentId`
+/ plain-shell flag on the instance).
+
+| State | Meaning | Detection |
+|---|---|---|
+| **Busy** | Streaming tokens / running tools | `now - lastOutputAt < BUSY_WINDOW_MS` (~600ms) |
+| **Waiting-for-decision** | Blocking prompt awaiting the user | Output settled **and** classifier matches a prompt pattern |
+| **Idle** | Turn finished, at the empty input box | Output settled **and** no prompt pattern matched |
+| **Stopped** | Process exited | Existing `terminal-finished` event |
+
+"Needs attention" == Waiting-for-decision, and nothing else.
+
+## Detection
+
+### Pure classifier module — `src/lib/terminalState.ts`
+
+```
+export type SessionState = 'busy' | 'waiting' | 'idle' | 'stopped';
+
+// Given the bottom N rows of xterm's already-parsed buffer (clean text, no ANSI),
+// decide between a blocking prompt and a plain idle prompt.
+export function classifySettled(lines: string[]): 'waiting' | 'idle';
+```
+
+- Input is clean text read from `instance.xterm.buffer.active` (xterm has already parsed
+  ANSI), so we never hand-roll escape-code stripping.
+- Patterns live in one exported, versioned list (`WAITING_PATTERNS`) so they're cheap to
+  update as Claude Code's UI evolves. Initial set (case-insensitive, trimmed):
+  - Numbered choice menus: a line matching `^❯?\s*\d+\.\s+` near another `\d+\.\s+` line.
+  - Yes/No selectors containing `❯` plus `Yes`/`No`.
+  - Permission / proceed prompts: `Do you want to proceed`, `Do you want to`, `(y/n)`,
+    `[y/N]`, `Allow this tool`, tool-use permission phrasing.
+  - Trust prompt: `Do you trust the files in this folder`.
+- **Fail-safe:** if classification is uncertain, return `'idle'`. We must never falsely
+  raise "needs attention." (A missed prompt is a minor annoyance; a false alarm erodes
+  trust in the whole feature.)
+
+### Driver — single global poller
+
+One ~500ms interval (mounted once, e.g. in `App.tsx` or a dedicated hook
+`useSessionStateDetection`) that, for each Claude terminal:
+
+1. If `now - lastOutputAt < BUSY_WINDOW_MS` → `busy`.
+2. Else read the bottom ~15 rows of `instance.xterm.buffer.active`, join to `lines`,
+   call `classifySettled(lines)` → `waiting` | `idle`.
+3. Call `setTerminalState(id, state)` (no-ops when unchanged).
+
+xterm instances persist for **all** tabs (output is written to `instance.xterm` regardless
+of which tab is active — see `handleTerminalOutput`), so background sessions classify
+correctly. (Planning must confirm `TerminalView` keeps the xterm mounted for inactive tabs;
+if any path disposes it, fall back to the last-known state for that terminal.)
+
+## State store
+
+- High-frequency `lastOutputAt` stays in the existing plain Map in `terminalActivity`
+  (no Zustand `set()` on the streaming hot path — preserves the current optimization).
+- New Zustand state in `terminalStore`: `terminalStates: Map<string, SessionState>` plus
+  `setTerminalState(id, state)` which **returns the same state object when unchanged** so
+  no needless re-renders fire. Transitions are infrequent, so writing them to Zustand is fine.
+- `closeTerminal` / cleanup removes the id from `terminalStates` (alongside the existing
+  `clearTerminalActivity`).
+- `terminal-finished` sets state to `stopped`.
+
+## UI surfacing
+
+### Tab indicator (`TerminalTabs.tsx`)
+
+Replace the binary `isWorking` dot with a state-driven dot:
+
+- `busy` → pulsing green (current behavior).
+- `waiting` → pulsing **amber** "attention" dot (`title="Claude needs your input…"`).
+- `idle` → faint/no dot.
+- `stopped` → gray dot.
+
+Honors the existing Reduce-motion setting (no pulse animation when enabled — same gate the
+current `ct-working-dot` uses). The amber accent is added to the existing CSS class set.
+
+### Agent View (upgrade Recent Terminals dropdown — `titlebar/RecentTerminalsMenu.tsx`)
+
+- Each row shows a small state pill (Busy / Waiting / Idle / Stopped) with matching color.
+- Rows **sort Waiting-for-decision to the top**, then Busy, then Idle, then Stopped.
+- The toolbar Layers icon gets a colored **count badge** when ≥1 session is Waiting.
+- Grid view (`TerminalGrid.tsx`) reuses the same dot component for per-cell state.
+
+## Notifications
+
+- On a **transition into** `waiting`, fire exactly one native notification
+  (`useNotification().notify`) **unless** that terminal is the active tab **and** the app
+  window is focused (i.e., the user is already looking at it).
+- Dedup via a per-terminal `notifiedForPrompt` flag set when the notification fires and
+  cleared when the terminal leaves `waiting`. This prevents re-firing while the prompt
+  remains on screen across poll ticks.
+- Respects existing DND-hours and notification-sound Settings (reuse the same gating the
+  app already applies to notifications).
+- **No** idle/turn-complete notification. The existing `notifyOnFinish` (process-exit) path
+  is unchanged.
+
+### Window focus
+
+Track whether the app window is focused (Tauri window focus events, surfaced as a small
+`useWindowFocused()` hook or a store boolean). Used solely by the notification suppression
+rule above.
+
+## Edge cases
+
+- **Multi-step tool runs:** the `BUSY_WINDOW_MS` settle window prevents flickering to
+  Idle/Waiting between rapid tool outputs.
+- **Classifier uncertainty:** defaults to `idle` — never a false "needs attention."
+- **Plain shells / script children / bottom-pane shells:** skipped entirely; they have no
+  Claude prompt semantics.
+- **Restored sessions:** restored output is painted into xterm on mount; the poller will
+  classify the current on-screen state on its next tick like any other terminal.
+- **Disposed xterm (if any inactive-tab path disposes it):** retain last-known state rather
+  than forcing a default.
+
+## Testing
+
+- `classifySettled()` is pure → unit tests against fixtures captured from real Claude
+  output: permission/proceed dialog, AskUserQuestion numbered menu, Yes/No selector, trust
+  prompt, plain idle input box, and a mid-stream snapshot (should never be called for Busy,
+  but verify it doesn't classify partial output as Waiting). Include a Reduce-motion-agnostic
+  data-only test of the state→dot mapping.
+- Transition→notification logic tested with a mocked clock and mocked focus/active-tab
+  state: fires once on entry, suppressed when active+focused, re-arms after leaving Waiting,
+  respects DND.
+- State store `setTerminalState` no-op-on-unchanged test (referential stability).
+
+## Tuning constants (initial values, revisit during implementation)
+
+- `BUSY_WINDOW_MS = 600`
+- `POLL_INTERVAL_MS = 500`
+- `BUFFER_TAIL_ROWS = 15`
+
+## Open items for planning
+
+- Confirm inactive-tab `TerminalView` keeps its xterm mounted (assumed yes from
+  `handleTerminalOutput`); decide fallback if not.
+- Confirm the exact existing DND/sound gating helper to reuse so notification behavior is
+  consistent with the rest of the app.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { useTerminalStore } from './store/terminalStore';
 import { toast } from './store/toastStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useNotification } from './hooks/useNotification';
+import { useSessionStateDetection } from './hooks/useSessionStateDetection';
 import {
   applyAccentColor,
   applyThemeMode,
@@ -108,6 +109,7 @@ function App() {
   const { notify } = useNotification();
 
   useKeyboardShortcuts();
+  useSessionStateDetection();
 
   // v1.22.0 — apply theme/density/accent/motion/scale on store change.
   const themeMode = useAppStore((s) => s.themeMode);

--- a/src/components/FileChangesPanel.tsx
+++ b/src/components/FileChangesPanel.tsx
@@ -457,7 +457,7 @@ export function FileChangesPanel() {
             <button
               onClick={handleQuickPull}
               disabled={pullingTop || !activeTerminalId || !result?.is_git_repo}
-              className="flex items-center gap-1 h-6 px-1.5 rounded text-[11px] text-accent-primary hover:bg-accent-primary/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+              className="flex items-center gap-1 h-6 px-1.5 rounded text-[11px] text-success hover:bg-success/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
               title="Pull from upstream (or origin/<current branch>) into the current branch"
             >
               {pullingTop ? (
@@ -470,7 +470,7 @@ export function FileChangesPanel() {
             <button
               onClick={() => { if (activePath) useAppStore.getState().openPushModal(activePath); }}
               disabled={!activePath || !result?.is_git_repo}
-              className="flex items-center gap-1 h-6 px-1.5 rounded text-[11px] text-sky-400 hover:bg-sky-500/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
+              className="flex items-center gap-1 h-6 px-1.5 rounded text-[11px] text-error hover:bg-error/10 transition-colors disabled:opacity-40 disabled:hover:bg-transparent"
               title="Push commits to remote (Ctrl+Shift+K)"
             >
               <Upload size={12} strokeWidth={2} />

--- a/src/components/StateDot.tsx
+++ b/src/components/StateDot.tsx
@@ -1,0 +1,19 @@
+import type { SessionState } from '../lib/terminalState';
+
+const DOT: Record<SessionState, { cls: string; pulse: boolean; title: string }> = {
+  busy:    { cls: 'bg-success',          pulse: true,  title: 'Claude is working…' },
+  waiting: { cls: 'bg-amber-400',        pulse: true,  title: 'Claude needs your input' },
+  idle:    { cls: 'bg-text-tertiary/40', pulse: false, title: 'Idle' },
+  stopped: { cls: 'bg-text-tertiary',    pulse: false, title: 'Stopped' },
+};
+
+export function StateDot({ state, size = 8 }: { state: SessionState; size?: number }) {
+  const d = DOT[state];
+  return (
+    <span
+      className={`rounded-full flex-shrink-0 ${d.cls} ${d.pulse ? 'ct-working-dot' : ''}`}
+      style={{ width: size, height: size }}
+      title={d.title}
+    />
+  );
+}

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -221,7 +221,9 @@ export function TerminalTabs() {
               const liveBusy = lastOutputAt != null && now - lastOutputAt < 2000;
               // Prefer the poller's classified state; fall back to the live
               // activity timer so the dot lights up instantly on first output
-              // before the first poll tick lands.
+              // before the first poll tick lands. The 2000ms window here is
+              // intentionally wider than the poller's 600ms BUSY_WINDOW_MS to
+              // avoid flicker during the brief gap before the poller takes over.
               const sessionState: SessionState =
                 terminalStates.get(terminal.id) ?? (liveBusy ? 'busy' : 'idle');
               const isWorking = sessionState === 'busy';

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -15,6 +15,8 @@ import { BottomTerminalPane } from './BottomTerminalPane';
 import { getDragData, isTerminalDrag } from '../utils/dragDrop';
 import { useNowTick } from '../hooks/useNowTick';
 import { getLastOutputAt } from '../lib/terminalActivity';
+import { StateDot } from './StateDot';
+import type { SessionState } from '../lib/terminalState';
 
 function fileBasename(p: string): string {
   const trimmed = p.replace(/[\\/]+$/, '');
@@ -28,6 +30,7 @@ export function TerminalTabs() {
   const { terminals, activeTerminalId, setActiveTerminal, closeTerminal, unreadTerminalIds, gitInfoCache, reorderTerminals, scriptChildren, closeScript } = useTerminalStore();
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree } = useAppStore();
   const now = useNowTick();
+  const terminalStates = useTerminalStore((s) => s.terminalStates);
 
   // Selecting a terminal clears the file-tab focus (so terminal view shows),
   // selecting a file clears the terminal focus-visual intent.
@@ -215,7 +218,13 @@ export function TerminalTabs() {
               const isWorktree = instance?.isWorktree;
               const loopInfo = instance?.loopInfo;
               const lastOutputAt = getLastOutputAt(terminal.id);
-              const isWorking = lastOutputAt != null && now - lastOutputAt < 2000;
+              const liveBusy = lastOutputAt != null && now - lastOutputAt < 2000;
+              // Prefer the poller's classified state; fall back to the live
+              // activity timer so the dot lights up instantly on first output
+              // before the first poll tick lands.
+              const sessionState: SessionState =
+                terminalStates.get(terminal.id) ?? (liveBusy ? 'busy' : 'idle');
+              const isWorking = sessionState === 'busy';
               const isActiveTab = activeTerminalId === terminal.id && !activeFilePath;
 
               return (
@@ -254,11 +263,8 @@ export function TerminalTabs() {
                   {unreadTerminalIds.has(terminal.id) && activeTerminalId !== terminal.id && (
                     <div className="w-1.5 h-1.5 rounded-full bg-accent-primary flex-shrink-0" />
                   )}
-                  {isWorking && (
-                    <div
-                      className="ct-working-dot w-2 h-2 rounded-full bg-success flex-shrink-0 text-success"
-                      title="Claude is working&hellip;"
-                    />
+                  {sessionState !== 'idle' && (
+                    <StateDot state={sessionState} />
                   )}
                   {terminal.color_tag && (
                     <div className={`w-2 h-2 rounded-full ${terminal.color_tag} flex-shrink-0`} />

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -146,28 +146,12 @@ export function TitleBar() {
     ? 'bg-error'
     : 'bg-text-tertiary';
 
-  // Colorful per-icon variants for the right-side tool cluster.
-  const COLOR_BTN = {
-    emerald: {
-      base: 'text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300',
-      active: 'bg-emerald-500/20 text-emerald-300 ring-1 ring-inset ring-emerald-500/40',
-    },
-    violet: {
-      base: 'text-violet-400 hover:bg-violet-500/10 hover:text-violet-300',
-      active: 'bg-violet-500/20 text-violet-300 ring-1 ring-inset ring-violet-500/40',
-    },
-    amber: {
-      base: 'text-amber-400 hover:bg-amber-500/10 hover:text-amber-300',
-      active: 'bg-amber-500/20 text-amber-200 ring-1 ring-inset ring-amber-500/40',
-    },
-    sky: {
-      base: 'text-sky-400 hover:bg-sky-500/10 hover:text-sky-300',
-      active: 'bg-sky-500/20 text-sky-300 ring-1 ring-inset ring-sky-500/40',
-    },
-  } as const;
-  const colorBtn = (active: boolean, color: keyof typeof COLOR_BTN) =>
+  // Neutral monochrome styling for the right-side tool cluster.
+  const toolBtn = (active: boolean) =>
     `no-drag w-7 h-7 flex items-center justify-center rounded-[6px] transition-colors ${
-      active ? COLOR_BTN[color].active : COLOR_BTN[color].base
+      active
+        ? 'bg-white/[0.08] text-text-primary'
+        : 'text-text-secondary hover:bg-white/[0.06] hover:text-text-primary'
     }`;
 
   return (
@@ -335,13 +319,13 @@ export function TitleBar() {
       <div className="flex items-stretch">
         <div className="flex items-center gap-0.5 pr-2 no-drag">
           <UpdatePill />
-          <button onClick={toggleChanges} className={colorBtn(changesOpen, 'emerald')} title="File Changes (F2)">
+          <button onClick={toggleChanges} className={toolBtn(changesOpen)} title="File Changes (F2)">
             <FileDiff size={15} strokeWidth={2} />
           </button>
-          <button onClick={toggleOrchestration} className={colorBtn(orchestrationOpen, 'violet')} title="Agent Teams (F4)">
+          <button onClick={toggleOrchestration} className={toolBtn(orchestrationOpen)} title="Agent Teams (F4)">
             <Users size={15} strokeWidth={2} />
           </button>
-          <button onClick={toggleHints} className={colorBtn(hintsOpen, 'amber')} title="Command Hints">
+          <button onClick={toggleHints} className={toolBtn(hintsOpen)} title="Command Hints">
             <Lightbulb size={15} strokeWidth={2} />
           </button>
 
@@ -352,7 +336,7 @@ export function TitleBar() {
 
           <div className="w-px h-4 bg-[var(--ij-divider-soft)] mx-1" />
 
-          <button onClick={openSettings} className={colorBtn(false, 'sky')} title="Settings (Ctrl+,)">
+          <button onClick={openSettings} className={toolBtn(false)} title="Settings (Ctrl+,)">
             <Settings size={15} strokeWidth={2} />
           </button>
         </div>

--- a/src/components/titlebar/RecentTerminalsMenu.tsx
+++ b/src/components/titlebar/RecentTerminalsMenu.tsx
@@ -2,26 +2,44 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { Layers, ChevronDown, GitBranch, GitFork } from 'lucide-react';
 import { useTerminalStore } from '../../store/terminalStore';
 import { useAppStore } from '../../store/appStore';
+import { StateDot } from '../StateDot';
+import type { SessionState } from '../../lib/terminalState';
 
-const STATUS_DOT: Record<string, string> = {
-  Running: 'bg-success',
-  Idle: 'bg-warning',
-  Error: 'bg-error',
-  Stopped: 'bg-text-tertiary',
+const STATE_ORDER: Record<SessionState, number> = { waiting: 0, busy: 1, idle: 2, stopped: 3 };
+const STATE_LABEL: Record<SessionState, string> = {
+  waiting: 'Waiting', busy: 'Working', idle: 'Idle', stopped: 'Stopped',
 };
 
 export function RecentTerminalsMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const { terminals, activeTerminalId, setActiveTerminal, gitInfoCache } = useTerminalStore();
+  const terminalStates = useTerminalStore((s) => s.terminalStates);
   const openCommandPalette = useAppStore((s) => s.openCommandPalette);
 
   const items = useMemo(() => {
-    return Array.from(terminals.values())
-      .filter((t) => !t.scriptParentId && !t.isShellTerminal)
-      .sort((a, b) => (a.config.created_at < b.config.created_at ? 1 : -1))
+    const list = Array.from(terminals.values())
+      .filter((t) => !t.scriptParentId && !t.isShellTerminal);
+    return list
+      .sort((a, b) => {
+        const sa = STATE_ORDER[terminalStates.get(a.config.id) ?? 'idle'];
+        const sb = STATE_ORDER[terminalStates.get(b.config.id) ?? 'idle'];
+        if (sa !== sb) return sa - sb;                       // waiting first
+        return a.config.created_at < b.config.created_at ? 1 : -1; // then recent
+      })
       .slice(0, 20);
-  }, [terminals]);
+  }, [terminals, terminalStates]);
+
+  const waitingCount = useMemo(
+    () =>
+      Array.from(terminals.values()).filter(
+        (t) =>
+          !t.scriptParentId &&
+          !t.isShellTerminal &&
+          terminalStates.get(t.config.id) === 'waiting',
+      ).length,
+    [terminals, terminalStates],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -49,7 +67,17 @@ export function RecentTerminalsMenu() {
         title="Recent Terminals"
         aria-label="Recent Terminals"
       >
-        <Layers size={13} strokeWidth={2} className="text-pink-400" />
+        <span className="relative inline-flex">
+          <Layers size={13} strokeWidth={2} className="text-pink-400" />
+          {waitingCount > 0 && (
+            <span
+              className="absolute -top-1.5 -right-1.5 min-w-[14px] h-[14px] px-[3px] rounded-full bg-amber-400 text-black text-[9px] font-bold leading-[14px] text-center"
+              title={`${waitingCount} session(s) waiting for input`}
+            >
+              {waitingCount}
+            </span>
+          )}
+        </span>
         <ChevronDown size={10} strokeWidth={2} className="text-text-tertiary" />
       </button>
 
@@ -73,11 +101,16 @@ export function RecentTerminalsMenu() {
                     isActive ? 'bg-accent-primary/15 text-text-primary' : 'hover:bg-white/[0.05] text-text-secondary'
                   }`}
                 >
-                  <span className={`mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${STATUS_DOT[t.config.status]}`} />
+                  <span className="mt-1.5">
+                    <StateDot state={terminalStates.get(t.config.id) ?? 'idle'} size={6} />
+                  </span>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5">
                       <span className="text-[12px] font-medium truncate text-text-primary">
                         {t.config.nickname || t.config.label}
+                      </span>
+                      <span className="text-[9px] text-text-tertiary flex-shrink-0">
+                        {STATE_LABEL[terminalStates.get(t.config.id) ?? 'idle']}
                       </span>
                       {gitInfo?.is_git_repo && gitInfo.current_branch && (
                         <span className="flex items-center gap-0.5 text-[10px] font-mono text-text-tertiary flex-shrink-0">

--- a/src/components/titlebar/RecentTerminalsMenu.tsx
+++ b/src/components/titlebar/RecentTerminalsMenu.tsx
@@ -68,7 +68,7 @@ export function RecentTerminalsMenu() {
         aria-label="Recent Terminals"
       >
         <span className="relative inline-flex">
-          <Layers size={13} strokeWidth={2} className="text-pink-400" />
+          <Layers size={13} strokeWidth={2} className="text-text-secondary" />
           {waitingCount > 0 && (
             <span
               className="absolute -top-1.5 -right-1.5 min-w-[14px] h-[14px] px-[3px] rounded-full bg-amber-400 text-black text-[9px] font-bold leading-[14px] text-center"

--- a/src/components/titlebar/ToolsMenu.tsx
+++ b/src/components/titlebar/ToolsMenu.tsx
@@ -54,7 +54,7 @@ export function ToolsMenu() {
         title="Tools"
         aria-label="Tools"
       >
-        <Wrench size={13} strokeWidth={2} className="text-orange-400" />
+        <Wrench size={13} strokeWidth={2} className="text-text-secondary" />
         <ChevronDown size={10} strokeWidth={2} className="text-text-tertiary" />
       </button>
 

--- a/src/hooks/useSessionStateDetection.ts
+++ b/src/hooks/useSessionStateDetection.ts
@@ -1,0 +1,92 @@
+// Single global poller that infers each Claude terminal's session state every
+// 500ms and fires an attention notification when a session becomes blocked
+// waiting for the user. Mounted once (see App.tsx).
+
+import { useEffect, useRef } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import { useTerminalStore } from '../store/terminalStore';
+import { useAppStore } from '../store/appStore';
+import { getLastOutputAt } from '../lib/terminalActivity';
+import { classifySettled, type SessionState } from '../lib/terminalState';
+import { isWithinDnd, playNotificationSound } from '../lib/notificationGate';
+import { useNotification } from './useNotification';
+import { useWindowFocused } from './useWindowFocused';
+
+const POLL_INTERVAL_MS = 500;
+const BUSY_WINDOW_MS = 600;
+const BUFFER_TAIL_ROWS = 15;
+
+/** Read the bottom `rows` lines of xterm's already-parsed buffer as clean text. */
+function readBufferTail(term: Terminal, rows: number): string[] {
+  const buf = term.buffer.active;
+  const end = buf.length;
+  const start = Math.max(0, end - rows);
+  const out: string[] = [];
+  for (let i = start; i < end; i++) {
+    const line = buf.getLine(i);
+    out.push(line ? line.translateToString(true) : '');
+  }
+  return out;
+}
+
+export function useSessionStateDetection(): void {
+  const { notify } = useNotification();
+  const windowFocused = useWindowFocused();
+
+  // Keep focus readable inside the interval without re-creating it.
+  const focusedRef = useRef(windowFocused);
+  focusedRef.current = windowFocused;
+
+  // Terminals we've already notified for the current waiting episode.
+  const notifiedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const store = useTerminalStore.getState();
+      const app = useAppStore.getState();
+      const now = Date.now();
+
+      for (const [id, inst] of store.terminals) {
+        // Claude terminals only — skip plain shells and script children.
+        if (inst.scriptParentId || inst.isShellTerminal) continue;
+
+        // Exited process: pin to stopped and re-arm notifications.
+        if (inst.config.status === 'Stopped') {
+          store.setTerminalState(id, 'stopped');
+          notifiedRef.current.delete(id);
+          continue;
+        }
+
+        let state: SessionState;
+        const last = getLastOutputAt(id);
+        if (last != null && now - last < BUSY_WINDOW_MS) {
+          state = 'busy';
+        } else if (inst.xterm) {
+          state = classifySettled(readBufferTail(inst.xterm, BUFFER_TAIL_ROWS));
+        } else {
+          // No mounted buffer to read — keep the last known state.
+          state = store.terminalStates.get(id) ?? 'idle';
+        }
+
+        const prev = store.terminalStates.get(id);
+        store.setTerminalState(id, state);
+
+        if (state === 'waiting') {
+          const lookingAtIt = id === store.activeTerminalId && focusedRef.current;
+          const dnd = isWithinDnd(app.dndStart, app.dndEnd, new Date());
+          if (prev !== 'waiting' && !lookingAtIt && !dnd && !notifiedRef.current.has(id)) {
+            const name = inst.config.nickname || inst.config.label;
+            notify('Claude needs your input', `${name} is waiting for your response.`);
+            if (app.notificationSoundEnabled) playNotificationSound();
+            notifiedRef.current.add(id);
+          }
+        } else {
+          // Left the waiting episode — re-arm for the next prompt.
+          notifiedRef.current.delete(id);
+        }
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [notify]);
+}

--- a/src/hooks/useSessionStateDetection.ts
+++ b/src/hooks/useSessionStateDetection.ts
@@ -73,7 +73,7 @@ export function useSessionStateDetection(): void {
 
         if (state === 'waiting') {
           const lookingAtIt = id === store.activeTerminalId && focusedRef.current;
-          const dnd = isWithinDnd(app.dndStart, app.dndEnd, new Date());
+          const dnd = app.dndEnabled && isWithinDnd(app.dndStart, app.dndEnd, new Date());
           if (prev !== 'waiting' && !lookingAtIt && !dnd && !notifiedRef.current.has(id)) {
             const name = inst.config.nickname || inst.config.label;
             notify('Claude needs your input', `${name} is waiting for your response.`);

--- a/src/hooks/useSessionStateDetection.ts
+++ b/src/hooks/useSessionStateDetection.ts
@@ -88,5 +88,8 @@ export function useSessionStateDetection(): void {
     }, POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
+    // windowFocused is read via focusedRef inside the interval, so it is
+    // intentionally omitted here — no need to recreate the interval on focus
+    // change. notify is stable (useCallback).
   }, [notify]);
 }

--- a/src/hooks/useWindowFocused.ts
+++ b/src/hooks/useWindowFocused.ts
@@ -1,0 +1,24 @@
+// Tracks whether the app window currently has focus, used by the session-state
+// notification rule to suppress alerts for a session the user is looking at.
+
+import { useEffect, useState } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+
+export function useWindowFocused(): boolean {
+  const [focused, setFocused] = useState(true);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    let unlisten: (() => void) | undefined;
+
+    win.isFocused().then(setFocused).catch(() => { /* default true */ });
+    win
+      .onFocusChanged(({ payload }) => setFocused(payload))
+      .then((fn) => { unlisten = fn; })
+      .catch(() => { /* ignore */ });
+
+    return () => { unlisten?.(); };
+  }, []);
+
+  return focused;
+}

--- a/src/lib/notificationGate.test.ts
+++ b/src/lib/notificationGate.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isWithinDnd } from './notificationGate';
+
+function at(hh: number, mm: number): Date {
+  const d = new Date(2026, 5, 1, hh, mm, 0, 0);
+  return d;
+}
+
+describe('isWithinDnd', () => {
+  it('returns false when start equals end (window disabled)', () => {
+    expect(isWithinDnd('00:00', '00:00', at(3, 0))).toBe(false);
+  });
+
+  it('handles a same-day window (09:00–17:00)', () => {
+    expect(isWithinDnd('09:00', '17:00', at(12, 0))).toBe(true);
+    expect(isWithinDnd('09:00', '17:00', at(8, 59))).toBe(false);
+    expect(isWithinDnd('09:00', '17:00', at(17, 0))).toBe(false); // end exclusive
+  });
+
+  it('handles an overnight window (22:00–08:00)', () => {
+    expect(isWithinDnd('22:00', '08:00', at(23, 30))).toBe(true);
+    expect(isWithinDnd('22:00', '08:00', at(2, 0))).toBe(true);
+    expect(isWithinDnd('22:00', '08:00', at(8, 0))).toBe(false); // end exclusive
+    expect(isWithinDnd('22:00', '08:00', at(12, 0))).toBe(false);
+  });
+
+  it('treats malformed times as disabled (returns false)', () => {
+    expect(isWithinDnd('bad', '08:00', at(2, 0))).toBe(false);
+  });
+});

--- a/src/lib/notificationGate.ts
+++ b/src/lib/notificationGate.ts
@@ -1,0 +1,44 @@
+function toMinutes(hhmm: string): number | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(hhmm);
+  if (!m) return null;
+  return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+}
+
+/**
+ * True if `now` falls inside the Do-Not-Disturb window [start, end).
+ * Supports same-day (start < end) and overnight (start > end) windows.
+ * A zero-length or malformed window is treated as disabled (false).
+ */
+export function isWithinDnd(start: string, end: string, now: Date): boolean {
+  const s = toMinutes(start);
+  const e = toMinutes(end);
+  if (s === null || e === null || s === e) return false;
+  const cur = now.getHours() * 60 + now.getMinutes();
+  return s < e ? cur >= s && cur < e : cur >= s || cur < e;
+}
+
+/**
+ * Best-effort short beep for users who enable notification sound. Uses a brief
+ * Web Audio oscillator so we don't ship an audio asset. Silently no-ops if the
+ * AudioContext is unavailable or blocked.
+ */
+export function playNotificationSound(): void {
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = 880;
+    gain.gain.value = 0.05;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.12);
+    osc.onended = () => ctx.close();
+  } catch {
+    /* sound is best-effort; never throw into the poller */
+  }
+}

--- a/src/lib/terminalState.test.ts
+++ b/src/lib/terminalState.test.ts
@@ -61,4 +61,21 @@ describe('classifySettled', () => {
     ];
     expect(classifySettled(lines)).toBe('idle');
   });
+
+  it('does not raise waiting on a numbered list with no cursor and no idle box', () => {
+    const lines = [
+      'Here are the steps I took:',
+      '1. Updated the parser',
+      '2. Added a test',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+
+  it('treats a single cursor option line as idle (below the menu threshold)', () => {
+    expect(classifySettled(['❯ 1. Yes'])).toBe('idle');
+  });
+
+  it('treats empty input as idle', () => {
+    expect(classifySettled([])).toBe('idle');
+  });
 });

--- a/src/lib/terminalState.test.ts
+++ b/src/lib/terminalState.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { classifySettled } from './terminalState';
+
+describe('classifySettled', () => {
+  it('flags a "Do you want to proceed?" permission prompt as waiting', () => {
+    const lines = [
+      'Do you want to proceed?',
+      '❯ 1. Yes',
+      '  2. No, tell Claude what to do differently',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('flags an AskUserQuestion numbered menu as waiting', () => {
+    const lines = [
+      'Which approach should I take?',
+      '❯ 1. Rewrite the module',
+      '  2. Patch in place',
+      '  3. Leave it',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('flags the folder-trust prompt as waiting', () => {
+    const lines = [
+      'Do you trust the files in this folder?',
+      '❯ 1. Yes, proceed',
+      '  2. No, exit',
+    ];
+    expect(classifySettled(lines)).toBe('waiting');
+  });
+
+  it('treats the plain idle input box as idle', () => {
+    const lines = [
+      '╭───────────────────────────────╮',
+      '│ >                             │',
+      '╰───────────────────────────────╯',
+      '  ? for shortcuts',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+
+  it('does not raise waiting on a finished response that contains a numbered list', () => {
+    const lines = [
+      'Here are the steps I took:',
+      '1. Updated the parser',
+      '2. Added a test',
+      '╭───────────────────────────────╮',
+      '│ >                             │',
+      '╰───────────────────────────────╯',
+      '  ? for shortcuts',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+
+  it('treats mid-stream prose with no prompt as idle (never a false alarm)', () => {
+    const lines = [
+      '● Running the test suite…',
+      '  Updated src/foo.ts with 3 additions',
+      'Now I will check the output.',
+    ];
+    expect(classifySettled(lines)).toBe('idle');
+  });
+});

--- a/src/lib/terminalState.ts
+++ b/src/lib/terminalState.ts
@@ -1,0 +1,55 @@
+/** Inferred state of a Claude Code terminal. */
+export type SessionState = 'busy' | 'waiting' | 'idle' | 'stopped';
+
+/**
+ * Phrases that unambiguously mean Claude is blocked waiting for a decision.
+ * Kept as an exported, versioned list so they are cheap to tune as Claude
+ * Code's prompt UI changes. Matched against the joined, trimmed tail text.
+ */
+export const WAITING_PATTERNS: RegExp[] = [
+  /Do you want to proceed\??/i,
+  /Do you trust the files in this folder\??/i,
+  /\(y\/n\)/i,
+  /\[y\/N\]/,
+];
+
+/**
+ * Markers that mean the plain input box is on screen — i.e. Claude is idle and
+ * ready for a new prompt, even if a numbered list from the last response is
+ * still visible above the box.
+ */
+const IDLE_MARKERS: RegExp[] = [
+  /\?\s+for\s+shortcuts/i,
+  /^[│|]?\s*>\s*$/,
+];
+
+/** A selectable option line, e.g. "❯ 1. Yes" or "2. No". */
+const OPTION_LINE = /^(?:❯\s*)?\d+\.\s+\S/;
+
+/**
+ * Decide whether settled terminal output represents a blocking prompt
+ * (`waiting`) or a ready input box (`idle`). Only called once output has gone
+ * quiet — `busy` is handled by the caller via the activity timer.
+ *
+ * Bias: when uncertain, return `idle`. A missed prompt is a minor annoyance;
+ * a false "needs attention" alarm erodes trust in the whole feature.
+ */
+export function classifySettled(lines: string[]): 'waiting' | 'idle' {
+  const trimmed = lines.map((l) => l.trim());
+  const joined = trimmed.join('\n');
+
+  // 1. Explicit blocking phrases win immediately.
+  for (const re of WAITING_PATTERNS) {
+    if (re.test(joined)) return 'waiting';
+  }
+
+  // 2. If the plain input box is visible, Claude is idle regardless of any
+  //    numbered list left over from its last response.
+  if (IDLE_MARKERS.some((re) => trimmed.some((l) => re.test(l)))) return 'idle';
+
+  // 3. Two or more option lines = a selection menu (AskUserQuestion / picker).
+  const optionLines = trimmed.filter((l) => OPTION_LINE.test(l));
+  if (optionLines.length >= 2) return 'waiting';
+
+  return 'idle';
+}

--- a/src/lib/terminalState.ts
+++ b/src/lib/terminalState.ts
@@ -10,7 +10,7 @@ export const WAITING_PATTERNS: RegExp[] = [
   /Do you want to proceed\??/i,
   /Do you trust the files in this folder\??/i,
   /\(y\/n\)/i,
-  /\[y\/N\]/,
+  /\[y\/n\]/i,
 ];
 
 /**
@@ -47,9 +47,12 @@ export function classifySettled(lines: string[]): 'waiting' | 'idle' {
   //    numbered list left over from its last response.
   if (IDLE_MARKERS.some((re) => trimmed.some((l) => re.test(l)))) return 'idle';
 
-  // 3. Two or more option lines = a selection menu (AskUserQuestion / picker).
+  // 3. A selection menu: two or more option lines AND at least one carries the
+  //    `❯` cursor. The cursor distinguishes an interactive picker from a plain
+  //    numbered list left in a finished response.
   const optionLines = trimmed.filter((l) => OPTION_LINE.test(l));
-  if (optionLines.length >= 2) return 'waiting';
+  const hasCursor = trimmed.some((l) => /^❯\s*\d+\.\s+\S/.test(l));
+  if (optionLines.length >= 2 && hasCursor) return 'waiting';
 
   return 'idle';
 }

--- a/src/store/terminalStore.test.ts
+++ b/src/store/terminalStore.test.ts
@@ -233,3 +233,29 @@ describe('terminalStore — writeToTerminal chunking', () => {
     expect(dataLengths.every((len) => len <= 60 * 1024)).toBe(true);
   });
 });
+
+describe('terminalStore session state', () => {
+  beforeEach(() => {
+    useTerminalStore.setState({ terminalStates: new Map() });
+  });
+
+  it('setTerminalState stores a state', () => {
+    useTerminalStore.getState().setTerminalState('a', 'waiting');
+    expect(useTerminalStore.getState().terminalStates.get('a')).toBe('waiting');
+  });
+
+  it('setTerminalState is a no-op (same map reference) when unchanged', () => {
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    const before = useTerminalStore.getState().terminalStates;
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    expect(useTerminalStore.getState().terminalStates).toBe(before);
+  });
+
+  it('setTerminalState replaces the map when the value changes', () => {
+    useTerminalStore.getState().setTerminalState('a', 'busy');
+    const before = useTerminalStore.getState().terminalStates;
+    useTerminalStore.getState().setTerminalState('a', 'idle');
+    expect(useTerminalStore.getState().terminalStates).not.toBe(before);
+    expect(useTerminalStore.getState().terminalStates.get('a')).toBe('idle');
+  });
+});

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -4,6 +4,7 @@ import { Terminal } from '@xterm/xterm';
 import type { WorktreeDetectResult } from '../types/git';
 import { markTerminalActive, clearTerminalActivity } from '../lib/terminalActivity';
 import { chunkUtf8Bytes } from '../lib/chunkUtf8';
+import type { SessionState } from '../lib/terminalState';
 
 // Stay safely under the backend's 64 KB per-write cap so very large pastes
 // (multi-hundred KB) don't hit "Write payload too large".
@@ -54,6 +55,10 @@ interface TerminalState {
   terminals: Map<string, TerminalInstance>;
   activeTerminalId: string | null;
   unreadTerminalIds: Set<string>;
+  // Inferred Claude session state per terminal (busy/waiting/idle/stopped).
+  // Written only on transitions by the detection poller — never on the
+  // streaming hot path — so subscribers re-render only when state changes.
+  terminalStates: Map<string, SessionState>;
   gitInfoCache: Map<string, WorktreeDetectResult>;
   // Parent terminal ID → script child terminal ID (one child per parent).
   scriptChildren: Map<string, string>;
@@ -92,6 +97,7 @@ interface TerminalState {
   getTerminalList: () => TerminalConfig[];
   clearUnread: (id: string) => void;
   hasUnread: (id: string) => boolean;
+  setTerminalState: (id: string, state: SessionState) => void;
   fetchGitInfo: (terminalId: string) => Promise<void>;
   reorderTerminals: (orderedIds: string[]) => void;
 
@@ -113,6 +119,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminals: new Map(),
   activeTerminalId: null,
   unreadTerminalIds: new Set(),
+  terminalStates: new Map(),
   gitInfoCache: new Map(),
   scriptChildren: new Map(),
   bottomTerminalIds: [],
@@ -258,6 +265,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newGitCache = new Map(state.gitInfoCache);
       newGitCache.delete(id);
 
+      const newStates = new Map(state.terminalStates);
+      newStates.delete(id);
+      if (childId) newStates.delete(childId);
+
       const newChildren = new Map(state.scriptChildren);
       newChildren.delete(id);
 
@@ -271,6 +282,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         terminals: newTerminals,
         unreadTerminalIds: newUnread,
         gitInfoCache: newGitCache,
+        terminalStates: newStates,
         scriptChildren: newChildren,
         activeTerminalId: state.activeTerminalId === id
           ? (remainingIds[0] || null)
@@ -416,6 +428,16 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
   hasUnread: (id) => {
     return get().unreadTerminalIds.has(id);
+  },
+
+  setTerminalState: (id, state) => {
+    // Short-circuit before set() so unchanged states cause zero re-renders.
+    if (get().terminalStates.get(id) === state) return;
+    set((s) => {
+      const next = new Map(s.terminalStates);
+      next.set(id, state);
+      return { terminalStates: next };
+    });
   },
 
   fetchGitInfo: async (terminalId) => {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -523,7 +523,9 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       nextTerminals.delete(childId);
       const nextChildren = new Map(state.scriptChildren);
       nextChildren.delete(parentId);
-      return { terminals: nextTerminals, scriptChildren: nextChildren };
+      const nextStates = new Map(state.terminalStates);
+      nextStates.delete(childId);
+      return { terminals: nextTerminals, scriptChildren: nextChildren, terminalStates: nextStates };
     });
   },
 
@@ -568,10 +570,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           nextActive = nextIds[fallbackIdx];
         }
       }
+      const nextStates = new Map(state.terminalStates);
+      nextStates.delete(id);
       return {
         terminals: nextTerminals,
         bottomTerminalIds: nextIds,
         activeBottomTerminalId: nextActive,
+        terminalStates: nextStates,
       };
     });
   },


### PR DESCRIPTION
## Summary
- **Session state model** per Claude terminal — busy / waiting-for-decision / idle / stopped — inferred from xterm's parsed buffer (no machine-readable signal exists in Claude Code), with a single 500ms poller.
- **Tab indicators** now reflect all four states (green busy, amber waiting, faint idle, gray stopped).
- **Agent View**: the title-bar Recent Terminals dropdown shows per-session state pills, sorts waiting sessions to the top, and shows an amber count badge when any session needs input.
- **Attention-only notifications**: fire once when a session enters *waiting* and you're not already looking at it; respect the `dndEnabled` toggle + DND hours; no alert-fatigue on turn completion.
- **UI polish**: reverted the colored title-bar tool icons to a uniform monochrome style; File Changes Pull is green, Push is red.

## Design / Plan
- Spec: `docs/superpowers/specs/2026-06-01-session-state-smart-notifications-design.md`
- Plan: `docs/superpowers/plans/2026-06-01-session-state-smart-notifications.md`

## Test Plan
Automated (all passing): `npx tsc --noEmit`, `npx vitest run` (153 tests incl. classifier + DND gate + store), `npm run build`.

Manual GUI calibration:
- [ ] Permission / AskUserQuestion prompt → tab dot amber, Agent View "Waiting" sorted top, icon badge count
- [ ] Streaming → green; finished turn at input box → faint/idle; process exit → gray stopped
- [ ] Background-tab waiting prompt notifies; active+focused one does not
- [ ] DND window covering now (enabled) suppresses notifications; toggling DND off restores them