### PR TITLE
feat: UI polish v2 — IntelliJ IDEA primitives

### DIFF
--- a/docs/superpowers/plans/2026-07-13-ui-polish-primitives.md
+++ b/docs/superpowers/plans/2026-07-13-ui-polish-primitives.md
@@ -1,0 +1,1495 @@
+# UI Polish v2 — Primitives + Consistency Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four new `ui/` primitives (`ListRow`, `PanelHeader`, `ProgressStripe`, `EmptyState`), migrate the panels/modals/dropdowns in the spec onto them, add a status-bar notification-unread dot + optional global progress stripe, and add a "just-finished" tab flash — all as a single-release polish pass.
+
+**Architecture:** Primitive-first. Add four small React components under `src/components/ui/`; extract the only branching logic (`ProgressStripe`) to `src/lib/progressStripe.ts` for unit testing per the repo's existing style (pure helpers unit-tested; visual components verified in the dev app). Then walk each listed surface and replace its ad-hoc row/header/empty markup with the new primitives, preserving all behavior.
+
+**Tech Stack:** React 18 + TypeScript, Tailwind CSS (with the existing `--elevation-*`, accent, and text tokens from `src/index.css`), Framer Motion (already wired via `src/lib/motionTokens.ts`), Vitest for pure-helper tests. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md`.
+
+---
+
+## Prep
+
+- [ ] **Prep Step 1: Confirm baseline is green**
+
+Run:
+```bash
+cd /c/Users/talay/claude-terminal
+npx tsc --noEmit
+npm run test:run
+```
+Expected: type-check clean, all vitest suites pass. If either fails, stop and surface — the plan assumes a clean baseline.
+
+- [ ] **Prep Step 2: Read the spec**
+
+Read `docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md` end-to-end. The plan below implements every section of it. Do not deviate from the visual tokens spelled out there (heights, colors, motions).
+
+---
+
+## Task 1: `progressStripe` helper + tests
+
+**Files:**
+- Create: `src/lib/progressStripe.ts`
+- Create: `src/lib/progressStripe.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/progressStripe.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeStripeStyle } from './progressStripe';
+
+describe('computeStripeStyle', () => {
+  it('returns indeterminate mode when value is undefined', () => {
+    const s = computeStripeStyle(undefined);
+    expect(s.mode).toBe('indeterminate');
+    expect(s.width).toBeUndefined();
+  });
+
+  it('returns determinate mode with clamped width when value is provided', () => {
+    expect(computeStripeStyle(0.5)).toEqual({ mode: 'determinate', width: '50%' });
+    expect(computeStripeStyle(0)).toEqual({ mode: 'determinate', width: '0%' });
+    expect(computeStripeStyle(1)).toEqual({ mode: 'determinate', width: '100%' });
+  });
+
+  it('clamps out-of-range values', () => {
+    expect(computeStripeStyle(-0.2)).toEqual({ mode: 'determinate', width: '0%' });
+    expect(computeStripeStyle(1.5)).toEqual({ mode: 'determinate', width: '100%' });
+  });
+
+  it('treats NaN as indeterminate (defensive)', () => {
+    expect(computeStripeStyle(Number.NaN)).toEqual({ mode: 'indeterminate' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+npx vitest run src/lib/progressStripe.test.ts
+```
+Expected: FAIL — `Cannot find module './progressStripe'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/lib/progressStripe.ts`:
+
+```ts
+export interface StripeStyle {
+  mode: 'indeterminate' | 'determinate';
+  /** Only set when mode === 'determinate'. e.g. '62%'. */
+  width?: string;
+}
+
+/**
+ * Resolve the visual state for ProgressStripe. Undefined or NaN => indeterminate
+ * (animated slide). Numeric input is clamped to [0, 1] and rendered as a
+ * percentage. Extracted for unit-testing per the codebase's existing style.
+ */
+export function computeStripeStyle(value: number | undefined): StripeStyle {
+  if (value === undefined || Number.isNaN(value)) return { mode: 'indeterminate' };
+  const clamped = Math.max(0, Math.min(1, value));
+  return { mode: 'determinate', width: `${Math.round(clamped * 100)}%` };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+npx vitest run src/lib/progressStripe.test.ts
+```
+Expected: PASS, 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/progressStripe.ts src/lib/progressStripe.test.ts
+git commit -m "feat(ui): progressStripe helper + tests"
+```
+
+---
+
+## Task 2: `ProgressStripe` component
+
+**Files:**
+- Create: `src/components/ui/ProgressStripe.tsx`
+- Modify: `src/index.css` (add `ct-stripe-slide` keyframe)
+
+- [ ] **Step 1: Add the keyframe to `index.css`**
+
+Open `src/index.css`. Find the block that ends with the existing `ct-shimmer` keyframe (search for `@keyframes ct-shimmer`). Add immediately after it:
+
+```css
+/* ProgressStripe indeterminate slide (Phase-2 UI polish). Neutralised by the
+   global reduce-motion cascade above. */
+@keyframes ct-stripe-slide {
+  0%   { left: -30%; }
+  100% { left: 100%; }
+}
+```
+
+- [ ] **Step 2: Implement the component**
+
+Create `src/components/ui/ProgressStripe.tsx`:
+
+```tsx
+import { computeStripeStyle } from '../../lib/progressStripe';
+
+interface ProgressStripeProps {
+  /** 0..1 for determinate; omit for indeterminate. Values outside [0,1] are clamped. */
+  value?: number;
+  /** Reserves the 2 px row without rendering the bar — prevents layout shift. */
+  hidden?: boolean;
+  className?: string;
+}
+
+/**
+ * 2 px indeterminate or determinate progress bar. Sits inside `PanelHeader`
+ * or above a status bar. Uses the app's accent color; reduce-motion falls
+ * back to a static 30% bar via the global `[data-reduce-motion]` cascade
+ * (animation duration collapses to 0.001s).
+ */
+export function ProgressStripe({ value, hidden = false, className = '' }: ProgressStripeProps) {
+  const style = computeStripeStyle(value);
+  return (
+    <div
+      role={value === undefined ? 'progressbar' : 'progressbar'}
+      aria-valuemin={0}
+      aria-valuemax={1}
+      aria-valuenow={style.mode === 'determinate' ? value : undefined}
+      className={`relative h-[2px] overflow-hidden ${className}`}
+    >
+      {!hidden && style.mode === 'indeterminate' && (
+        <span
+          aria-hidden
+          className="absolute top-0 bottom-0 bg-accent-primary"
+          style={{
+            width: '30%',
+            left: '-30%',
+            animation: 'ct-stripe-slide 1400ms cubic-bezier(0.25, 0.1, 0.25, 1) infinite',
+          }}
+        />
+      )}
+      {!hidden && style.mode === 'determinate' && (
+        <span
+          aria-hidden
+          className="absolute top-0 bottom-0 left-0 bg-accent-primary"
+          style={{ width: style.width }}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.css src/components/ui/ProgressStripe.tsx
+git commit -m "feat(ui): ProgressStripe primitive"
+```
+
+---
+
+## Task 3: `EmptyState` component
+
+**Files:**
+- Create: `src/components/ui/EmptyState.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/components/ui/EmptyState.tsx`:
+
+```tsx
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  /** Lucide icon (or any 24 px node). Rendered at ~24 px, muted color. */
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  /** Optional primary action — pass a Button. */
+  action?: ReactNode;
+  /** Top-align instead of vertical-center. Auto-selected when the parent is short (<200px). */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * Centered vertical stack used inside panels/modals when a list is empty.
+ * Sober by design: muted icon, one-line title, optional short description,
+ * optional primary Button. No illustration, no gradient. Matches IntelliJ
+ * "No X yet" tool-window placeholders.
+ */
+export function EmptyState({ icon, title, description, action, compact = false, className = '' }: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center ${compact ? 'justify-start pt-6' : 'justify-center'} px-6 py-8 gap-2 text-center ${className}`}
+    >
+      {icon && (
+        <div className="w-8 h-8 flex items-center justify-center text-text-tertiary">
+          {icon}
+        </div>
+      )}
+      <div className="text-[13px] font-medium text-text-primary">{title}</div>
+      {description && (
+        <div className="text-[12px] text-text-tertiary max-w-[220px] leading-[1.5]">
+          {description}
+        </div>
+      )}
+      {action && <div className="mt-1.5">{action}</div>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ui/EmptyState.tsx
+git commit -m "feat(ui): EmptyState primitive"
+```
+
+---
+
+## Task 4: `ListRow` component
+
+**Files:**
+- Create: `src/components/ui/ListRow.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/components/ui/ListRow.tsx`:
+
+```tsx
+import { forwardRef } from 'react';
+import type { ReactNode, MouseEvent, KeyboardEvent } from 'react';
+
+export type ListRowVariant = 'default' | 'compact';
+
+interface ListRowProps {
+  selected?: boolean;
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  onContextMenu?: (e: MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLElement>) => void;
+  /** Optional leading icon/dot. Rendered before children. */
+  leading?: ReactNode;
+  /** Optional right-aligned meta slot (kbd chip, count, date). */
+  trailing?: ReactNode;
+  /** Render as a <button> (default — keyboard-clickable) or a <div> (for
+   *  wrapping already-interactive children). */
+  as?: 'button' | 'div';
+  /** 'default' = 26px; 'compact' = 22px. */
+  variant?: ListRowVariant;
+  title?: string;
+  ariaLabel?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Canonical selectable list item. Selected state gets an accent-blue tint
+ * plus a 2px stripe on the left (IntelliJ tool-window selection). Hover state
+ * is `bg-white/[0.045]`, consistent across every migrated surface.
+ *
+ * When `as="button"` (default), the row is keyboard-focusable and inherits
+ * the global `:focus-visible` outline from index.css.
+ */
+export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
+  {
+    selected = false,
+    disabled = false,
+    onClick,
+    onContextMenu,
+    onKeyDown,
+    leading,
+    trailing,
+    as = 'button',
+    variant = 'default',
+    title,
+    ariaLabel,
+    className = '',
+    children,
+  },
+  ref,
+) {
+  const height = variant === 'compact' ? 'h-[22px]' : 'h-[26px]';
+  const base =
+    `relative flex items-center gap-2 w-full px-3 text-left transition-colors ${height}`;
+  const state = selected
+    ? 'bg-accent-primary/12 text-text-primary'
+    : 'text-text-primary hover:bg-white/[0.045]';
+  const disabledCls = disabled ? 'opacity-50 cursor-default pointer-events-none' : '';
+
+  const content = (
+    <>
+      {selected && (
+        <span
+          aria-hidden
+          className="absolute left-0 top-[3px] bottom-[3px] w-[2px] rounded-r-[2px] bg-accent-primary"
+        />
+      )}
+      {leading && <span className="flex-shrink-0 flex items-center">{leading}</span>}
+      <span className="flex-1 min-w-0 flex items-center gap-2">{children}</span>
+      {trailing && <span className="flex-shrink-0 flex items-center">{trailing}</span>}
+    </>
+  );
+
+  if (as === 'div') {
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role="option"
+        aria-selected={selected}
+        aria-disabled={disabled || undefined}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={disabled ? undefined : onClick}
+        onContextMenu={onContextMenu}
+        onKeyDown={onKeyDown}
+        className={`${base} ${state} ${disabledCls} ${className}`}
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      ref={ref as React.Ref<HTMLButtonElement>}
+      type="button"
+      aria-selected={selected}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      onKeyDown={onKeyDown}
+      className={`${base} ${state} ${disabledCls} ${className}`}
+    >
+      {content}
+    </button>
+  );
+});
+```
+
+- [ ] **Step 2: Verify build**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ui/ListRow.tsx
+git commit -m "feat(ui): ListRow primitive with accent selection stripe"
+```
+
+---
+
+## Task 5: `PanelHeader` component
+
+**Files:**
+- Create: `src/components/ui/PanelHeader.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/components/ui/PanelHeader.tsx`:
+
+```tsx
+import type { ReactNode } from 'react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+import { ProgressStripe } from './ProgressStripe';
+
+interface PanelHeaderProps {
+  title: ReactNode;
+  /** Optional trailing count next to the title, e.g. sessions count. */
+  count?: number;
+  /** Renders a chevron on the left; when true, the whole header is a click target. */
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  /** Right-slot: usually a small cluster of icon buttons. */
+  actions?: ReactNode;
+  /** When present, renders a 2px progress bar under the header — shows either
+   *  an indeterminate slide or a determinate fill (value 0..1). */
+  progress?: { active: boolean; value?: number };
+  className?: string;
+}
+
+/**
+ * 26 px header strip for tool windows. Converges the divergent panel-title
+ * styles across the codebase onto one primitive: uppercase 11 px muted title,
+ * optional count, optional actions cluster (right), optional 2 px progress
+ * stripe below the header row.
+ */
+export function PanelHeader({
+  title,
+  count,
+  collapsible = false,
+  collapsed = false,
+  onToggleCollapsed,
+  actions,
+  progress,
+  className = '',
+}: PanelHeaderProps) {
+  const titleNode = (
+    <span className="flex items-center gap-1.5 text-text-secondary text-[11px] font-semibold uppercase tracking-[0.06em]">
+      {collapsible && (
+        collapsed
+          ? <ChevronRight size={11} strokeWidth={2} />
+          : <ChevronDown size={11} strokeWidth={2} />
+      )}
+      {title}
+      {typeof count === 'number' && count > 0 && (
+        <span className="text-text-tertiary text-[10.5px] tabular-nums normal-case tracking-normal font-normal ml-0.5">
+          {count}
+        </span>
+      )}
+    </span>
+  );
+
+  return (
+    <div className={className}>
+      <div className="h-[26px] flex items-center justify-between px-3 bg-elevation-1 border-b border-[var(--ij-divider-soft)]">
+        {collapsible ? (
+          <button
+            onClick={onToggleCollapsed}
+            className="flex items-center hover:text-text-primary transition-colors"
+            title={collapsed ? 'Expand' : 'Collapse'}
+          >
+            {titleNode}
+          </button>
+        ) : (
+          titleNode
+        )}
+        {actions && <div className="flex items-center gap-0.5">{actions}</div>}
+      </div>
+      {progress?.active && (
+        <ProgressStripe value={progress.value} className="-mt-[1px]" />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ui/PanelHeader.tsx
+git commit -m "feat(ui): PanelHeader primitive"
+```
+
+---
+
+## Task 6: Migrate `SessionsPanel`
+
+**Files:**
+- Modify: `src/components/SessionsPanel.tsx`
+
+- [ ] **Step 1: Replace the header block**
+
+Open `src/components/SessionsPanel.tsx`. Add these imports at the top of the file (alongside the existing imports):
+
+```tsx
+import { PanelHeader } from './ui/PanelHeader';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
+```
+
+Replace the entire header `<div>` block (currently at ~lines 200–230, from `<div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">` through its closing `</div>`) with:
+
+```tsx
+<PanelHeader
+  title="Sessions"
+  count={collapsed ? undefined : sessions.length}
+  collapsible
+  collapsed={collapsed}
+  onToggleCollapsed={toggleCollapsed}
+  progress={{ active: !collapsed && loading }}
+  actions={!collapsed && (
+    <button
+      onClick={fetchSessions}
+      disabled={loading}
+      className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+      title="Refresh"
+    >
+      <RefreshCw size={11} className={loading ? 'animate-spin' : ''} strokeWidth={1.75} />
+    </button>
+  )}
+/>
+```
+
+- [ ] **Step 2: Replace the empty-list placeholders with EmptyState**
+
+Still in `SessionsPanel.tsx`. Replace the block:
+
+```tsx
+{!error && sessions.length === 0 && !loading && (
+  <div className="px-3 py-2 text-text-tertiary text-[11px]">
+    No saved sessions in this folder yet.
+  </div>
+)}
+```
+
+with:
+
+```tsx
+{!error && sessions.length === 0 && !loading && (
+  <EmptyState
+    icon={<MessageSquare size={20} strokeWidth={1.75} />}
+    title="No sessions yet"
+    description="Resumable Claude sessions in this folder will appear here."
+    compact
+  />
+)}
+```
+
+- [ ] **Step 3: Replace the inner `SessionRow` implementation with `ListRow`**
+
+Still in `SessionsPanel.tsx`. Replace the entire `function SessionRow` body (its rendered `<button>` tree, ~lines 295–334) with a `ListRow`:
+
+```tsx
+function SessionRow({ session, active, onOpenInNewTab, onContextMenu }: SessionRowProps) {
+  return (
+    <ListRow
+      selected={active}
+      onClick={() => { if (!active) onOpenInNewTab(session); }}
+      onContextMenu={(e) => onContextMenu(e, session)}
+      title={session.preview || session.id}
+      leading={
+        <MessageSquare
+          size={11}
+          strokeWidth={1.75}
+          className={`shrink-0 ${active ? 'text-accent-primary' : 'text-text-tertiary'}`}
+        />
+      }
+      trailing={
+        <span className="text-[10.5px] text-text-tertiary tabular-nums">
+          {formatRelativeTime(session.modified_at)}
+        </span>
+      }
+    >
+      <span className={`text-[12px] truncate ${active ? 'text-accent-primary font-medium' : 'text-text-primary'}`}>
+        {session.preview || `Session ${session.id.slice(0, 8)}`}
+      </span>
+    </ListRow>
+  );
+}
+```
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Manual visual check**
+
+Run `npm run tauri dev`. Open a folder that has at least one saved Claude session. Verify:
+- Sessions header is 26 px, uppercase muted title with count.
+- Refresh spinner still works and a thin progress stripe appears under the header while loading.
+- Selected session row has a 2 px accent stripe on the left plus tinted background.
+- With a folder that has no sessions, the empty state renders centered with a `MessageSquare` icon.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SessionsPanel.tsx
+git commit -m "feat(sessions): migrate to PanelHeader + ListRow + EmptyState + progress"
+```
+
+---
+
+## Task 7: Migrate `FileTreePanel` and `Sidebar`'s outer header
+
+**Files:**
+- Modify: `src/components/FileTreePanel.tsx`
+- Modify: `src/components/Sidebar.tsx`
+
+- [ ] **Step 1: Replace the outer Sidebar "PROJECT" header**
+
+Open `src/components/Sidebar.tsx`. At the top imports, add:
+
+```tsx
+import { PanelHeader } from './ui/PanelHeader';
+```
+
+Replace the header block (currently the `<div className="flex items-center justify-between h-[30px] px-3 ...">` and its children) with:
+
+```tsx
+<PanelHeader
+  title={<><FolderTree size={12} strokeWidth={1.75} />Project</>}
+  actions={
+    <Tooltip label="Collapse Sidebar">
+      <button
+        onClick={toggleSidebarCollapse}
+        className="w-6 h-6 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors"
+      >
+        <ChevronsLeft size={13} strokeWidth={1.75} />
+      </button>
+    </Tooltip>
+  }
+/>
+```
+
+- [ ] **Step 2: Migrate FileTreePanel header**
+
+Open `src/components/FileTreePanel.tsx`. Locate the panel's header block (the current inline uppercase title + refresh/pin buttons cluster). Add the import:
+
+```tsx
+import { PanelHeader } from './ui/PanelHeader';
+```
+
+Replace the header block with a `PanelHeader` invocation that preserves the existing title, actions (pin/reveal/refresh), and — if the panel has a loading state — the progress prop. Read the current header for the exact actions cluster; do not drop any buttons.
+
+- [ ] **Step 3: Migrate the file-tree row rendering to `ListRow (compact)`**
+
+In `FileTreePanel.tsx`, locate the row-rendering function (search for the `<button` or `<div` that renders each file/folder). Add the import:
+
+```tsx
+import { ListRow } from './ui/ListRow';
+```
+
+Replace the row markup with `<ListRow variant="compact" selected={isActive} onClick={...} leading={<icon/>} trailing={...}>{name}</ListRow>`. Preserve all existing click/context/keyboard handlers and the folder-vs-file iconography.
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Manual visual check**
+
+Run `npm run tauri dev`. Open a folder in the Explorer panel. Verify:
+- Sidebar's "PROJECT" header is unchanged visually but goes through `PanelHeader`.
+- FileTreePanel rows are 22 px, hover fill consistent, selected file has the 2 px stripe.
+- All existing behavior (expand folders, click to open, right-click menu) still works.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FileTreePanel.tsx src/components/Sidebar.tsx
+git commit -m "feat(sidebar): migrate outer header + file tree to PanelHeader + ListRow"
+```
+
+---
+
+## Task 8: Migrate `TitleBar` branch dropdown to `ListRow (compact)`
+
+**Files:**
+- Modify: `src/components/TitleBar.tsx`
+
+- [ ] **Step 1: Add import**
+
+At the top of `src/components/TitleBar.tsx`, add:
+
+```tsx
+import { ListRow } from './ui/ListRow';
+```
+
+- [ ] **Step 2: Replace each `<button>` inside the branch dropdown with `ListRow`**
+
+In `TitleBar.tsx`, find the branch-list mapping block (search for `filteredBranches.map((b) =>`). Replace each rendered `<button>` (currently ~lines 262–280) with:
+
+```tsx
+<ListRow
+  key={b}
+  variant="compact"
+  selected={b === gitInfo.current_branch}
+  disabled={checkoutTarget === b || b === gitInfo.current_branch}
+  onClick={() => handleCheckout(b)}
+  trailing={
+    checkoutTarget === b ? (
+      <Loader2 size={11} className="animate-spin text-text-tertiary" />
+    ) : b === gitInfo.current_branch ? (
+      <Check size={12} className="text-accent-primary" />
+    ) : null
+  }
+>
+  <span className="truncate font-mono text-[12px]">{b}</span>
+</ListRow>
+```
+
+- [ ] **Step 3: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 4: Manual visual check**
+
+Run `npm run tauri dev`. Open the branch dropdown from the title bar. Verify:
+- Current branch row has the 2 px accent stripe on the left.
+- Filter input still works.
+- Hover / click on a different branch still checks it out.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TitleBar.tsx
+git commit -m "feat(titlebar): branch dropdown uses ListRow"
+```
+
+---
+
+## Task 9: Migrate `SessionWidget` dropdown to `ListRow (compact)`
+
+**Files:**
+- Modify: `src/components/titlebar/SessionWidget.tsx`
+
+- [ ] **Step 1: Add import**
+
+Add to the top of `src/components/titlebar/SessionWidget.tsx`:
+
+```tsx
+import { ListRow } from '../ui/ListRow';
+```
+
+- [ ] **Step 2: Replace each session row inside the dropdown with `ListRow`**
+
+Find the session-list mapping block inside the widget's dropdown. Replace each rendered row (currently a `<button>` or `<div>` with a state dot + name + branch + cwd) with:
+
+```tsx
+<ListRow
+  key={t.id}
+  variant="compact"
+  selected={t.id === activeTerminalId}
+  onClick={() => onSelect(t.id)}
+  leading={<StateDot state={terminalStates.get(t.id) ?? 'idle'} />}
+  trailing={t.git_branch && (
+    <span className={`text-[11px] font-mono ${t.isWorktree ? 'text-purple-400' : 'text-text-tertiary'} truncate max-w-[80px]`}>
+      {t.git_branch}
+    </span>
+  )}
+>
+  <span className="truncate text-[12px]">{t.nickname || t.label}</span>
+  <span className="text-text-tertiary text-[11px] truncate">{t.cwdBase}</span>
+</ListRow>
+```
+
+Adjust the property names to match the widget's local variables — do **not** rename them; they're already established.
+
+- [ ] **Step 3: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 4: Manual visual check**
+
+Run `npm run tauri dev`. Open the session widget dropdown from the titlebar. Verify:
+- Active session has the 2 px accent stripe.
+- Waiting-count badge in the collapsed widget is unchanged.
+- Click switches terminals; footer actions still work.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/titlebar/SessionWidget.tsx
+git commit -m "feat(titlebar): session widget dropdown uses ListRow"
+```
+
+---
+
+## Task 10: Migrate `FileChangesPanel` change rows to `ListRow`
+
+**Files:**
+- Modify: `src/components/FileChangesPanel.tsx`
+- Modify: `src/components/ChangelistSection.tsx` (only the leaf row rendering)
+
+- [ ] **Step 1: Add import to `ChangelistSection.tsx`**
+
+At the top of `src/components/ChangelistSection.tsx`, add:
+
+```tsx
+import { ListRow } from './ui/ListRow';
+```
+
+- [ ] **Step 2: Replace only the file-change leaf-row markup**
+
+Inside `ChangelistSection.tsx`, find the row that renders each individual file change (typically has status letter + file path + optional selected/staged indicators). **Do not touch** the collapsible section headers, staging buttons, or drag-drop wrappers — they are load-bearing per the spec.
+
+Replace the leaf row's `<div>` or `<button>` with:
+
+```tsx
+<ListRow
+  variant="compact"
+  selected={isExpanded}                 // or isActive, per the existing local flag
+  onClick={onToggleExpand}
+  leading={<StatusGlyph status={change.status} />}
+  trailing={change.staged && <Check size={11} className="text-emerald-400" />}
+  title={change.path}
+>
+  <span className="truncate text-[12px] font-mono">{change.path}</span>
+</ListRow>
+```
+
+Use whatever the existing local names are for `isExpanded` / `StatusGlyph` — do not introduce new components.
+
+- [ ] **Step 3: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 4: Manual visual check**
+
+Run `npm run tauri dev` in a git repo with uncommitted changes. Open the Git panel. Verify:
+- Selected/expanded file row has the accent stripe.
+- Group headers, drag-drop, and staging buttons all still work.
+- Right-click still opens the file context menu.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ChangelistSection.tsx
+git commit -m "feat(git): file-change rows use ListRow"
+```
+
+---
+
+## Task 11: Migrate `WorktreeModal` list
+
+**Files:**
+- Modify: `src/components/WorktreeModal.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
+```
+
+- [ ] **Step 2: Replace the worktree list rows**
+
+Find the mapping over worktrees inside `WorktreeModal.tsx`. Replace each row's markup with:
+
+```tsx
+<ListRow
+  key={wt.path}
+  selected={wt.path === selectedPath}
+  onClick={() => setSelectedPath(wt.path)}
+  leading={<GitBranch size={12} strokeWidth={1.75} className={wt.is_worktree ? 'text-purple-400' : 'text-text-tertiary'} />}
+  trailing={wt.branch && (
+    <span className="text-[11px] font-mono text-text-tertiary truncate max-w-[120px]">{wt.branch}</span>
+  )}
+>
+  <span className="truncate text-[12px]">{wt.name}</span>
+</ListRow>
+```
+
+Match the local property names of the existing worktree data (`name`, `path`, `branch`, `is_worktree`) — do not rename.
+
+- [ ] **Step 3: Add an EmptyState for the "no worktrees" case**
+
+Find the current "No worktrees" text-only fallback. Replace with:
+
+```tsx
+<EmptyState
+  icon={<GitBranch size={20} strokeWidth={1.75} />}
+  title="No worktrees"
+  description="Create a worktree to work on multiple branches in parallel."
+  compact
+/>
+```
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/WorktreeModal.tsx
+git commit -m "feat(worktree): modal uses ListRow + EmptyState"
+```
+
+---
+
+## Task 12: Migrate `SnippetsModal` list
+
+**Files:**
+- Modify: `src/components/SnippetsModal.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
+```
+
+- [ ] **Step 2: Replace snippet row markup with `ListRow`**
+
+Find the mapping over snippets. Replace each row's markup with:
+
+```tsx
+<ListRow
+  key={s.id}
+  selected={s.id === selectedId}
+  onClick={() => setSelectedId(s.id)}
+  onContextMenu={(e) => openContextMenu(e, s)}
+  trailing={<span className="text-[11px] text-text-tertiary tabular-nums">{s.hits ?? ''}</span>}
+>
+  <span className="truncate text-[12px]">{s.title}</span>
+  <span className="text-text-tertiary text-[11px] font-mono truncate">{s.shortcut}</span>
+</ListRow>
+```
+
+Adjust to match the actual local variable names.
+
+- [ ] **Step 3: Add EmptyState for empty search / no snippets**
+
+Replace whichever placeholder is currently shown when the snippets list is empty (either "no snippets" or "no match") with an `EmptyState` invocation using an appropriate icon (`FileText` or `Search`) and short description.
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/SnippetsModal.tsx
+git commit -m "feat(snippets): modal uses ListRow + EmptyState"
+```
+
+---
+
+## Task 13: Migrate `NewTerminalModal` recent/profile lists
+
+**Files:**
+- Modify: `src/components/NewTerminalModal.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
+```
+
+- [ ] **Step 2: Replace each list row (recents, profiles, suggestions)**
+
+Locate every list inside the modal that renders items (recent folders, profiles, filtered suggestions). For each `<button>` or `<div>` row, swap to `<ListRow selected={...} onClick={...} leading={<icon/>} trailing={<meta/>}>{name}</ListRow>`. Do not change the click handlers or keyboard-navigation logic.
+
+- [ ] **Step 3: Add EmptyState for empty search results**
+
+Where the modal currently shows "No matches" as a plain paragraph, swap to `EmptyState` with a small `Search` or `FolderOpen` icon and a one-line description.
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/NewTerminalModal.tsx
+git commit -m "feat(new-terminal): modal uses ListRow + EmptyState"
+```
+
+---
+
+## Task 14: Migrate `ProfileModal` profile list
+
+**Files:**
+- Modify: `src/components/ProfileModal.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
+```
+
+- [ ] **Step 2: Replace profile row markup with `ListRow`**
+
+Locate the profile list mapping. Replace each row with a `ListRow` (default variant) including the profile name (children), color dot (leading), and any right-side meta (trailing). Preserve onClick / onContextMenu behavior.
+
+- [ ] **Step 3: Add EmptyState when no profiles exist**
+
+Replace the "No profiles yet" placeholder with `EmptyState` (icon = `User` or `Settings`, description "Create a profile to save Claude command-line flags for reuse.", optional action = a small `Button` that triggers the "new profile" flow).
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ProfileModal.tsx
+git commit -m "feat(profiles): modal uses ListRow + EmptyState"
+```
+
+---
+
+## Task 15: Migrate `SessionHistory` rows
+
+**Files:**
+- Modify: `src/components/SessionHistory.tsx`
+
+- [ ] **Step 1: Add import**
+
+```tsx
+import { ListRow } from './ui/ListRow';
+```
+
+- [ ] **Step 2: Replace each history row with `ListRow (compact)`**
+
+Find the history-list mapping. Replace each rendered row with `<ListRow variant="compact" selected={...} onClick={...} leading={<Clock/>} trailing={<time/>}>{label}</ListRow>`. Preserve click behavior.
+
+- [ ] **Step 3: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SessionHistory.tsx
+git commit -m "feat(history): rows use ListRow"
+```
+
+---
+
+## Task 16: `StatusBar` — unread-notification dot on the bell
+
+**Files:**
+- Modify: `src/store/appStore.ts`
+- Modify: `src/components/StatusBar.tsx`
+- Modify: `src/App.tsx` (increment on background finish)
+
+- [ ] **Step 1: Add store state**
+
+Open `src/store/appStore.ts`. Add two new fields to the persisted store slice and their setters, mirroring the existing patterns (e.g. `notifyOnFinish`):
+
+```ts
+// in the state interface
+unreadNotificationCount: number;
+incrementUnreadNotifications: () => void;
+clearUnreadNotifications: () => void;
+```
+
+Implementation inside the store creator:
+
+```ts
+unreadNotificationCount: 0,
+incrementUnreadNotifications: () => set((s) => ({ unreadNotificationCount: s.unreadNotificationCount + 1 })),
+clearUnreadNotifications: () => set({ unreadNotificationCount: 0 }),
+```
+
+Add `unreadNotificationCount` to the persist middleware's `partialize` allow-list (find the existing allow-list keys and append this one), and update the matching test in `src/store/appStore.test.ts` — the test's "persisted keys allow-list" assertion must include the new key.
+
+- [ ] **Step 2: Increment on background finish**
+
+Open `src/App.tsx`. Find the existing `terminal-finished` event listener. Immediately before it fires the toast/notification, add:
+
+```ts
+if (document.hidden) {
+  useAppStore.getState().incrementUnreadNotifications();
+}
+```
+
+- [ ] **Step 3: Render the dot on the bell**
+
+Open `src/components/StatusBar.tsx`. Read the unread count from the store:
+
+```tsx
+const unreadCount = useAppStore((s) => s.unreadNotificationCount);
+const clearUnread = useAppStore((s) => s.clearUnreadNotifications);
+```
+
+Wrap the existing notification-bell button so that when `unreadCount > 0`, a 6 px accent dot appears at the top-right of the icon. Also invoke `clearUnread()` in the button's `onClick` (in addition to the existing toggle). Concretely:
+
+```tsx
+<Tooltip label={notifyOnFinish ? 'Notifications on' : 'Notifications off'} side="top">
+  <button
+    onClick={() => { setNotifyOnFinish(!notifyOnFinish); clearUnread(); }}
+    className={`relative flex items-center h-[18px] w-[22px] justify-center rounded-[3px] transition-colors hover:bg-white/[0.06] ${
+      notifyOnFinish ? 'text-text-secondary hover:text-text-primary' : 'text-text-tertiary hover:text-text-secondary'
+    }`}
+  >
+    {notifyOnFinish ? <Bell size={11} strokeWidth={1.75} /> : <BellOff size={11} strokeWidth={1.75} />}
+    {unreadCount > 0 && (
+      <span
+        aria-hidden
+        className="absolute top-[1px] right-[2px] w-[6px] h-[6px] rounded-full bg-accent-primary"
+      />
+    )}
+  </button>
+</Tooltip>
+```
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run test:run
+npm run build
+```
+Expected: all clean; the appStore persist-allow-list test now includes `unreadNotificationCount`.
+
+- [ ] **Step 5: Manual visual check**
+
+Run `npm run tauri dev`. Start a terminal, hide the window (minimize / switch app), and wait for a Claude session to finish. Refocus the app — the status-bar bell should show a dot. Click the bell — dot disappears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/appStore.ts src/store/appStore.test.ts src/App.tsx src/components/StatusBar.tsx
+git commit -m "feat(statusbar): unread-notification dot"
+```
+
+---
+
+## Task 17: `StatusBar` — optional global progress stripe
+
+**Files:**
+- Modify: `src/store/appStore.ts`
+- Modify: `src/components/StatusBar.tsx`
+- Modify: `src/lsp/*.ts` (call the setter on start/ready)
+- Modify: any git fetch/pull invocation site that already tracks local `loading` — publish it up
+
+- [ ] **Step 1: Add store state**
+
+In `src/store/appStore.ts`:
+
+```ts
+// in the state interface
+globalBusy: string | null;              // label of the currently-busy activity (e.g. 'LSP starting…') or null
+setGlobalBusy: (label: string | null) => void;
+```
+
+Implementation:
+
+```ts
+globalBusy: null,
+setGlobalBusy: (label) => set({ globalBusy: label }),
+```
+
+Do **not** persist `globalBusy` — omit from `partialize`. It's ephemeral.
+
+- [ ] **Step 2: Render the stripe above the status bar**
+
+In `src/components/StatusBar.tsx`, import `ProgressStripe`:
+
+```tsx
+import { ProgressStripe } from './ui/ProgressStripe';
+```
+
+Read the state:
+
+```tsx
+const globalBusy = useAppStore((s) => s.globalBusy);
+```
+
+Wrap the current `<div className="h-[22px] ...">` in a fragment and add the stripe immediately above it:
+
+```tsx
+return (
+  <div className="flex flex-col shrink-0">
+    {globalBusy && <ProgressStripe />}
+    <div className="h-[22px] ...">
+      {/* existing content unchanged */}
+    </div>
+  </div>
+);
+```
+
+- [ ] **Step 3: Hook LSP startup**
+
+Open `src/lib/lsp/lspClient.ts` (or wherever the LSP start/ready handshake lives). At the moment the client transitions to `starting`, call `useAppStore.getState().setGlobalBusy('Starting language server…')`. When the client transitions to `ready` (or errors), call `useAppStore.getState().setGlobalBusy(null)`.
+
+If multiple language servers may start concurrently, keep a **counter** in the module (not the store) and only clear the store label when the counter drops to zero — otherwise the last one ready clears the stripe even if others are still starting.
+
+- [ ] **Step 4: Hook git fetch/pull**
+
+Find the sites that already track a local `loading` flag around `git_fetch` / `git_pull_branch` invocations (search: `git_fetch\|git_pull_branch`). For each, mirror the local `loading` to `setGlobalBusy('Fetching…')` / `setGlobalBusy('Pulling…')` and clear it on completion/error. Keep the local `loading` state as-is (it drives per-panel UI).
+
+- [ ] **Step 5: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean.
+
+- [ ] **Step 6: Manual visual check**
+
+Run `npm run tauri dev`. Open a `.ts` file to trigger LSP startup — a 2 px accent stripe should appear above the status bar and disappear once the LSP is ready. Trigger a `git pull` from the file-changes panel — the stripe should appear again while it runs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/store/appStore.ts src/components/StatusBar.tsx src/lib/lsp/lspClient.ts src/components/FileChangesPanel.tsx
+git commit -m "feat(statusbar): global progress stripe (LSP + git ops)"
+```
+
+---
+
+## Task 18: Tab "just-finished" green flash
+
+**Files:**
+- Modify: `src/index.css` (new keyframe)
+- Modify: `src/components/TerminalTabs.tsx` (data-attribute + trigger)
+- Modify: `src/store/terminalStore.ts` (transient `justFinishedAt` map)
+
+- [ ] **Step 1: Add the keyframe**
+
+Open `src/index.css`. After the existing `ct-shimmer` block, add:
+
+```css
+/* Tab bottom-underline "just finished" flash (Phase-2 UI polish). Runs once
+   for 800 ms when a terminal transitions from busy → idle. Reduce-motion
+   collapses to a static color change via the global cascade. */
+@keyframes ct-tab-finish {
+  0%   { background-color: rgb(74, 222, 128); }     /* --success */
+  100% { background-color: var(--accent-primary); }
+}
+.ct-tab-finish::after {
+  animation: ct-tab-finish 800ms cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+```
+
+- [ ] **Step 2: Track "just-finished" per terminal in the store**
+
+Open `src/store/terminalStore.ts`. Locate the state-transition logic that already updates `terminalStates`. In the branch where a terminal moves from `busy` → `idle`, additionally set a timestamp:
+
+```ts
+// alongside the existing terminalStates update:
+const justFinishedAt = new Map(get().justFinishedAt);
+justFinishedAt.set(id, Date.now());
+set({ justFinishedAt });
+
+setTimeout(() => {
+  const map = new Map(get().justFinishedAt);
+  if (map.get(id) === Date.now()) return;   // defensive
+  map.delete(id);
+  set({ justFinishedAt: map });
+}, 850);   // slightly longer than the 800ms animation so React unmounts the class cleanly
+```
+
+Add `justFinishedAt: Map<string, number>` to the interface. Initial value `new Map()`.
+
+- [ ] **Step 3: Apply the class to the active underline**
+
+Open `src/components/TerminalTabs.tsx`. Locate the tab's inner underline element (the current active-underline `<span>` at the bottom, around line 283). Extend its className to include `ct-tab-finish` when `justFinishedAt.get(terminal.id)` is set:
+
+```tsx
+{(isActiveTab || splitDropTargetId === terminal.id) && (
+  <span
+    className={`absolute left-2 right-2 bottom-0 h-[2px] rounded-t bg-accent-primary ${
+      useTerminalStore.getState().justFinishedAt.has(terminal.id) ? 'ct-tab-finish' : ''
+    }`}
+  />
+)}
+```
+
+Subscribe to `justFinishedAt` via a Zustand selector at the top of the component so React re-renders when it changes:
+
+```tsx
+const justFinishedAt = useTerminalStore((s) => s.justFinishedAt);
+```
+
+And use `justFinishedAt.has(terminal.id)` in the classname (not the `getState()` call inline).
+
+For **inactive tabs** that finish, apply the same class briefly so the user sees the flash from across the tab strip. Reuse the existing `ct-working-tab::after` selector — that pseudo-element already sits at the same position. Add a sibling rule:
+
+```css
+.ct-tab-finish-inactive::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 2px;
+  animation: ct-tab-finish 800ms cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+```
+
+And apply `ct-tab-finish-inactive` to the tab wrapper when `justFinishedAt.has(id) && !isActiveTab`.
+
+- [ ] **Step 4: Verify type-check + build**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run test:run
+npm run build
+```
+Expected: all clean.
+
+- [ ] **Step 5: Manual visual check**
+
+Run `npm run tauri dev`. In an active terminal, type a Claude prompt and wait for it to finish. The active tab's bottom underline should flash green for ~800 ms then fade back to accent blue. Switch to another terminal while the first is busy and let it finish — the inactive tab flashes green in the strip.
+
+- [ ] **Step 6: Reduce-motion verification**
+
+Open Settings → Appearance → toggle "Reduce motion" ON. Re-run the same finish sequence. The color should still change (green → blue) but instantly, with no visible animation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/index.css src/components/TerminalTabs.tsx src/store/terminalStore.ts
+git commit -m "feat(tabs): green flash on busy → idle transition"
+```
+
+---
+
+## Task 19: Final verification + release prep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full type-check + build + tests**
+
+Run:
+```bash
+npx tsc --noEmit
+npm run test:run
+npm run build
+```
+Expected: all green. If anything fails, stop and fix before proceeding.
+
+- [ ] **Step 2: End-to-end visual smoke test**
+
+Run `npm run tauri dev`. Walk through this checklist and confirm each item:
+
+1. Sidebar's "PROJECT" header height/style is unchanged; expand/collapse works.
+2. Sessions panel — refresh spinner + progress stripe both fire; selected row has stripe; empty state renders in a folder with no sessions.
+3. FileTreePanel — hovering, selecting, expanding folders all still work; selected file has stripe.
+4. TitleBar branch dropdown — current branch has stripe; other branches don't; filter still works.
+5. Session widget dropdown — active session has stripe.
+6. FileChangesPanel — expanded change row has stripe; group headers and staging unchanged.
+7. WorktreeModal — worktrees list uses stripe; empty state renders when there are none.
+8. SnippetsModal — selected snippet has stripe; empty-search state renders.
+9. NewTerminalModal — recent/profile rows have stripe when selected; empty search state renders.
+10. ProfileModal — profile rows have stripe; empty state renders.
+11. SessionHistory — rows migrated.
+12. StatusBar — unread bell dot appears on background-finish; clears on click.
+13. StatusBar — global progress stripe appears during LSP startup and git pull.
+14. Terminal tab — flashes green for ~800 ms on busy → idle.
+
+- [ ] **Step 3: Reduce-motion pass**
+
+Enable the in-app "Reduce motion" toggle. Repeat items 2, 13, and 14 above. Confirm no animation plays — stripes are static/absent, tab flash is instant, all list-row hover transitions are instant.
+
+- [ ] **Step 4: Cross-platform sanity**
+
+If a Mac is available, build there and repeat items 4, 12, 14. If only Windows: skip and note in the release PR.
+
+- [ ] **Step 5: Prepare release notes entry**
+
+Open `src/changelog.json`. Add a new entry above the existing 1.27.1 block:
+
+```jsonc
+{
+  "version": "1.28.0",
+  "date": "2026-07-13",
+  "sections": [
+    {
+      "heading": "UI polish",
+      "items": [
+        "New selection stripe on list rows across sessions, file tree, branch and session widgets.",
+        "Consistent tool-window headers with optional progress bar (LSP startup, git fetch/pull).",
+        "Empty states in sessions, worktrees, snippets, new-terminal, and profiles.",
+        "Status-bar notification bell shows an unread dot when a session finishes in the background.",
+        "Terminal tab flashes green when a session finishes."
+      ]
+    }
+  ]
+}
+```
+
+Do not bump the version files here — that's the `/publish 1.28.0` command's job.
+
+- [ ] **Step 6: Commit changelog**
+
+```bash
+git add src/changelog.json
+git commit -m "docs: changelog for 1.28.0 UI polish"
+```
+
+- [ ] **Step 7: Hand off to release**
+
+The full polish pass is done. The next command is `/publish 1.28.0`.
+
+---
+
+## Self-review checks (done — see below)
+
+- **Spec coverage:** Every migration surface in the spec's Part 2 table maps to a task (6–15). Part 3 status-bar additions → Tasks 16, 17. Part 4 motion delta → Task 18 (tab flash), Task 5 (modal open — verified in place via `dialogMotion` which the primitive already uses). Part 1 primitives → Tasks 1–5. Verification section → Task 19.
+- **No placeholders:** No TBD/TODO/vague "handle appropriately" instructions; every step has concrete code or a concrete search key.
+- **Type consistency:** `ListRow` props (`selected`, `disabled`, `variant`, `leading`, `trailing`, `as`) are consistent across every consumer. `PanelHeader` `progress` prop shape (`{active, value?}`) is consistent. `computeStripeStyle` return type matches the consumer.
+- **Ambiguity fixes applied:** Task 17 clarifies that `globalBusy` counts multiple concurrent LSP starts via a module counter (not the store).

--- a/docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md
@@ -1,0 +1,269 @@
+# UI Polish v2 — Shared Primitives + Consistency Pass
+
+**Date:** 2026-07-13
+**Goal:** Close the remaining IntelliJ-fidelity gaps end-users notice — list-row
+selection stripe, panel headers, per-panel progress, considered empty states —
+by extending the `src/components/ui/` primitive set and migrating existing
+panels/modals onto it. Purely visual and behavioral polish; no new features,
+no color-scheme or font changes, no layout re-work.
+
+## Non-goals
+
+- **No** change to `--elevation-0…4`, `#3574F0` accent, Inter, or JetBrains Mono
+- **No** change to `--ui-row-py/px` density tokens (compact/comfortable/spacious keep their current values)
+- **No** re-layout of Sidebar/Explorer/Terminal grid — containers keep their current geometry
+- **No** new features; behavior of every migrated component is preserved
+- **No** tooltip migration inside Settings modals (~120 sites, deferred per the 2026-07-08 spec)
+- **No** touchup to `xterm` content itself (terminal rendering is out of scope)
+
+## Part 1 — New primitives
+
+Four new components in `src/components/ui/`. Each is small, prop-driven, and
+inherits the existing focus-ring cascade from `index.css`. Each ships with a
+`*.test.tsx` (rendered smoke test + one behavior test where behavior exists).
+
+### 1.1 `ListRow`
+
+The canonical selectable list-item. Replaces the ad-hoc
+`<button className="w-full ... hover:bg-white/[0.045] ...">` blocks scattered
+across `SessionsPanel`, `SessionHistory`, `FileTreePanel`, `WorktreeModal`,
+`SnippetsModal`, and the branch dropdown in `TitleBar`.
+
+**API:**
+
+```tsx
+<ListRow
+  selected={boolean}
+  onClick={() => void}
+  onContextMenu={(e) => void}
+  leading={<Icon />}                // optional
+  trailing={<span>meta</span>}      // optional right-aligned slot (kbd, count, date)
+  disabled={boolean}
+  as="button" | "div"               // default 'button'
+  variant="default" | "compact"     // 'compact' = 22px, 'default' = 26px
+  ariaLabel={string}
+  className={string}
+>
+  {/* row body — usually a name + badges */}
+</ListRow>
+```
+
+**Look:**
+
+- Height: 26 px (`default`), 22 px (`compact`). Both respect `--ui-row-py/px`
+  via the shared spacing utilities — density still cascades.
+- Idle: `text-text-primary`, no background.
+- Hover: `bg-white/[0.045]` (matches existing pattern).
+- **Selected: `bg-accent-primary/12` + a 2 px left stripe (`::before`,
+  `bg-accent-primary`, `top: 3px; bottom: 3px; border-radius: 0 2px 2px 0`).**
+  The stripe is the visual anchor missing today — every IntelliJ tool window
+  uses one.
+- Focus (keyboard): the global `:focus-visible` outline still applies; the
+  selected stripe is orthogonal to focus.
+- Disabled: `opacity-50 cursor-default`.
+- Reduce-motion: no override needed; row-level transitions are already
+  `transition-colors` which the global reduce-motion cascade neutralizes.
+
+### 1.2 `PanelHeader`
+
+The 26 px header strip used at the top of every tool window
+(SessionsPanel, FileChangesPanel, FileTreePanel, WorktreeModal, etc.). Today
+these headers all diverge slightly — some 30 px, some 26 px, uppercase title
+here, sentence case there, different action-button paddings. `PanelHeader`
+converges them.
+
+**API:**
+
+```tsx
+<PanelHeader
+  title="Sessions"
+  count={4}                              // optional trailing count
+  collapsible={boolean}                  // renders a chevron on the left; defaults to false
+  collapsed={boolean}                    // controlled
+  onToggleCollapsed={() => void}
+  actions={<><IconButton .../><IconButton .../></>}   // right-slot
+  progress={<ProgressStripe indeterminate />}          // optional (see 1.3)
+/>
+```
+
+**Look:**
+
+- Height 26 px, `bg-elevation-1`, bottom border `border-[var(--ij-divider-soft)]`.
+- Title: 11 px, `font-semibold`, `uppercase`, `tracking-[0.06em]`,
+  `text-text-secondary` — same treatment as the existing Sidebar "PROJECT"
+  header, promoted to a primitive.
+- Count: 10.5 px, tabular-nums, `text-text-tertiary`, non-uppercase.
+- Actions slot: right-aligned, small icon buttons (20 × 20 px, 3 px radius,
+  hover `bg-white/[0.06]`). Uses a nested `IconButton` sub-primitive
+  (defined in the same file — not exported separately, YAGNI).
+- Progress slot: renders a `ProgressStripe` immediately below the header row,
+  overlapping the bottom border by 1 px so the border becomes the progress
+  bar's rail when active. Zero-height when not passed → no layout shift.
+
+### 1.3 `ProgressStripe`
+
+Thin (2 px) indeterminate or determinate bar. Used inside `PanelHeader.progress`
+today; can later be dropped anywhere a panel needs "work in progress" feedback
+(LSP starting, git fetching, session polling).
+
+**API:**
+
+```tsx
+<ProgressStripe />                    // indeterminate (default)
+<ProgressStripe value={0.62} />       // determinate, 0..1
+<ProgressStripe hidden />             // reserves the 2 px so layout doesn't jump
+```
+
+**Look:**
+
+- Height 2 px, transparent track.
+- Indeterminate: a 30% wide gradient bar slides left→right on a 1.4 s loop,
+  color `--accent-primary`. Neutralised by reduce-motion (bar becomes a
+  static 30% width instead of animating).
+- Determinate: filled bar from `0..value`, no animation.
+- Never renders shadow/glow — the stripe is a rail, not a chrome element.
+
+### 1.4 `EmptyState`
+
+Centered vertical stack for empty lists. Replaces the current one-line
+`text-text-tertiary` "No X yet" placeholders — sober but considered.
+
+**API:**
+
+```tsx
+<EmptyState
+  icon={<Terminal />}                    // Lucide icon, sized ~24 px
+  title="No terminals yet"
+  description="Create a Claude Code session to start working on a project."
+  action={<Button variant="primary" size="sm" icon={<Plus />}>New Terminal</Button>}   // optional
+/>
+```
+
+**Look:**
+
+- Vertical stack, `padding: 32px 24px`, `gap-2`.
+- Icon: 32 × 32 px container, `color: text-text-tertiary`, no background.
+- Title: 13 px, `text-text-primary`, `font-medium`.
+- Description: 12 px, `text-text-tertiary`, `max-width: 220px`, `line-height: 1.5`.
+- Action: renders whatever `Button` is passed; primary/sm/plus-icon is the
+  recommended composition.
+- Alignment: centered when the container is ≥ 200 px tall, top-aligned
+  otherwise (small panels use the same primitive without wasting height).
+
+## Part 2 — Migration map
+
+Each row: **surface → primitive(s) it adopts → what changes visibly**.
+
+| Surface | Primitive(s) | Visible change |
+| --- | --- | --- |
+| `SessionsPanel` header + rows | `PanelHeader`, `ListRow`, `EmptyState`, `ProgressStripe` (when `loading`) | Rows gain the accent stripe on the active session; header count becomes consistent; empty-repo state is a considered stack; refresh spinner promoted to the panel-level `ProgressStripe`. |
+| `FileChangesPanel` group headers + rows | `ListRow` for change rows; keep the current bespoke section headers (they carry too much unique logic — commit/push/stash — to fold into `PanelHeader` right now). | Selected change row gets accent stripe; hover consistency across the panel. |
+| `FileTreePanel` header + rows | `PanelHeader`, `ListRow (compact)` | Header height unifies; tree rows get consistent hover; selected file gets accent stripe. |
+| `Sidebar` outer "PROJECT" header | `PanelHeader` | Same look, but centralised. |
+| `WorktreeModal` list | `ListRow`, `EmptyState` | Row stripe for selected; "no worktrees" becomes the empty state. |
+| `SnippetsModal` list | `ListRow`, `EmptyState` | Row stripe for selected; empty search state uses `EmptyState`. |
+| `TitleBar` branch dropdown | `ListRow (compact)` | Row stripe for current branch (replacing the current `text-accent-primary bg-accent-primary/10`). |
+| `SessionWidget` dropdown | `ListRow (compact)` | Same. |
+| `NewTerminalModal` recent/profile list | `ListRow`, `EmptyState` | Row stripe on hover-selected suggestion; empty search state. |
+| `ProfileModal` profile list | `ListRow`, `EmptyState` | Same. |
+| `SessionHistory` rows | `ListRow (compact)` | Same. |
+| `StatusBar` | — (see Part 3) | Adds notification bell + unread dot; can host a `ProgressStripe` above the bar during LSP startup / global git operations (opt-in only, off by default). |
+
+`ChangelistSection` inside `FileChangesPanel` is intentionally **not migrated**
+— its collapsible group + drag-drop staging targets are load-bearing and
+inline-only. Extracting them would fight the primitive.
+
+## Part 3 — StatusBar additions
+
+Two small end-user-visible additions:
+
+1. **Notification bell (already present)** — augmented with an unread dot
+   (2 px accent circle at top-right of the bell glyph) that appears when a
+   terminal finished while the app was un-focused and the notification event
+   has not been acknowledged. Clicking the bell clears the dot. State lives
+   in `appStore` (`unreadNotificationCount: number`, incremented by the
+   existing `terminal-finished` listener when `document.hidden`).
+
+2. **Global progress stripe (opt-in)** — a 2 px `ProgressStripe` rendered
+   above the status bar's border, driven by a new `appStore.globalBusy: string
+   | null` flag. Only two hooks light it up: LSP startup (already emits an
+   event via the LspManager), and long-running git fetch/pull operations
+   (already track their `loading` state locally — publish it up to the store).
+   Hidden by default so existing users see zero visual delta unless one of
+   those hooks fires.
+
+## Part 4 — Motion polish delta
+
+Small, additive changes to the shared motion behaviour:
+
+- **Modal open** — already uses `dialogMotion` (`scale 0.98 → 1 + fade`,
+  120 ms). Verify every modal that currently doesn't use the `Modal`
+  primitive is migrated in this pass (audit: grep for `motion.div … role="dialog"`
+  outside `Modal.tsx`).
+- **"Just-finished" tab flash** — when a terminal transitions from `busy` →
+  `idle`, its tab's bottom underline flashes `--success` for 800 ms then
+  fades back. Implemented as a new keyframe `ct-tab-finish` in
+  `index.css`, added to the tab element via a data attribute the poller
+  sets and clears. Reduce-motion falls back to a static 800 ms color change.
+- **Tab close-x reveal** — already present (`opacity-0 group-hover:opacity-100`).
+  Keep; verify all three "action" icons inside the tab (split, duplicate,
+  add-to-grid) share the same reveal pattern.
+- **Notification-bell unread pulse** — the dot pulses (0.9 → 1.0 opacity,
+  1.4 s) once, then goes static, matching the existing `ct-pulse-dot`
+  keyframe but running once. Reduce-motion: static from frame 1.
+
+## Part 5 — File structure
+
+New files:
+
+```
+src/components/ui/
+  ListRow.tsx         + ListRow.test.tsx
+  PanelHeader.tsx     + PanelHeader.test.tsx
+  ProgressStripe.tsx  + ProgressStripe.test.tsx
+  EmptyState.tsx      + EmptyState.test.tsx
+```
+
+Modified files (migration):
+
+- `src/components/SessionsPanel.tsx`
+- `src/components/FileChangesPanel.tsx`
+- `src/components/FileTreePanel.tsx`
+- `src/components/Sidebar.tsx`
+- `src/components/WorktreeModal.tsx`
+- `src/components/SnippetsModal.tsx`
+- `src/components/TitleBar.tsx`
+- `src/components/titlebar/SessionWidget.tsx`
+- `src/components/NewTerminalModal.tsx`
+- `src/components/ProfileModal.tsx`
+- `src/components/SessionHistory.tsx`
+- `src/components/StatusBar.tsx`
+- `src/store/appStore.ts` (adds `unreadNotificationCount`, `globalBusy`)
+- `src/index.css` (adds the `ct-tab-finish` keyframe)
+
+No files are deleted.
+
+## Verification
+
+- `npx tsc --noEmit` — clean.
+- `vite build` — clean.
+- Vitest — all existing suites plus the four new `*.test.tsx` files green.
+- Manual visual check in `npm run tauri dev` (port 5174):
+  1. Open Sessions panel with a folder that has ≥ 1 saved session — active
+     session row shows the 2 px accent stripe on the left.
+  2. Empty a Snippets modal (search for a nonsense string) — empty state
+     renders centered with a muted icon.
+  3. Start LSP by opening a `.ts` file — status bar's `ProgressStripe`
+     appears above the border, disappears when LSP is ready.
+  4. Finish a Claude session — the corresponding tab flashes green for
+     ~800 ms then returns to its idle color.
+  5. Trigger `terminal-finished` while the app is unfocused — the
+     status-bar notification bell shows a dot; clicking clears it.
+- Reduce-motion: enable `prefers-reduced-motion` (or the in-app toggle) and
+  verify none of the new animations play — stripes are static, tab flash is
+  a plain color change, unread pulse is a static dot.
+
+## Rollout
+
+Single PR / single release (target v1.28.0). No feature flag — this is
+purely visual polish; there's no user-facing setting to expose.

--- a/docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-13-ui-polish-primitives-design.md
@@ -19,8 +19,12 @@ no color-scheme or font changes, no layout re-work.
 ## Part 1 — New primitives
 
 Four new components in `src/components/ui/`. Each is small, prop-driven, and
-inherits the existing focus-ring cascade from `index.css`. Each ships with a
-`*.test.tsx` (rendered smoke test + one behavior test where behavior exists).
+inherits the existing focus-ring cascade from `index.css`. Where a primitive
+has non-trivial branching logic (currently only `ProgressStripe`), that logic
+is extracted to `src/lib/<name>.ts` and unit-tested there, matching the
+existing codebase style (see `tooltipPosition.test.ts`). The rest is visual
+polish — verified in the running dev app, not in a rendered-component test
+(this repo does not use `@testing-library/react`).
 
 ### 1.1 `ListRow`
 
@@ -218,10 +222,12 @@ New files:
 
 ```
 src/components/ui/
-  ListRow.tsx         + ListRow.test.tsx
-  PanelHeader.tsx     + PanelHeader.test.tsx
-  ProgressStripe.tsx  + ProgressStripe.test.tsx
-  EmptyState.tsx      + EmptyState.test.tsx
+  ListRow.tsx
+  PanelHeader.tsx
+  ProgressStripe.tsx
+  EmptyState.tsx
+src/lib/
+  progressStripe.ts       + progressStripe.test.ts
 ```
 
 Modified files (migration):
@@ -246,8 +252,8 @@ No files are deleted.
 ## Verification
 
 - `npx tsc --noEmit` — clean.
-- `vite build` — clean.
-- Vitest — all existing suites plus the four new `*.test.tsx` files green.
+- `npm run build` — clean.
+- Vitest — all existing suites plus the new `progressStripe.test.ts` green.
 - Manual visual check in `npm run tauri dev` (port 5174):
   1. Open Sessions panel with a folder that has ≥ 1 saved session — active
      session row shows the 2 px accent stripe on the left.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -482,6 +482,11 @@ function App() {
       // Always show in-app toast
       toast.info('Terminal Finished', `${name} has finished running.`);
 
+      // Status-bar unread dot when the user isn't watching.
+      if (document.hidden) {
+        useAppStore.getState().incrementUnreadNotifications();
+      }
+
       if (notifyOnFinish) {
         notify('Terminal Finished', `${name} has finished running.`);
       }

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "1.28.0",
+    "date": "2026-07-13",
+    "features": [
+      { "title": "Accent stripe on selected list rows", "description": "Every selectable list in the app - Sessions, Explorer, branches, session widget, Worktrees, Snippets, Profiles, History - now marks the selected row with a 2 px accent-blue stripe on the left plus a subtle tint. The IntelliJ tool-window selection you'd expect." },
+      { "title": "Consistent tool-window headers", "description": "Sessions and Explorer share a single 26 px header primitive - uppercase muted title, count badge, action buttons on the right, and an optional thin progress bar under the header that lights up while the panel is loading." },
+      { "title": "Considered empty states", "description": "Empty lists in Sessions, Worktrees, Snippets, Profiles, and History now show a centered stack (muted icon + short title + one-line description) instead of a lonely paragraph." },
+      { "title": "Status-bar notification dot", "description": "When a terminal finishes while the app is in the background, the status-bar bell shows a small accent dot. Click the bell to clear it." },
+      { "title": "Global progress stripe", "description": "A 2 px accent stripe appears above the status bar while a language server is starting or a git pull is running, so you know work is in flight even when the panel that started it is out of view." },
+      { "title": "Tab flashes green when a session finishes", "description": "The active terminal's tab briefly flashes green on the busy → idle transition, then fades back to accent blue. Inactive tabs get the same signal on their underline so you can catch it from across the strip." }
+    ]
+  },
+  {
     "version": "1.27.1",
     "date": "2026-07-09",
     "features": [

--- a/src/components/FileChangesPanel.tsx
+++ b/src/components/FileChangesPanel.tsx
@@ -304,6 +304,7 @@ export function FileChangesPanel() {
   const handleQuickPull = useCallback(async () => {
     if (!activePath || !result?.is_git_repo) return;
     setPullingTop(true);
+    useAppStore.getState().setGlobalBusy('Pulling…');
     try {
       const upstream = await invoke<string | null>('get_upstream_branch', { path: activePath });
       let remote: string | null = null;
@@ -346,6 +347,7 @@ export function FileChangesPanel() {
       toast.error('Pull failed', typeof err === 'string' ? err : 'Unknown error');
     } finally {
       setPullingTop(false);
+      useAppStore.getState().setGlobalBusy(null);
     }
   }, [activePath, result?.is_git_repo, result?.branch, activeTerminalId, activeCwd, triggerChangesRefreshAction]);
 
@@ -1068,6 +1070,7 @@ function RepoRow({ repo }: { repo: ScannedGitRepo }) {
     const branch = pullRef.slice(slashIdx + 1);
 
     setPulling(true);
+    useAppStore.getState().setGlobalBusy('Pulling…');
     try {
       const msg = await pullWithStashConfirm({
         path: repo.path,
@@ -1087,6 +1090,7 @@ function RepoRow({ repo }: { repo: ScannedGitRepo }) {
       toast.error('Pull failed', typeof err === 'string' ? err : 'Unknown error');
     } finally {
       setPulling(false);
+      useAppStore.getState().setGlobalBusy(null);
     }
   }, [repo.path, pullRef, pullStrategy, activeTerminalId, activeCwd, fetchGitInfo, triggerChangesRefreshAction]);
 

--- a/src/components/FileTreePanel.tsx
+++ b/src/components/FileTreePanel.tsx
@@ -19,6 +19,8 @@ import { useAppStore } from '../store/appStore';
 import { useTerminalStore } from '../store/terminalStore';
 import { getFileIconUrl, getFolderIconUrl } from '../utils/fileIcons';
 import { toast } from '../store/toastStore';
+import { PanelHeader } from './ui/PanelHeader';
+import { ListRow } from './ui/ListRow';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 const REVEAL_LABEL = isMac ? 'Reveal in Finder' : 'Show in File Explorer';
@@ -108,6 +110,7 @@ export function FileTreePanel() {
   const defaultClaudeArgs = useAppStore((s) => s.defaultClaudeArgs);
   const setPinnedRepoPath = useAppStore((s) => s.setPinnedRepoPath);
   const openFileTab = useAppStore((s) => s.openFileTab);
+  const activeFilePath = useAppStore((s) => s.activeFilePath);
   const changesRefreshTrigger = useAppStore((s) => s.changesRefreshTrigger);
   const triggerChangesRefresh = useAppStore((s) => s.triggerChangesRefresh);
   const collapsed = useAppStore((s) => s.explorerCollapsed);
@@ -556,31 +559,25 @@ export function FileTreePanel() {
 
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden">
-      {/* Section header */}
-      <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
-        <button
-          onClick={toggleCollapsed}
-          className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors"
-          title={collapsed ? 'Expand Explorer' : 'Collapse Explorer'}
-        >
-          {collapsed ? (
-            <ChevronRight size={11} strokeWidth={2} />
-          ) : (
-            <ChevronDown size={11} strokeWidth={2} />
-          )}
-          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">Explorer</span>
-        </button>
-        {!collapsed && (
-          <button
-            onClick={refreshRoot}
-            disabled={rootLoading}
-            className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
-            title="Refresh"
-          >
-            <RefreshCw size={11} className={rootLoading ? 'animate-spin' : ''} strokeWidth={1.75} />
-          </button>
-        )}
-      </div>
+      <PanelHeader
+        title="Explorer"
+        collapsible
+        collapsed={collapsed}
+        onToggleCollapsed={toggleCollapsed}
+        progress={{ active: !collapsed && rootLoading }}
+        actions={
+          !collapsed ? (
+            <button
+              onClick={refreshRoot}
+              disabled={rootLoading}
+              className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+              title="Refresh"
+            >
+              <RefreshCw size={11} className={rootLoading ? 'animate-spin' : ''} strokeWidth={1.75} />
+            </button>
+          ) : undefined
+        }
+      />
 
       {/* Root path label */}
       {!collapsed && rootPath && (
@@ -622,6 +619,7 @@ export function FileTreePanel() {
             renamingPath={renamingPath}
             onRenameCommit={doRenameCommit}
             onRenameCancel={() => setRenamingPath(null)}
+            activeFilePath={activeFilePath}
           />
         ))}
       </div>}
@@ -726,6 +724,7 @@ interface TreeRowProps {
   renamingPath: string | null;
   onRenameCommit: (oldPath: string, newName: string) => void;
   onRenameCancel: () => void;
+  activeFilePath: string | null;
 }
 
 function TreeRow({
@@ -738,14 +737,13 @@ function TreeRow({
   renamingPath,
   onRenameCommit,
   onRenameCancel,
+  activeFilePath,
 }: TreeRowProps) {
   const { entry } = node;
   const indent = 8 + depth * 12;
   const isRenaming = renamingPath === entry.path;
   const isCut = cutPaths !== null && cutPaths.includes(entry.path);
-  const rowClass = `group flex items-center gap-1 h-[22px] px-1 rounded-[3px] cursor-pointer hover:bg-white/[0.045] transition-colors ${
-    isCut ? 'opacity-50' : ''
-  }`;
+  const cutClass = isCut ? 'opacity-50' : '';
 
   const renameInput = isRenaming && (
     <RenameInput
@@ -758,30 +756,36 @@ function TreeRow({
   if (entry.is_dir) {
     return (
       <>
-        <div
-          className={rowClass}
-          style={{ paddingLeft: indent }}
+        <ListRow
+          as="div"
+          variant="compact"
           onClick={() => { if (!isRenaming) onToggle(node); }}
           onContextMenu={(e) => onContextMenu(e, entry.path, true)}
+          style={{ paddingLeft: indent }}
+          className={cutClass}
+          leading={
+            <>
+              {node.expanded ? (
+                <ChevronDown size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
+              ) : (
+                <ChevronRight size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
+              )}
+              <img
+                src={getFolderIconUrl(entry.name, node.expanded)}
+                alt=""
+                aria-hidden="true"
+                draggable={false}
+                className="w-[14px] h-[14px] shrink-0 select-none"
+              />
+            </>
+          }
         >
-          {node.expanded ? (
-            <ChevronDown size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
-          ) : (
-            <ChevronRight size={11} className="text-text-tertiary shrink-0" strokeWidth={2} />
-          )}
-          <img
-            src={getFolderIconUrl(entry.name, node.expanded)}
-            alt=""
-            aria-hidden="true"
-            draggable={false}
-            className="w-[14px] h-[14px] shrink-0 select-none"
-          />
           {isRenaming ? renameInput : (
             <span className="text-[12px] text-text-primary truncate" title={entry.name}>
               {entry.name}
             </span>
           )}
-        </div>
+        </ListRow>
         {node.expanded && node.loading && (
           <div className="text-text-tertiary text-[11px]" style={{ paddingLeft: indent + 24 }}>
             Loading…
@@ -804,6 +808,7 @@ function TreeRow({
             renamingPath={renamingPath}
             onRenameCommit={onRenameCommit}
             onRenameCancel={onRenameCancel}
+            activeFilePath={activeFilePath}
           />
         ))}
       </>
@@ -811,25 +816,33 @@ function TreeRow({
   }
 
   // File row
+  const isActive = activeFilePath === entry.path;
   return (
-    <div
-      className={rowClass}
-      style={{ paddingLeft: indent + 12 /* align with folder names */ }}
+    <ListRow
+      as="div"
+      variant="compact"
+      selected={isActive}
       onClick={() => { if (!isRenaming) onOpenFile(entry.path); }}
       onContextMenu={(e) => onContextMenu(e, entry.path, false)}
       title={entry.path}
+      style={{ paddingLeft: indent + 12 }}
+      className={cutClass}
+      leading={
+        <img
+          src={getFileIconUrl(entry.name)}
+          alt=""
+          aria-hidden="true"
+          draggable={false}
+          className="w-[14px] h-[14px] shrink-0 select-none"
+        />
+      }
     >
-      <img
-        src={getFileIconUrl(entry.name)}
-        alt=""
-        aria-hidden="true"
-        draggable={false}
-        className="w-[14px] h-[14px] shrink-0 select-none"
-      />
       {isRenaming ? renameInput : (
-        <span className="text-[12px] text-text-secondary truncate">{entry.name}</span>
+        <span className={`text-[12px] truncate ${isActive ? 'text-text-primary' : 'text-text-secondary'}`}>
+          {entry.name}
+        </span>
       )}
-    </div>
+    </ListRow>
   );
 }
 

--- a/src/components/NewTerminalModal.tsx
+++ b/src/components/NewTerminalModal.tsx
@@ -9,6 +9,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import type { WorktreeInfo, WorktreeDetectResult } from '../types/git';
 import { Button } from './ui/Button';
 import { Modal } from './ui/Modal';
+import { ListRow } from './ui/ListRow';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
@@ -469,23 +470,22 @@ export function NewTerminalModal() {
                     const isSelected = selectedWorktreePath === wt.path
                       || (!selectedWorktreePath && wt.path.replace(/\//g, '\\') === workingDirectory.replace(/\//g, '\\'));
                     return (
-                      <button
+                      <ListRow
                         key={wt.path}
+                        selected={isSelected}
                         onClick={() => {
                           setSelectedWorktreePath(wt.path);
                           setWorkingDirectory(wt.path);
                         }}
-                        className={`w-full flex items-center gap-2 p-2 rounded-md text-left transition-colors ${
-                          isSelected
-                            ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
-                            : 'bg-bg-primary ring-1 ring-border hover:ring-border-light'
-                        }`}
+                        className="items-start py-1.5"
+                        leading={
+                          wt.is_main ? (
+                            <GitBranch size={13} className="text-accent-primary flex-shrink-0" />
+                          ) : (
+                            <GitFork size={13} className="text-purple-400 flex-shrink-0" />
+                          )
+                        }
                       >
-                        {wt.is_main ? (
-                          <GitBranch size={13} className="text-accent-primary flex-shrink-0" />
-                        ) : (
-                          <GitFork size={13} className="text-purple-400 flex-shrink-0" />
-                        )}
                         <div className="flex-1 min-w-0">
                           <p className="text-text-primary text-[12px] font-mono truncate">
                             {wt.branch || '(detached)'}
@@ -493,7 +493,7 @@ export function NewTerminalModal() {
                           </p>
                           <p className="text-text-tertiary text-[11px] truncate">{wt.path}</p>
                         </div>
-                      </button>
+                      </ListRow>
                     );
                   })}
                 </div>

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { X, Plus, Trash2, Save, FolderOpen } from 'lucide-react';
+import { X, Plus, Trash2, Save, FolderOpen, User } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useAppStore } from '../store/appStore';
@@ -7,6 +7,8 @@ import { toast } from '../store/toastStore';
 import { v4 as uuidv4 } from 'uuid';
 import { Button } from './ui/Button';
 import { Modal } from './ui/Modal';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
 
 interface ConfigProfile {
   id: string;
@@ -141,27 +143,29 @@ export function ProfileModal() {
 
             <div className="flex-1 overflow-y-auto space-y-0.5">
               {profiles.map((profile) => (
-                <div
+                <ListRow
                   key={profile.id}
+                  selected={selectedProfile?.id === profile.id}
                   onClick={() => {
                     setSelectedProfile(profile);
                     setIsCreating(false);
                   }}
-                  className={`p-2 rounded-md cursor-pointer transition-colors ${
-                    selectedProfile?.id === profile.id
-                      ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
-                      : 'hover:bg-white/[0.04]'
-                  }`}
+                  className="items-start py-1.5"
                 >
-                  <p className="text-text-primary text-[12px] font-medium truncate">{profile.name}</p>
-                  <p className="text-text-tertiary text-[11px] truncate">{profile.description || 'No description'}</p>
-                </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-text-primary text-[12px] font-medium truncate">{profile.name}</p>
+                    <p className="text-text-tertiary text-[11px] truncate">{profile.description || 'No description'}</p>
+                  </div>
+                </ListRow>
               ))}
 
               {profiles.length === 0 && (
-                <p className="text-text-tertiary text-[12px] text-center py-4">
-                  No profiles yet
-                </p>
+                <EmptyState
+                  icon={<User size={20} strokeWidth={1.75} />}
+                  title="No profiles yet"
+                  description="Save Claude command-line flags and env vars as reusable profiles."
+                  compact
+                />
               )}
             </div>
           </div>

--- a/src/components/SessionHistory.tsx
+++ b/src/components/SessionHistory.tsx
@@ -3,6 +3,8 @@ import { motion } from 'framer-motion';
 import { X, Trash2, Clock, FileText } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '../store/appStore';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
 
 interface SessionHistoryEntry {
   id: number;
@@ -124,42 +126,42 @@ export function SessionHistory() {
           {/* Left: Entry List */}
           <div className="w-72 border-r border-border overflow-y-auto p-2">
             {entries.map((entry) => (
-              <div
+              <ListRow
                 key={entry.id}
+                selected={selectedEntry?.id === entry.id}
                 onClick={() => handleSelect(entry)}
-                className={`group p-2.5 rounded-md cursor-pointer transition-colors mb-0.5 ${
-                  selectedEntry?.id === entry.id
-                    ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
-                    : 'hover:bg-white/[0.04]'
-                }`}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="min-w-0 flex-1">
-                    <p className="text-text-primary text-[12px] font-medium truncate">{entry.label}</p>
-                    <p className="text-text-tertiary text-[11px] mt-0.5">
-                      {formatDate(entry.started_at)}
-                    </p>
-                    <p className="text-text-tertiary text-[11px]">
-                      Duration: {formatDuration(entry.started_at, entry.ended_at)}
-                    </p>
-                  </div>
+                className="group items-start py-1.5 mb-0.5"
+                trailing={
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
                       handleDelete(entry);
                     }}
-                    className="p-1 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0"
+                    className="p-1 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
                   >
                     <Trash2 size={12} />
                   </button>
+                }
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-text-primary text-[12px] font-medium truncate">{entry.label}</p>
+                  <p className="text-text-tertiary text-[11px] mt-0.5">
+                    {formatDate(entry.started_at)}
+                  </p>
+                  <p className="text-text-tertiary text-[11px]">
+                    Duration: {formatDuration(entry.started_at, entry.ended_at)}
+                  </p>
                 </div>
-              </div>
+              </ListRow>
             ))}
 
             {entries.length === 0 && (
-              <p className="text-text-tertiary text-[12px] text-center py-8">
-                No session history yet
-              </p>
+              <EmptyState
+                icon={<Clock size={20} strokeWidth={1.75} />}
+                title="No session history yet"
+                description="Closed terminals with saved logs will appear here."
+                compact
+              />
             )}
           </div>
 

--- a/src/components/SessionsPanel.tsx
+++ b/src/components/SessionsPanel.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import {
-  ChevronRight,
-  ChevronDown,
   RefreshCw,
   MessageSquare,
   ExternalLink,
@@ -13,6 +11,9 @@ import { homeDir } from '@tauri-apps/api/path';
 import { useAppStore } from '../store/appStore';
 import { useTerminalStore } from '../store/terminalStore';
 import { toast } from '../store/toastStore';
+import { PanelHeader } from './ui/PanelHeader';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 const REVEAL_LABEL = isMac ? 'Reveal in Finder' : 'Show in File Explorer';
@@ -197,37 +198,26 @@ export function SessionsPanel() {
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between h-[26px] px-3 flex-shrink-0">
-        <button
-          onClick={toggleCollapsed}
-          className="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition-colors"
-          title={collapsed ? 'Expand Sessions' : 'Collapse Sessions'}
-        >
-          {collapsed ? (
-            <ChevronRight size={11} strokeWidth={2} />
-          ) : (
-            <ChevronDown size={11} strokeWidth={2} />
-          )}
-          <span className="text-[11px] font-semibold uppercase tracking-[0.06em]">
-            Sessions
-          </span>
-          {sessions.length > 0 && !collapsed && (
-            <span className="text-text-tertiary text-[10.5px] tabular-nums">
-              {sessions.length}
-            </span>
-          )}
-        </button>
-        {!collapsed && (
-          <button
-            onClick={fetchSessions}
-            disabled={loading}
-            className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
-            title="Refresh"
-          >
-            <RefreshCw size={11} className={loading ? 'animate-spin' : ''} strokeWidth={1.75} />
-          </button>
-        )}
-      </div>
+      <PanelHeader
+        title="Sessions"
+        count={collapsed ? undefined : sessions.length}
+        collapsible
+        collapsed={collapsed}
+        onToggleCollapsed={toggleCollapsed}
+        progress={{ active: !collapsed && loading }}
+        actions={
+          !collapsed ? (
+            <button
+              onClick={fetchSessions}
+              disabled={loading}
+              className="w-5 h-5 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-40"
+              title="Refresh"
+            >
+              <RefreshCw size={11} className={loading ? 'animate-spin' : ''} strokeWidth={1.75} />
+            </button>
+          ) : undefined
+        }
+      />
 
       {/* Body - only when expanded */}
       {!collapsed && (
@@ -248,9 +238,12 @@ export function SessionsPanel() {
                 <div className="px-3 py-2 text-red-400 text-[11px]">{error}</div>
               )}
               {!error && sessions.length === 0 && !loading && (
-                <div className="px-3 py-2 text-text-tertiary text-[11px]">
-                  No saved sessions in this folder yet.
-                </div>
+                <EmptyState
+                  icon={<MessageSquare size={20} strokeWidth={1.75} />}
+                  title="No sessions yet"
+                  description="Resumable Claude sessions in this folder will appear here."
+                  compact
+                />
               )}
               {sessions.map((s) => {
                 const isActive = activeSessionId === s.id;
@@ -294,42 +287,32 @@ interface SessionRowProps {
 
 function SessionRow({ session, active, onOpenInNewTab, onContextMenu }: SessionRowProps) {
   return (
-    <button
-      type="button"
+    <ListRow
+      selected={active}
       onClick={() => { if (!active) onOpenInNewTab(session); }}
       onContextMenu={(e) => onContextMenu(e, session)}
       title={session.preview || session.id}
-      className={`w-full text-left px-3 py-1.5 group flex items-start gap-2 transition-colors ${
-        active
-          ? 'bg-accent-primary/10'
-          : 'hover:bg-white/[0.045]'
-      }`}
+      leading={
+        <MessageSquare
+          size={11}
+          strokeWidth={1.75}
+          className={`shrink-0 ${active ? 'text-accent-primary' : 'text-text-tertiary'}`}
+        />
+      }
+      trailing={
+        <span className="text-[10.5px] text-text-tertiary tabular-nums">
+          {formatRelativeTime(session.modified_at)}
+        </span>
+      }
     >
-      <MessageSquare
-        size={11}
-        strokeWidth={1.75}
-        className={`mt-0.5 shrink-0 ${active ? 'text-accent-primary' : 'text-text-tertiary'}`}
-      />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-baseline justify-between gap-2">
-          <span
-            className={`text-[12px] truncate ${
-              active ? 'text-accent-primary font-medium' : 'text-text-primary'
-            }`}
-          >
-            {session.preview || `Session ${session.id.slice(0, 8)}`}
-          </span>
-          <span className="text-[10.5px] text-text-tertiary tabular-nums shrink-0">
-            {formatRelativeTime(session.modified_at)}
-          </span>
-        </div>
-        {session.preview && (
-          <div className="text-[10.5px] text-text-tertiary font-mono truncate">
-            {session.id.slice(0, 8)}{active && ' · active'}
-          </div>
-        )}
-      </div>
-    </button>
+      <span
+        className={`text-[12px] truncate ${
+          active ? 'text-accent-primary font-medium' : 'text-text-primary'
+        }`}
+      >
+        {session.preview || `Session ${session.id.slice(0, 8)}`}
+      </span>
+    </ListRow>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '../store/appStore';
 import { FileTreePanel } from './FileTreePanel';
 import { SessionsPanel } from './SessionsPanel';
 import { Tooltip } from './ui/Tooltip';
+import { PanelHeader } from './ui/PanelHeader';
 
 export function Sidebar() {
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
@@ -88,20 +89,24 @@ export function Sidebar() {
 
   return (
     <div className="h-full bg-elevation-1 border-r border-[var(--ij-divider)] flex flex-col">
-      <div className="flex items-center justify-between h-[30px] px-3 border-b border-[var(--ij-divider-soft)]">
-        <span className="flex items-center gap-1.5 text-text-secondary text-[11px] font-semibold uppercase tracking-[0.06em]">
-          <FolderTree size={12} strokeWidth={1.75} />
-          Project
-        </span>
-        <Tooltip label="Collapse Sidebar">
-          <button
-            onClick={toggleSidebarCollapse}
-            className="w-6 h-6 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors"
-          >
-            <ChevronsLeft size={13} strokeWidth={1.75} />
-          </button>
-        </Tooltip>
-      </div>
+      <PanelHeader
+        title={
+          <>
+            <FolderTree size={12} strokeWidth={1.75} />
+            Project
+          </>
+        }
+        actions={
+          <Tooltip label="Collapse Sidebar">
+            <button
+              onClick={toggleSidebarCollapse}
+              className="w-6 h-6 flex items-center justify-center rounded-[4px] hover:bg-white/[0.06] text-text-tertiary hover:text-text-secondary transition-colors"
+            >
+              <ChevronsLeft size={13} strokeWidth={1.75} />
+            </button>
+          </Tooltip>
+        }
+      />
 
       <div ref={stackRef} className="flex-1 min-h-0 flex flex-col">
         <div

--- a/src/components/SnippetsModal.tsx
+++ b/src/components/SnippetsModal.tsx
@@ -6,6 +6,8 @@ import { useTerminalStore } from '../store/terminalStore';
 import { toast } from '../store/toastStore';
 import { Modal } from './ui/Modal';
 import { Button } from './ui/Button';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
 
 interface Snippet {
   id: string;
@@ -164,37 +166,37 @@ export function SnippetsModal() {
             {/* Snippet List */}
             <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
               {filteredSnippets.map((snippet) => (
-                <div
+                <ListRow
                   key={snippet.id}
+                  selected={selectedSnippet?.id === snippet.id}
                   onClick={() => handleSelect(snippet)}
-                  className={`group p-2 rounded-md cursor-pointer transition-colors ${
-                    selectedSnippet?.id === snippet.id
-                      ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
-                      : 'hover:bg-white/[0.04]'
-                  }`}
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="min-w-0 flex-1">
-                      <p className="text-text-primary text-[12px] font-medium truncate">{snippet.title}</p>
-                      <p className="text-text-tertiary text-[11px] truncate mt-0.5">{snippet.category}</p>
-                    </div>
+                  className="group items-start py-1.5"
+                  trailing={
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
                         handleDelete(snippet);
                       }}
-                      className="p-0.5 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0"
+                      className="p-0.5 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
                     >
                       <Trash2 size={12} />
                     </button>
+                  }
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-text-primary text-[12px] font-medium truncate">{snippet.title}</p>
+                    <p className="text-text-tertiary text-[11px] truncate mt-0.5">{snippet.category}</p>
                   </div>
-                </div>
+                </ListRow>
               ))}
 
               {filteredSnippets.length === 0 && (
-                <p className="text-text-tertiary text-[12px] text-center py-4">
-                  No snippets yet
-                </p>
+                <EmptyState
+                  icon={<FileText size={20} strokeWidth={1.75} />}
+                  title="No snippets yet"
+                  description="Save reusable Claude prompts, commands, or templates here."
+                  compact
+                />
               )}
             </div>
           </div>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -44,6 +44,8 @@ export function StatusBar() {
     setNotifyOnFinish,
     openSettings,
   } = useAppStore();
+  const unreadCount = useAppStore((s) => s.unreadNotificationCount);
+  const clearUnread = useAppStore((s) => s.clearUnreadNotifications);
 
   const [appVersion, setAppVersion] = useState('');
   const [claudeVersion, setClaudeVersion] = useState<string | null>(null);
@@ -136,14 +138,30 @@ export function StatusBar() {
         )}
 
         {/* Notifications toggle */}
-        <Tooltip label={notifyOnFinish ? 'Notifications on' : 'Notifications off'} side="top">
+        <Tooltip
+          label={
+            unreadCount > 0
+              ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
+              : notifyOnFinish ? 'Notifications on' : 'Notifications off'
+          }
+          side="top"
+        >
           <button
-            onClick={() => setNotifyOnFinish(!notifyOnFinish)}
-            className={`flex items-center h-[18px] w-[22px] justify-center rounded-[3px] transition-colors hover:bg-white/[0.06] ${
+            onClick={() => {
+              setNotifyOnFinish(!notifyOnFinish);
+              if (unreadCount > 0) clearUnread();
+            }}
+            className={`relative flex items-center h-[18px] w-[22px] justify-center rounded-[3px] transition-colors hover:bg-white/[0.06] ${
               notifyOnFinish ? 'text-text-secondary hover:text-text-primary' : 'text-text-tertiary hover:text-text-secondary'
             }`}
           >
             {notifyOnFinish ? <Bell size={11} strokeWidth={1.75} /> : <BellOff size={11} strokeWidth={1.75} />}
+            {unreadCount > 0 && (
+              <span
+                aria-hidden
+                className="absolute top-[1px] right-[2px] w-[6px] h-[6px] rounded-full bg-accent-primary"
+              />
+            )}
           </button>
         </Tooltip>
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
   LayoutGrid,
 } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
+import { ProgressStripe } from './ui/ProgressStripe';
 
 const MODEL_COLORS: Record<string, { bg: string; text: string; label: string }> = {
   opus: { bg: 'bg-purple-500/15', text: 'text-purple-400', label: 'Opus' },
@@ -46,6 +47,7 @@ export function StatusBar() {
   } = useAppStore();
   const unreadCount = useAppStore((s) => s.unreadNotificationCount);
   const clearUnread = useAppStore((s) => s.clearUnreadNotifications);
+  const globalBusy = useAppStore((s) => s.globalBusy);
 
   const [appVersion, setAppVersion] = useState('');
   const [claudeVersion, setClaudeVersion] = useState<string | null>(null);
@@ -73,7 +75,13 @@ export function StatusBar() {
   const modelInfo = modelKey ? MODEL_COLORS[modelKey] : null;
 
   return (
-    <div className="h-[22px] flex items-center justify-between pl-2 pr-1 bg-elevation-1 border-t border-[var(--ij-divider)] text-[11px] select-none shrink-0">
+    <div className="flex flex-col shrink-0">
+      {globalBusy && (
+        <div title={globalBusy}>
+          <ProgressStripe />
+        </div>
+      )}
+      <div className="h-[22px] flex items-center justify-between pl-2 pr-1 bg-elevation-1 border-t border-[var(--ij-divider)] text-[11px] select-none">
       {/* Left side */}
       <div className="flex items-center gap-0.5">
         {/* Terminal count */}
@@ -182,6 +190,7 @@ export function StatusBar() {
         <Tooltip label={`ClaudeTerminal v${appVersion}`} side="top">
           <span className="text-text-tertiary px-1.5 font-mono">v{appVersion}</span>
         </Tooltip>
+      </div>
       </div>
     </div>
   );

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -41,6 +41,7 @@ export function TerminalTabs() {
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree, showTabActivity } = useAppStore();
   const now = useNowTick();
   const terminalStates = useTerminalStore((s) => s.terminalStates);
+  const justFinishedAt = useTerminalStore((s) => s.justFinishedAt);
   const terminalMetrics = useTerminalStore((s) => s.terminalMetrics);
 
   // Tab drag/drop + multi-select + tear-off. Keyed on this window's label so a
@@ -276,11 +277,17 @@ export function TerminalTabs() {
                       : isActiveTab
                         ? 'bg-elevation-0 text-text-primary'
                         : 'hover:bg-white/[0.045] text-text-secondary'
-                  } ${selected && !isActiveTab ? 'ring-1 ring-inset ring-accent-primary/40' : ''} ${dragged ? 'opacity-20' : ''} ${isWorking && !isActiveTab && showTabActivity ? 'ct-working-tab' : ''}`}
+                  } ${selected && !isActiveTab ? 'ring-1 ring-inset ring-accent-primary/40' : ''} ${dragged ? 'opacity-20' : ''} ${isWorking && !isActiveTab && showTabActivity ? 'ct-working-tab' : ''} ${
+                    justFinishedAt.has(terminal.id) && !isActiveTab ? 'ct-tab-finish-inactive' : ''
+                  }`}
                 >
                   {/* IntelliJ-style bottom underline for active tab */}
                   {(isActiveTab || splitDropTargetId === terminal.id) && (
-                    <span className="absolute left-2 right-2 bottom-0 h-[2px] rounded-t bg-accent-primary" />
+                    <span
+                      className={`absolute left-2 right-2 bottom-0 h-[2px] rounded-t bg-accent-primary ${
+                        justFinishedAt.has(terminal.id) ? 'ct-tab-finish-underline' : ''
+                      }`}
+                    />
                   )}
                   {splitDropTargetId === terminal.id && (
                     <SplitSquareHorizontal size={12} className="text-accent-primary flex-shrink-0 animate-pulse" />

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -22,6 +22,7 @@ import { UpdatePill } from './UpdatePill';
 import { ToolsMenu } from './titlebar/ToolsMenu';
 import { SessionWidget } from './titlebar/SessionWidget';
 import { Tooltip } from './ui/Tooltip';
+import { ListRow } from './ui/ListRow';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
@@ -260,23 +261,24 @@ export function TitleBar() {
                       const isCurrent = b === gitInfo.current_branch;
                       const isChecking = checkoutTarget === b;
                       return (
-                        <button
+                        <ListRow
                           key={b}
-                          onClick={() => handleCheckout(b)}
+                          variant="compact"
+                          selected={isCurrent}
                           disabled={isChecking || isCurrent}
-                          className={`w-full flex items-center justify-between px-3 py-1.5 text-[12px] font-mono text-left transition-colors ${
-                            isCurrent
-                              ? 'text-accent-primary bg-accent-primary/10 cursor-default'
-                              : 'text-text-primary hover:bg-white/[0.05]'
-                          }`}
+                          onClick={() => handleCheckout(b)}
+                          trailing={
+                            isChecking ? (
+                              <Loader2 size={11} className="animate-spin text-text-tertiary" />
+                            ) : isCurrent ? (
+                              <Check size={12} className="text-accent-primary" />
+                            ) : null
+                          }
                         >
-                          <span className="truncate">{b}</span>
-                          {isChecking ? (
-                            <Loader2 size={11} className="animate-spin text-text-tertiary flex-shrink-0" />
-                          ) : isCurrent ? (
-                            <Check size={12} className="text-accent-primary flex-shrink-0" />
-                          ) : null}
-                        </button>
+                          <span className={`truncate font-mono text-[12px] ${isCurrent ? 'text-accent-primary' : 'text-text-primary'}`}>
+                            {b}
+                          </span>
+                        </ListRow>
                       );
                     })}
                   </div>

--- a/src/components/WorktreeModal.tsx
+++ b/src/components/WorktreeModal.tsx
@@ -7,6 +7,8 @@ import { useTerminalStore } from '../store/terminalStore';
 import type { WorktreeInfo } from '../types/git';
 import { Modal } from './ui/Modal';
 import { Button } from './ui/Button';
+import { ListRow } from './ui/ListRow';
+import { EmptyState } from './ui/EmptyState';
 
 export function WorktreeModal() {
   const { closeWorktreeModal, worktreeModalRepoPath, defaultClaudeArgs } = useAppStore();
@@ -183,35 +185,41 @@ export function WorktreeModal() {
                 </div>
               ) : error ? (
                 <p className="text-error text-[12px] text-center py-4">{error}</p>
+              ) : worktrees.length === 0 ? (
+                <EmptyState
+                  icon={<GitBranch size={20} strokeWidth={1.75} />}
+                  title="No worktrees"
+                  description="Create a worktree to work on multiple branches in parallel."
+                  compact
+                />
               ) : (
                 worktrees.map((wt) => (
-                  <div
+                  <ListRow
                     key={wt.path}
+                    selected={selectedPath === wt.path}
                     onClick={() => {
                       setSelectedPath(wt.path);
                       setConfirmRemove(false);
                       setRemoveError(null);
                     }}
-                    className={`p-2 rounded-md cursor-pointer transition-colors ${
-                      selectedPath === wt.path
-                        ? 'bg-accent-primary/10 ring-1 ring-accent-primary/30'
-                        : 'hover:bg-white/[0.04]'
-                    }`}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      {wt.is_main ? (
+                    className="items-start py-1.5"
+                    leading={
+                      wt.is_main ? (
                         <GitBranch size={13} className="text-accent-primary flex-shrink-0" />
                       ) : (
                         <GitFork size={13} className="text-purple-400 flex-shrink-0" />
-                      )}
-                      <p className="text-text-primary text-[12px] font-mono font-medium truncate">
+                      )
+                    }
+                  >
+                    <div className="flex flex-col min-w-0">
+                      <span className="text-text-primary text-[12px] font-mono font-medium truncate">
                         {wt.branch || '(detached)'}
-                      </p>
+                      </span>
+                      {wt.is_main && (
+                        <span className="text-text-tertiary text-[11px]">main worktree</span>
+                      )}
                     </div>
-                    {wt.is_main && (
-                      <p className="text-text-tertiary text-[11px] ml-5">main worktree</p>
-                    )}
-                  </div>
+                  </ListRow>
                 ))
               )}
             </div>

--- a/src/components/titlebar/SessionWidget.tsx
+++ b/src/components/titlebar/SessionWidget.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, GitBranch, GitFork, Plus } from 'lucide-react';
 import { useTerminalStore } from '../../store/terminalStore';
 import { useAppStore } from '../../store/appStore';
 import { StateDot } from '../StateDot';
+import { ListRow } from '../ui/ListRow';
 import type { SessionState } from '../../lib/terminalState';
 
 const STATE_ORDER: Record<SessionState, number> = { waiting: 0, busy: 1, idle: 2, stopped: 3 };
@@ -110,16 +111,17 @@ export function SessionWidget() {
                 const isActive = t.config.id === activeTerminalId;
                 const gitInfo = gitInfoCache.get(t.config.id);
                 return (
-                  <button
+                  <ListRow
                     key={t.config.id}
+                    selected={isActive}
                     onClick={() => { setActiveTerminal(t.config.id); setOpen(false); }}
-                    className={`w-full flex items-start gap-2 px-3 py-1.5 text-left transition-colors ${
-                      isActive ? 'bg-accent-primary/15 text-text-primary' : 'hover:bg-white/[0.05] text-text-secondary'
-                    }`}
+                    className="py-1.5 items-start"
+                    leading={
+                      <span className="mt-1">
+                        <StateDot state={terminalStates.get(t.config.id) ?? 'idle'} size={6} />
+                      </span>
+                    }
                   >
-                    <span className="mt-1.5">
-                      <StateDot state={terminalStates.get(t.config.id) ?? 'idle'} size={6} />
-                    </span>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1.5">
                         <span className="text-[12px] font-medium truncate text-text-primary">
@@ -139,7 +141,7 @@ export function SessionWidget() {
                         {t.config.working_directory}
                       </div>
                     </div>
-                  </button>
+                  </ListRow>
                 );
               })}
             </div>

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  /** Lucide icon (or any 24 px node). Rendered at ~24 px, muted color. */
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  /** Optional primary action - pass a Button. */
+  action?: ReactNode;
+  /** Top-align instead of vertical-center. Use in short containers. */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * Centered vertical stack used inside panels/modals when a list is empty.
+ * Sober by design: muted icon, one-line title, optional short description,
+ * optional primary Button. Matches IntelliJ "No X yet" tool-window placeholders.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  compact = false,
+  className = '',
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center ${
+        compact ? 'justify-start pt-6' : 'justify-center'
+      } px-6 py-8 gap-2 text-center ${className}`}
+    >
+      {icon && (
+        <div className="w-8 h-8 flex items-center justify-center text-text-tertiary">
+          {icon}
+        </div>
+      )}
+      <div className="text-[13px] font-medium text-text-primary">{title}</div>
+      {description && (
+        <div className="text-[12px] text-text-tertiary max-w-[220px] leading-[1.5]">
+          {description}
+        </div>
+      )}
+      {action && <div className="mt-1.5">{action}</div>}
+    </div>
+  );
+}

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -1,0 +1,109 @@
+import { forwardRef } from 'react';
+import type { ReactNode, MouseEvent, KeyboardEvent } from 'react';
+
+export type ListRowVariant = 'default' | 'compact';
+
+interface ListRowProps {
+  selected?: boolean;
+  disabled?: boolean;
+  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  onContextMenu?: (e: MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLElement>) => void;
+  /** Optional leading icon/dot. Rendered before children. */
+  leading?: ReactNode;
+  /** Optional right-aligned meta slot (kbd chip, count, date). */
+  trailing?: ReactNode;
+  /** Render as a <button> (default - keyboard-clickable) or a <div> (for
+   *  wrapping already-interactive children). */
+  as?: 'button' | 'div';
+  /** 'default' = 26px; 'compact' = 22px. */
+  variant?: ListRowVariant;
+  title?: string;
+  ariaLabel?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Canonical selectable list item. Selected state gets an accent-blue tint
+ * plus a 2 px stripe on the left (IntelliJ tool-window selection). Hover
+ * state is `bg-white/[0.045]`, consistent across every migrated surface.
+ *
+ * When `as="button"` (default), the row is keyboard-focusable and inherits
+ * the global `:focus-visible` outline from index.css.
+ */
+export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
+  {
+    selected = false,
+    disabled = false,
+    onClick,
+    onContextMenu,
+    onKeyDown,
+    leading,
+    trailing,
+    as = 'button',
+    variant = 'default',
+    title,
+    ariaLabel,
+    className = '',
+    children,
+  },
+  ref,
+) {
+  const height = variant === 'compact' ? 'h-[22px]' : 'h-[26px]';
+  const base = `relative flex items-center gap-2 w-full px-3 text-left transition-colors ${height}`;
+  const state = selected
+    ? 'bg-accent-primary/12 text-text-primary'
+    : 'text-text-primary hover:bg-white/[0.045]';
+  const disabledCls = disabled ? 'opacity-50 cursor-default pointer-events-none' : '';
+
+  const content = (
+    <>
+      {selected && (
+        <span
+          aria-hidden
+          className="absolute left-0 top-[3px] bottom-[3px] w-[2px] rounded-r-[2px] bg-accent-primary"
+        />
+      )}
+      {leading && <span className="flex-shrink-0 flex items-center">{leading}</span>}
+      <span className="flex-1 min-w-0 flex items-center gap-2 overflow-hidden">{children}</span>
+      {trailing && <span className="flex-shrink-0 flex items-center">{trailing}</span>}
+    </>
+  );
+
+  if (as === 'div') {
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role="option"
+        aria-selected={selected}
+        aria-disabled={disabled || undefined}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={disabled ? undefined : onClick}
+        onContextMenu={onContextMenu}
+        onKeyDown={onKeyDown}
+        className={`${base} ${state} ${disabledCls} ${className}`}
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      ref={ref as React.Ref<HTMLButtonElement>}
+      type="button"
+      aria-selected={selected}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      onKeyDown={onKeyDown}
+      className={`${base} ${state} ${disabledCls} ${className}`}
+    >
+      {content}
+    </button>
+  );
+});

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -53,8 +53,9 @@ export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
   },
   ref,
 ) {
-  const height = variant === 'compact' ? 'h-[22px]' : 'h-[26px]';
-  const base = `relative flex items-center gap-2 w-full px-3 text-left transition-colors ${height}`;
+  // `min-h` (not `h`) lets multi-line content (e.g. session widget) grow.
+  const height = variant === 'compact' ? 'min-h-[22px]' : 'min-h-[26px]';
+  const base = `relative flex items-center gap-2 w-full px-3 py-0.5 text-left transition-colors ${height}`;
   const state = selected
     ? 'bg-accent-primary/12 text-text-primary'
     : 'text-text-primary hover:bg-white/[0.045]';

--- a/src/components/ui/ListRow.tsx
+++ b/src/components/ui/ListRow.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import type { ReactNode, MouseEvent, KeyboardEvent } from 'react';
+import type { ReactNode, MouseEvent, KeyboardEvent, CSSProperties } from 'react';
 
 export type ListRowVariant = 'default' | 'compact';
 
@@ -21,6 +21,8 @@ interface ListRowProps {
   title?: string;
   ariaLabel?: string;
   className?: string;
+  /** Inline style overrides - used e.g. for tree indent (`paddingLeft`). */
+  style?: CSSProperties;
   children: ReactNode;
 }
 
@@ -46,6 +48,7 @@ export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
     title,
     ariaLabel,
     className = '',
+    style,
     children,
   },
   ref,
@@ -83,6 +86,7 @@ export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
         onClick={disabled ? undefined : onClick}
         onContextMenu={onContextMenu}
         onKeyDown={onKeyDown}
+        style={style}
         className={`${base} ${state} ${disabledCls} ${className}`}
       >
         {content}
@@ -101,6 +105,7 @@ export const ListRow = forwardRef<HTMLElement, ListRowProps>(function ListRow(
       onClick={onClick}
       onContextMenu={onContextMenu}
       onKeyDown={onKeyDown}
+      style={style}
       className={`${base} ${state} ${disabledCls} ${className}`}
     >
       {content}

--- a/src/components/ui/PanelHeader.tsx
+++ b/src/components/ui/PanelHeader.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+import { ProgressStripe } from './ProgressStripe';
+
+interface PanelHeaderProps {
+  title: ReactNode;
+  /** Optional trailing count next to the title, e.g. sessions count. */
+  count?: number;
+  /** Renders a chevron on the left; when true, the title becomes a click target. */
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  /** Right-slot: usually a small cluster of icon buttons. */
+  actions?: ReactNode;
+  /** When present, renders a 2px progress bar under the header - shows either
+   *  an indeterminate slide or a determinate fill (value 0..1). */
+  progress?: { active: boolean; value?: number };
+  className?: string;
+}
+
+/**
+ * 26 px header strip for tool windows. Converges the divergent panel-title
+ * styles across the codebase onto one primitive: uppercase 11 px muted title,
+ * optional count, optional actions cluster (right), optional 2 px progress
+ * stripe below the header row.
+ */
+export function PanelHeader({
+  title,
+  count,
+  collapsible = false,
+  collapsed = false,
+  onToggleCollapsed,
+  actions,
+  progress,
+  className = '',
+}: PanelHeaderProps) {
+  const titleNode = (
+    <span className="flex items-center gap-1.5 text-text-secondary text-[11px] font-semibold uppercase tracking-[0.06em]">
+      {collapsible && (
+        collapsed ? (
+          <ChevronRight size={11} strokeWidth={2} />
+        ) : (
+          <ChevronDown size={11} strokeWidth={2} />
+        )
+      )}
+      {title}
+      {typeof count === 'number' && count > 0 && (
+        <span className="text-text-tertiary text-[10.5px] tabular-nums normal-case tracking-normal font-normal ml-0.5">
+          {count}
+        </span>
+      )}
+    </span>
+  );
+
+  return (
+    <div className={className}>
+      <div className="h-[26px] flex items-center justify-between px-3 bg-elevation-1 border-b border-[var(--ij-divider-soft)]">
+        {collapsible ? (
+          <button
+            onClick={onToggleCollapsed}
+            className="flex items-center hover:text-text-primary transition-colors"
+            title={collapsed ? 'Expand' : 'Collapse'}
+          >
+            {titleNode}
+          </button>
+        ) : (
+          titleNode
+        )}
+        {actions && <div className="flex items-center gap-0.5">{actions}</div>}
+      </div>
+      {progress?.active && (
+        <ProgressStripe value={progress.value} className="-mt-[1px]" />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ProgressStripe.tsx
+++ b/src/components/ui/ProgressStripe.tsx
@@ -1,0 +1,47 @@
+import { computeStripeStyle } from '../../lib/progressStripe';
+
+interface ProgressStripeProps {
+  /** 0..1 for determinate; omit for indeterminate. Values outside [0,1] are clamped. */
+  value?: number;
+  /** Reserves the 2 px row without rendering the bar - prevents layout shift. */
+  hidden?: boolean;
+  className?: string;
+}
+
+/**
+ * 2 px indeterminate or determinate progress bar. Sits inside `PanelHeader`
+ * or above a status bar. Uses the app's accent color; reduce-motion falls
+ * back to a static bar via the global `[data-reduce-motion]` cascade
+ * (animation duration collapses to 0.001s).
+ */
+export function ProgressStripe({ value, hidden = false, className = '' }: ProgressStripeProps) {
+  const style = computeStripeStyle(value);
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={1}
+      aria-valuenow={style.mode === 'determinate' ? value : undefined}
+      className={`relative h-[2px] overflow-hidden ${className}`}
+    >
+      {!hidden && style.mode === 'indeterminate' && (
+        <span
+          aria-hidden
+          className="absolute top-0 bottom-0 bg-accent-primary"
+          style={{
+            width: '30%',
+            left: '-30%',
+            animation: 'ct-stripe-slide 1400ms cubic-bezier(0.25, 0.1, 0.25, 1) infinite',
+          }}
+        />
+      )}
+      {!hidden && style.mode === 'determinate' && (
+        <span
+          aria-hidden
+          className="absolute top-0 bottom-0 left-0 bg-accent-primary"
+          style={{ width: style.width }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -228,6 +228,31 @@
   100% { left: 100%; }
 }
 
+/* Tab bottom-underline "just finished" flash (Phase-2 UI polish). Runs once
+   for ~800 ms when a terminal transitions from busy → idle. Reduce-motion
+   collapses to a static color change via the global cascade. */
+@keyframes ct-tab-finish {
+  0%   { background-color: #4ADE80; }               /* --success */
+  100% { background-color: var(--accent-primary); }
+}
+.ct-tab-finish-underline {
+  animation: ct-tab-finish 800ms cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+/* For inactive tabs (no persistent underline), inject the flash via ::after. */
+.ct-tab-finish-inactive {
+  position: relative;
+}
+.ct-tab-finish-inactive::after {
+  content: '';
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  animation: ct-tab-finish 800ms cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
 /* Tab drag "pickup": the floating ghost fades + settles in when grabbed.
    Only opacity is animated here — position/rotate/scale are written live as an
    inline transform, so they must not be touched by this keyframe. */

--- a/src/index.css
+++ b/src/index.css
@@ -221,6 +221,13 @@
   100% { background-position:  240px 0; }
 }
 
+/* ProgressStripe indeterminate slide (Phase-2 UI polish). Neutralised by the
+   global reduce-motion cascade above. */
+@keyframes ct-stripe-slide {
+  0%   { left: -30%; }
+  100% { left: 100%; }
+}
+
 /* Tab drag "pickup": the floating ghost fades + settles in when grabbed.
    Only opacity is animated here — position/rotate/scale are written live as an
    inline transform, so they must not be touched by this keyframe. */

--- a/src/lib/lsp/lspClient.ts
+++ b/src/lib/lsp/lspClient.ts
@@ -147,6 +147,16 @@ interface DiagnosticsEvent {
 let initialized = false;
 let tsServerRunning = false;
 
+// Track how many language servers are currently in `starting` state so the
+// global status-bar progress stripe only clears when the *last* one is done.
+let startingCount = 0;
+function bumpStartingCount(delta: number): void {
+  startingCount = Math.max(0, startingCount + delta);
+  useAppStore.getState().setGlobalBusy(
+    startingCount > 0 ? 'Starting language server…' : null,
+  );
+}
+
 // Monaco's bundled TS worker paints its own 'typescript'-owned markers. Once
 // the real tsserver is connected those are redundant duplicates — and worse,
 // the worker is tsconfig-blind. Silence it while our LSP covers TS/JS;
@@ -170,7 +180,21 @@ export function initLsp(): void {
   if (initialized) return;
   initialized = true;
 
+  // Per-server state - so bumpStartingCount can flip only on transitions.
+  const starting = new Set<string>();
+
   listen<StatusEvent>('lsp-status', (event) => {
+    const key = `${event.payload.language}:${event.payload.root}`;
+    if (event.payload.state === 'starting') {
+      if (!starting.has(key)) {
+        starting.add(key);
+        bumpStartingCount(+1);
+      }
+    } else if (starting.has(key)) {
+      starting.delete(key);
+      bumpStartingCount(-1);
+    }
+
     if (event.payload.language !== 'typescript') return;
     if (event.payload.state === 'running') tsServerRunning = true;
     else if (event.payload.state === 'error' || event.payload.state === 'stopped') tsServerRunning = false;

--- a/src/lib/progressStripe.test.ts
+++ b/src/lib/progressStripe.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { computeStripeStyle } from './progressStripe';
+
+describe('computeStripeStyle', () => {
+  it('returns indeterminate mode when value is undefined', () => {
+    const s = computeStripeStyle(undefined);
+    expect(s.mode).toBe('indeterminate');
+    expect(s.width).toBeUndefined();
+  });
+
+  it('returns determinate mode with clamped width when value is provided', () => {
+    expect(computeStripeStyle(0.5)).toEqual({ mode: 'determinate', width: '50%' });
+    expect(computeStripeStyle(0)).toEqual({ mode: 'determinate', width: '0%' });
+    expect(computeStripeStyle(1)).toEqual({ mode: 'determinate', width: '100%' });
+  });
+
+  it('clamps out-of-range values', () => {
+    expect(computeStripeStyle(-0.2)).toEqual({ mode: 'determinate', width: '0%' });
+    expect(computeStripeStyle(1.5)).toEqual({ mode: 'determinate', width: '100%' });
+  });
+
+  it('treats NaN as indeterminate (defensive)', () => {
+    expect(computeStripeStyle(Number.NaN)).toEqual({ mode: 'indeterminate' });
+  });
+});

--- a/src/lib/progressStripe.ts
+++ b/src/lib/progressStripe.ts
@@ -1,0 +1,16 @@
+export interface StripeStyle {
+  mode: 'indeterminate' | 'determinate';
+  /** Only set when mode === 'determinate'. e.g. '62%'. */
+  width?: string;
+}
+
+/**
+ * Resolve the visual state for ProgressStripe. Undefined or NaN => indeterminate
+ * (animated slide). Numeric input is clamped to [0, 1] and rendered as a
+ * percentage. Extracted for unit-testing per the codebase's existing style.
+ */
+export function computeStripeStyle(value: number | undefined): StripeStyle {
+  if (value === undefined || Number.isNaN(value)) return { mode: 'indeterminate' };
+  const clamped = Math.max(0, Math.min(1, value));
+  return { mode: 'determinate', width: `${Math.round(clamped * 100)}%` };
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -58,6 +58,11 @@ interface AppState {
   pushModalRepoPath: string | null;
   defaultClaudeArgs: string[];
   notifyOnFinish: boolean;
+  /** Count of terminal-finished events fired while the app was hidden and not
+   *  yet acknowledged by the user. Renders the accent dot on the status-bar bell. */
+  unreadNotificationCount: number;
+  incrementUnreadNotifications: () => void;
+  clearUnreadNotifications: () => void;
   restoreSession: boolean;
   telemetryEnabled: boolean;
   errorReportingEnabled: boolean;
@@ -447,6 +452,10 @@ export const useAppStore = create<AppState>()(
       pushModalRepoPath: null,
       defaultClaudeArgs: [],
       notifyOnFinish: true,
+      unreadNotificationCount: 0,
+      incrementUnreadNotifications: () =>
+        set((s) => ({ unreadNotificationCount: s.unreadNotificationCount + 1 })),
+      clearUnreadNotifications: () => set({ unreadNotificationCount: 0 }),
       restoreSession: true,
       telemetryEnabled: true,
       errorReportingEnabled: true,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -63,6 +63,11 @@ interface AppState {
   unreadNotificationCount: number;
   incrementUnreadNotifications: () => void;
   clearUnreadNotifications: () => void;
+  /** Label of the currently-busy global activity (LSP starting, git fetch/pull),
+   *  or null. Drives the 2px ProgressStripe above the status bar. Ephemeral -
+   *  never persisted. */
+  globalBusy: string | null;
+  setGlobalBusy: (label: string | null) => void;
   restoreSession: boolean;
   telemetryEnabled: boolean;
   errorReportingEnabled: boolean;
@@ -456,6 +461,8 @@ export const useAppStore = create<AppState>()(
       incrementUnreadNotifications: () =>
         set((s) => ({ unreadNotificationCount: s.unreadNotificationCount + 1 })),
       clearUnreadNotifications: () => set({ unreadNotificationCount: 0 }),
+      globalBusy: null,
+      setGlobalBusy: (label) => set({ globalBusy: label }),
       restoreSession: true,
       telemetryEnabled: true,
       errorReportingEnabled: true,

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -60,6 +60,10 @@ interface TerminalState {
   // Written only on transitions by the detection poller - never on the
   // streaming hot path - so subscribers re-render only when state changes.
   terminalStates: Map<string, SessionState>;
+  // Timestamp when a terminal most recently transitioned busy → idle. Drives
+  // the "just finished" green flash on the tab underline. Cleared ~850 ms
+  // after the transition so React unmounts the class cleanly.
+  justFinishedAt: Map<string, number>;
   // Live per-terminal cost/token metrics from the OTel receiver.
   terminalMetrics: Map<string, SessionMetrics>;
   // Terminals already warned about exceeding the budget cap (fire-once).
@@ -139,6 +143,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   activeTerminalId: null,
   unreadTerminalIds: new Set(),
   terminalStates: new Map(),
+  justFinishedAt: new Map(),
   terminalMetrics: new Map(),
   budgetWarnedIds: new Set(),
   gitInfoCache: new Map(),
@@ -466,12 +471,30 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
   setTerminalState: (id, state) => {
     // Short-circuit before set() so unchanged states cause zero re-renders.
-    if (get().terminalStates.get(id) === state) return;
+    const prev = get().terminalStates.get(id);
+    if (prev === state) return;
     set((s) => {
       const next = new Map(s.terminalStates);
       next.set(id, state);
       return { terminalStates: next };
     });
+    // Busy → idle transition: mark the tab so its underline flashes green.
+    if (prev === 'busy' && state === 'idle') {
+      const stamp = Date.now();
+      set((s) => {
+        const jf = new Map(s.justFinishedAt);
+        jf.set(id, stamp);
+        return { justFinishedAt: jf };
+      });
+      setTimeout(() => {
+        set((s) => {
+          if (s.justFinishedAt.get(id) !== stamp) return {};
+          const jf = new Map(s.justFinishedAt);
+          jf.delete(id);
+          return { justFinishedAt: jf };
+        });
+      }, 850);
+    }
   },
 
   applyTerminalMetrics: (payload) => {


### PR DESCRIPTION
## Summary

- Add 4 reusable UI primitives: `ListRow`, `PanelHeader`, `EmptyState`, `ProgressStripe`
- Migrate all panels/modals (Sidebar, SessionsPanel, FileTreePanel, TitleBar, SessionWidget, WorktreeModal, SnippetsModal, NewTerminalModal, ProfileModal, SessionHistory) onto new primitives
- Add 2px left accent stripe on selected rows (IntelliJ New UI style)
- Add global progress stripe in StatusBar for LSP startup + git pull activity
- Add unread-notification dot on bell icon when terminals finish while hidden
- Add green flash animation on tab underline when a terminal transitions busy → idle

## Test plan

- [ ] All list rows show left accent stripe when selected
- [ ] Panel headers render at 26px with correct typography
- [ ] Empty states appear when lists have no items
- [ ] Progress stripe appears during LSP startup and git pull
- [ ] Bell dot appears when a terminal finishes while the window is not focused
- [ ] Tab flashes green briefly when a terminal goes busy → idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)