### PR TITLE
Preview panel + security/lifecycle hardening + WebView2 reload guards

### DIFF
--- a/docs/superpowers/plans/2026-07-23-preview-panel.md
+++ b/docs/superpowers/plans/2026-07-23-preview-panel.md
@@ -1,0 +1,1445 @@
+# Preview Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Base44/Lovable/Dyad-style right-docked live preview panel that auto-detects a terminal's dev-server URL and renders it in an iframe alongside the Claude Code terminal.
+
+**Architecture:** Pure frontend detection (regex + `package.json` framework hint) wired into the existing `terminal-output` event listener; per-terminal state in a new Zustand slice; iframe rendered inside a new right-docked panel that reuses the app's existing dock pattern. Rust changes are limited to an additive `ConfigProfile.preview` field + a nullable `profiles.preview_json` column.
+
+**Tech Stack:** React 18 + TypeScript + Zustand + Framer Motion (frontend). Rust + Tauri 2 + `rusqlite` (backend). Vitest (unit tests).
+
+**Test approach:** Vitest for all pure functions (`allowlist`, `detector`, `framework`) and store lifecycle. Component tests via `@testing-library/react` **only** if it's already a dev dependency — otherwise stick to pure-fn tests + manual QA (following the project's existing pattern in `src/lib/*.test.ts`). Rust unit tests via `#[cfg(test)]` for `PreviewProfile` serde round-trip.
+
+**Milestones:**
+- **M1 — Foundation (Stage 1 from spec):** allow-list + detector + framework + store + basic iframe panel + `ToolStripe` toggle + `App.tsx` wiring. Ships as a working preview panel with manual URL entry.
+- **M2 — URL bar + auto-detect UX (Stages 2-3):** toolbar with reload/external-open/URL bar, allow-list Settings, inline hint on ad-hoc detection, profile flag, Rust schema, terminalStore seeding. Ships as full "profiles that have GUI" experience.
+- **M3 — Polish (Stages 4-7):** resize handle, device frames, back/forward, network-status pill, pop-out `WebviewWindow`. Task-level detail deferred to a follow-up plan drafted after M2 lands.
+
+---
+
+## File Structure
+
+### New files (M1 + M2)
+
+| Path | Responsibility |
+|---|---|
+| `src/lib/preview/allowlist.ts` | Pure `isUrlAllowed(url, allowList)`. Localhost variants always allowed; user globs matched with a small hand-rolled matcher. |
+| `src/lib/preview/detector.ts` | Pure `detectUrl(text)`: ANSI-strip, regex match, most-recent-wins priority. |
+| `src/lib/preview/framework.ts` | Pure `detectFramework(packageJson)`: priority `scripts.dev` > `dependencies` > `devDependencies`. Returns hint + default port. |
+| `src/lib/preview/allowlist.test.ts` | Vitest. |
+| `src/lib/preview/detector.test.ts` | Vitest with all 10 dev-server output fixtures from the spec. |
+| `src/lib/preview/framework.test.ts` | Vitest with per-package fixtures. |
+| `src/store/previewStore.ts` | Zustand slice for per-terminal preview state, allow-list, panel toggle, panel width. Partial persistence. |
+| `src/store/previewStore.test.ts` | Vitest for lifecycle (seed/remove), override priority, keep-alive toggle. |
+| `src/components/PreviewPanel.tsx` | The docked panel: header + iframe + resize handle (resize deferred to M3). |
+| `src/components/PreviewToolbar.tsx` | URL bar, reload, external open, close. (M2) |
+| `src/components/PreviewInlineHint.tsx` | Toast-style strip on ad-hoc detection. (M2) |
+| `src/components/settings/PreviewSettingsSection.tsx` | Allow-list editor + `keepAliveAcrossTabs` toggle. (M2) |
+
+### Modified files (M1 + M2)
+
+| Path | Change |
+|---|---|
+| `src/App.tsx` | In the `terminal-output` listener, also call `previewDetector.consume(id, bytes)`. Mount `<PreviewPanel/>` in the right-panel dock area. |
+| `src/components/ToolStripe.tsx` | Add "Preview" toggle icon on the right side. |
+| `src/components/ProfileModal.tsx` | Add "Has GUI preview" checkbox + optional URL override input. (M2) |
+| `src/hooks/useKeyboardShortcuts.ts` | Bind preview-toggle shortcut. Confirm free binding at implementation time. |
+| `src/store/terminalStore.ts` | On `createTerminal`, seed `previewStore` (framework hint + profile). On `closeTerminal`, call `previewStore.removeTerminal(id)`. (M2) |
+| `src-tauri/src/config.rs` | Add `PreviewProfile` struct + `preview: Option<PreviewProfile>` to `ConfigProfile`. (M2) |
+| `src-tauri/src/database.rs` | Migration: add nullable `preview_json TEXT` column to `profiles` table. Serialize/deserialize on read/write. (M2) |
+| `src-tauri/capabilities/default.json` | If `fs:read-text-file` isn't scoped to reach terminal `working_directory` for `package.json`, extend it. (M2) |
+| `src/changelog.json` | Entry for the What's New modal after M2 lands. |
+
+---
+
+# MILESTONE 1 — Foundation
+
+## Task 1: URL allow-list validation
+
+**Files:**
+- Create: `src/lib/preview/allowlist.ts`
+- Test: `src/lib/preview/allowlist.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/lib/preview/allowlist.test.ts
+import { describe, expect, it } from 'vitest';
+import { isUrlAllowed } from './allowlist';
+
+describe('isUrlAllowed', () => {
+  it('always allows localhost variants', () => {
+    expect(isUrlAllowed('http://localhost:5173', [])).toBe(true);
+    expect(isUrlAllowed('http://127.0.0.1:3000', [])).toBe(true);
+    expect(isUrlAllowed('http://0.0.0.0:4321/', [])).toBe(true);
+    expect(isUrlAllowed('https://localhost:8443', [])).toBe(true);
+  });
+
+  it('rejects arbitrary hostnames without allow-list entry', () => {
+    expect(isUrlAllowed('http://evil.com', [])).toBe(false);
+    expect(isUrlAllowed('https://example.org', [])).toBe(false);
+  });
+
+  it('allows hostnames matching allow-list glob', () => {
+    expect(isUrlAllowed('https://abc.ngrok.io', ['*.ngrok.io'])).toBe(true);
+    expect(isUrlAllowed('https://abc.def.ngrok.io', ['*.ngrok.io'])).toBe(false); // one label only
+    expect(isUrlAllowed('https://foo.trycloudflare.com', ['*.trycloudflare.com'])).toBe(true);
+  });
+
+  it('rejects hostname-boundary tricks', () => {
+    // '*.ngrok.io' must NOT match 'ngrok.io.evil.com'
+    expect(isUrlAllowed('https://ngrok.io.evil.com', ['*.ngrok.io'])).toBe(false);
+    expect(isUrlAllowed('https://evilngrok.io', ['*.ngrok.io'])).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isUrlAllowed('not-a-url', [])).toBe(false);
+    expect(isUrlAllowed('', [])).toBe(false);
+    expect(isUrlAllowed('javascript:alert(1)', [])).toBe(false);
+    expect(isUrlAllowed('file:///etc/passwd', [])).toBe(false);
+  });
+
+  it('only accepts http/https schemes', () => {
+    expect(isUrlAllowed('ftp://localhost', [])).toBe(false);
+    expect(isUrlAllowed('data:text/html,<h1>x</h1>', [])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/preview/allowlist.test.ts`
+Expected: FAIL — module `./allowlist` not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/lib/preview/allowlist.ts
+const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+function hostMatchesGlob(host: string, pattern: string): boolean {
+  // Only supports a single leading '*.' — 'foo.*' or 'a*b' are literal.
+  if (!pattern.startsWith('*.')) {
+    return host === pattern;
+  }
+  const suffix = pattern.slice(1); // '.ngrok.io'
+  // Must end with suffix AND the prefix must be exactly one dotless label.
+  if (!host.endsWith(suffix)) return false;
+  const prefix = host.slice(0, host.length - suffix.length);
+  return prefix.length > 0 && !prefix.includes('.');
+}
+
+export function isUrlAllowed(rawUrl: string, allowList: string[]): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  if (LOCALHOST_HOSTS.has(url.hostname)) return true;
+  return allowList.some((p) => hostMatchesGlob(url.hostname, p));
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run src/lib/preview/allowlist.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/preview/allowlist.ts src/lib/preview/allowlist.test.ts
+git commit -m "feat(preview): url allow-list validation (localhost + user globs)"
+```
+
+---
+
+## Task 2: URL detector
+
+**Files:**
+- Create: `src/lib/preview/detector.ts`
+- Test: `src/lib/preview/detector.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/lib/preview/detector.test.ts
+import { describe, expect, it } from 'vitest';
+import { detectUrl } from './detector';
+
+describe('detectUrl', () => {
+  const cases: Array<[string, string, string | null]> = [
+    ['Vite',       '➜  Local:   http://localhost:5173/',                        'http://localhost:5173'],
+    ['Next.js 13', '- Local:        http://localhost:3000',                     'http://localhost:3000'],
+    ['Next.js 15', '▲ Next.js 15.0.0\n- Local: http://localhost:3000',          'http://localhost:3000'],
+    ['CRA',        'Local:            http://localhost:3000',                    'http://localhost:3000'],
+    ['Astro',      '┃ Local    http://localhost:4321/',                          'http://localhost:4321'],
+    ['Nuxt',       '➜ Local:    http://localhost:3000/',                         'http://localhost:3000'],
+    ['SvelteKit',  '➜  Local:   http://localhost:5173/',                        'http://localhost:5173'],
+    ['Angular',    'Angular Live Development Server is listening on localhost:4200', null], // no scheme
+    ['Remix',      '[remix-serve] http://localhost:3000',                        'http://localhost:3000'],
+    ['Expo web',   'Web is waiting on http://localhost:19006',                   'http://localhost:19006'],
+  ];
+
+  for (const [label, input, expected] of cases) {
+    it(`detects ${label}`, () => {
+      expect(detectUrl(input)).toBe(expected);
+    });
+  }
+
+  it('strips ANSI escape codes before matching', () => {
+    expect(detectUrl('\x1b[32m➜\x1b[39m  \x1b[1mLocal:\x1b[22m   \x1b[36mhttp://localhost:5173/\x1b[39m'))
+      .toBe('http://localhost:5173');
+  });
+
+  it('returns most recent match when multiple are present', () => {
+    const text = 'http://localhost:3000\nreloading...\nhttp://localhost:5173';
+    expect(detectUrl(text)).toBe('http://localhost:5173');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(detectUrl('nothing here')).toBe(null);
+    expect(detectUrl('')).toBe(null);
+  });
+
+  it('handles Angular-style separately via detectHost helper (not required for M1)', () => {
+    // Angular prints "listening on localhost:4200" without scheme. For M1 we
+    // deliberately require a scheme. A future enhancement may add hostless
+    // parsing behind a framework hint.
+    expect(detectUrl('listening on localhost:4200')).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/preview/detector.test.ts`
+Expected: FAIL — module `./detector` not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/lib/preview/detector.ts
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+const URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d{1,5})/gi;
+
+const stripAnsi = (s: string): string => s.replace(ANSI_PATTERN, '');
+
+function trimTrailing(url: string): string {
+  // Drop trailing '/', punctuation, ANSI residue.
+  return url.replace(/[\/,;.)\]]+$/, '');
+}
+
+export function detectUrl(text: string): string | null {
+  if (!text) return null;
+  const clean = stripAnsi(text);
+  const matches = clean.match(URL_PATTERN);
+  if (!matches || matches.length === 0) return null;
+  return trimTrailing(matches[matches.length - 1]);
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run src/lib/preview/detector.test.ts`
+Expected: PASS (14 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/preview/detector.ts src/lib/preview/detector.test.ts
+git commit -m "feat(preview): dev-server url detector (10 framework fixtures)"
+```
+
+---
+
+## Task 3: Framework detection from package.json
+
+**Files:**
+- Create: `src/lib/preview/framework.ts`
+- Test: `src/lib/preview/framework.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/lib/preview/framework.test.ts
+import { describe, expect, it } from 'vitest';
+import { detectFramework } from './framework';
+
+describe('detectFramework', () => {
+  it('detects Next.js from dependencies', () => {
+    expect(detectFramework({ dependencies: { next: '^14.0.0' } })).toEqual({
+      hint: 'nextjs', defaultPort: 3000,
+    });
+  });
+
+  it('detects Vite from devDependencies', () => {
+    expect(detectFramework({ devDependencies: { vite: '^5.0.0' } })).toEqual({
+      hint: 'vite', defaultPort: 5173,
+    });
+  });
+
+  it('prefers scripts.dev when it names a framework CLI', () => {
+    // e.g. custom scripts.dev pointing at astro dev
+    expect(detectFramework({
+      scripts: { dev: 'astro dev' },
+      dependencies: { vite: '^5.0.0' }, // vite is also present but astro wins from scripts
+    })).toEqual({ hint: 'astro', defaultPort: 4321 });
+  });
+
+  it('returns unknown when nothing matches', () => {
+    expect(detectFramework({ dependencies: { lodash: '^4.0.0' } })).toEqual({
+      hint: 'unknown', defaultPort: null,
+    });
+  });
+
+  it('returns unknown for empty object', () => {
+    expect(detectFramework({})).toEqual({ hint: 'unknown', defaultPort: null });
+  });
+
+  it('handles all supported frameworks', () => {
+    const cases: Array<[Record<string, unknown>, string, number]> = [
+      [{ dependencies: { next: '*' } }, 'nextjs', 3000],
+      [{ dependencies: { vite: '*' } }, 'vite', 5173],
+      [{ dependencies: { '@angular/core': '*' } }, 'angular', 4200],
+      [{ dependencies: { astro: '*' } }, 'astro', 4321],
+      [{ dependencies: { nuxt: '*' } }, 'nuxt', 3000],
+      [{ dependencies: { '@sveltejs/kit': '*' } }, 'sveltekit', 5173],
+      [{ dependencies: { '@remix-run/dev': '*' } }, 'remix', 3000],
+      [{ dependencies: { 'react-scripts': '*' } }, 'cra', 3000],
+      [{ dependencies: { expo: '*' } }, 'expo', 8081],
+    ];
+    for (const [pkg, hint, port] of cases) {
+      expect(detectFramework(pkg)).toEqual({ hint, defaultPort: port });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/preview/framework.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/lib/preview/framework.ts
+export type FrameworkHint =
+  | 'nextjs' | 'vite' | 'astro' | 'nuxt' | 'sveltekit' | 'remix'
+  | 'angular' | 'cra' | 'expo' | 'unknown';
+
+export interface FrameworkInfo {
+  hint: FrameworkHint;
+  defaultPort: number | null;
+}
+
+// Order matters: entries earlier in the list win ties. `scripts.dev` scan uses
+// this array; dependencies scan iterates in the same order.
+const FRAMEWORKS: Array<{ hint: FrameworkHint; pkg: string; cliToken: string; port: number }> = [
+  { hint: 'nextjs',    pkg: 'next',              cliToken: 'next',       port: 3000  },
+  { hint: 'astro',     pkg: 'astro',             cliToken: 'astro',      port: 4321  },
+  { hint: 'nuxt',      pkg: 'nuxt',              cliToken: 'nuxt',       port: 3000  },
+  { hint: 'sveltekit', pkg: '@sveltejs/kit',     cliToken: 'svelte',     port: 5173  },
+  { hint: 'remix',     pkg: '@remix-run/dev',    cliToken: 'remix',      port: 3000  },
+  { hint: 'angular',   pkg: '@angular/core',     cliToken: 'ng ',        port: 4200  },
+  { hint: 'cra',       pkg: 'react-scripts',     cliToken: 'react-scripts', port: 3000 },
+  { hint: 'expo',      pkg: 'expo',              cliToken: 'expo',       port: 8081  },
+  { hint: 'vite',      pkg: 'vite',              cliToken: 'vite',       port: 5173  },
+];
+
+export function detectFramework(pkg: Record<string, unknown>): FrameworkInfo {
+  const scripts = (pkg.scripts ?? {}) as Record<string, string>;
+  const devScript = typeof scripts.dev === 'string' ? scripts.dev.toLowerCase() : '';
+
+  if (devScript) {
+    for (const fw of FRAMEWORKS) {
+      if (devScript.includes(fw.cliToken)) {
+        return { hint: fw.hint, defaultPort: fw.port };
+      }
+    }
+  }
+
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) } as Record<string, unknown>;
+  for (const fw of FRAMEWORKS) {
+    if (fw.pkg in deps) {
+      return { hint: fw.hint, defaultPort: fw.port };
+    }
+  }
+  return { hint: 'unknown', defaultPort: null };
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run src/lib/preview/framework.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/preview/framework.ts src/lib/preview/framework.test.ts
+git commit -m "feat(preview): framework detection from package.json"
+```
+
+---
+
+## Task 4: Preview Zustand store
+
+**Files:**
+- Create: `src/store/previewStore.ts`
+- Test: `src/store/previewStore.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/store/previewStore.test.ts
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePreviewStore } from './previewStore';
+
+describe('previewStore', () => {
+  beforeEach(() => {
+    usePreviewStore.setState({
+      perTerminal: new Map(),
+      globalOpen: false,
+      allowList: [],
+      keepAliveAcrossTabs: false,
+      panelWidthPx: 640,
+    });
+  });
+
+  it('seeds a terminal with defaults', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    const s = usePreviewStore.getState().perTerminal.get('t1');
+    expect(s).toBeDefined();
+    expect(s?.detectedUrl).toBeNull();
+    expect(s?.userOverride).toBeNull();
+    expect(s?.frameworkHint).toBe('unknown');
+    expect(s?.isOpen).toBe(false);
+  });
+
+  it('setDetectedUrl updates the state', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    expect(usePreviewStore.getState().perTerminal.get('t1')?.detectedUrl).toBe('http://localhost:5173');
+  });
+
+  it('userOverride wins over detectedUrl in resolveUrl', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    usePreviewStore.getState().setUserOverride('t1', 'http://localhost:3000');
+    // Consumers call resolveUrl to get the effective URL
+    const { resolveUrl } = usePreviewStore.getState();
+    expect(resolveUrl('t1')).toBe('http://localhost:3000');
+  });
+
+  it('resolveUrl falls back to detectedUrl when no override', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    expect(usePreviewStore.getState().resolveUrl('t1')).toBe('http://localhost:5173');
+  });
+
+  it('resolveUrl returns null when nothing is set', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    expect(usePreviewStore.getState().resolveUrl('t1')).toBeNull();
+  });
+
+  it('removeTerminal drops per-terminal state', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().removeTerminal('t1');
+    expect(usePreviewStore.getState().perTerminal.has('t1')).toBe(false);
+  });
+
+  it('toggleGlobal flips globalOpen', () => {
+    expect(usePreviewStore.getState().globalOpen).toBe(false);
+    usePreviewStore.getState().toggleGlobal();
+    expect(usePreviewStore.getState().globalOpen).toBe(true);
+    usePreviewStore.getState().toggleGlobal();
+    expect(usePreviewStore.getState().globalOpen).toBe(false);
+  });
+
+  it('reload bumps reloadCounter', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    const before = usePreviewStore.getState().perTerminal.get('t1')?.reloadCounter ?? 0;
+    usePreviewStore.getState().reload('t1');
+    const after = usePreviewStore.getState().perTerminal.get('t1')?.reloadCounter ?? 0;
+    expect(after).toBe(before + 1);
+  });
+
+  it('addToAllowList deduplicates', () => {
+    usePreviewStore.getState().addToAllowList('*.ngrok.io');
+    usePreviewStore.getState().addToAllowList('*.ngrok.io');
+    expect(usePreviewStore.getState().allowList.filter((p) => p === '*.ngrok.io')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/store/previewStore.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/store/previewStore.ts
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { FrameworkHint } from '../lib/preview/framework';
+
+export type DeviceName = 'desktop' | 'tablet' | 'mobile';
+export interface DeviceMode { name: DeviceName; width: number; height?: number }
+
+export const DEVICE_MODES: Record<DeviceName, DeviceMode> = {
+  desktop: { name: 'desktop', width: 0 }, // 0 = full width
+  tablet:  { name: 'tablet',  width: 768,  height: 1024 },
+  mobile:  { name: 'mobile',  width: 375,  height: 812  },
+};
+
+export interface PreviewState {
+  isOpen: boolean;
+  detectedUrl: string | null;
+  userOverride: string | null;
+  frameworkHint: FrameworkHint;
+  deviceMode: DeviceMode;
+  history: string[];
+  historyIndex: number;
+  lastError: string | null;
+  reloadCounter: number;
+  inlineHintDismissed: boolean;
+}
+
+const defaultPreviewState = (): PreviewState => ({
+  isOpen: false,
+  detectedUrl: null,
+  userOverride: null,
+  frameworkHint: 'unknown',
+  deviceMode: DEVICE_MODES.desktop,
+  history: [],
+  historyIndex: -1,
+  lastError: null,
+  reloadCounter: 0,
+  inlineHintDismissed: false,
+});
+
+interface PreviewStoreState {
+  perTerminal: Map<string, PreviewState>;
+  globalOpen: boolean;
+  allowList: string[];
+  keepAliveAcrossTabs: boolean;
+  panelWidthPx: number;
+
+  seedTerminal(id: string, initial: Partial<PreviewState>): void;
+  setDetectedUrl(id: string, url: string): void;
+  setUserOverride(id: string, url: string): void;
+  dismissInlineHint(id: string): void;
+  markOpen(id: string, open: boolean): void;
+  removeTerminal(id: string): void;
+  toggleGlobal(): void;
+  setDeviceMode(id: string, mode: DeviceMode): void;
+  reload(id: string): void;
+  addToAllowList(pattern: string): void;
+  removeFromAllowList(pattern: string): void;
+  setPanelWidth(px: number): void;
+  setKeepAliveAcrossTabs(v: boolean): void;
+  resolveUrl(id: string): string | null;
+}
+
+function withMutatedTerminal(
+  set: (fn: (s: PreviewStoreState) => Partial<PreviewStoreState>) => void,
+  id: string,
+  mutator: (s: PreviewState) => PreviewState,
+) {
+  set((state) => {
+    const next = new Map(state.perTerminal);
+    const cur = next.get(id) ?? defaultPreviewState();
+    next.set(id, mutator(cur));
+    return { perTerminal: next };
+  });
+}
+
+export const usePreviewStore = create<PreviewStoreState>()(
+  persist(
+    (set, get) => ({
+      perTerminal: new Map(),
+      globalOpen: false,
+      allowList: [],
+      keepAliveAcrossTabs: false,
+      panelWidthPx: 640,
+
+      seedTerminal: (id, initial) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, ...initial })),
+
+      setDetectedUrl: (id, url) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, detectedUrl: url, lastError: null })),
+
+      setUserOverride: (id, url) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, userOverride: url })),
+
+      dismissInlineHint: (id) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, inlineHintDismissed: true })),
+
+      markOpen: (id, open) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, isOpen: open })),
+
+      removeTerminal: (id) =>
+        set((state) => {
+          const next = new Map(state.perTerminal);
+          next.delete(id);
+          return { perTerminal: next };
+        }),
+
+      toggleGlobal: () => set((s) => ({ globalOpen: !s.globalOpen })),
+
+      setDeviceMode: (id, mode) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, deviceMode: mode })),
+
+      reload: (id) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, reloadCounter: s.reloadCounter + 1 })),
+
+      addToAllowList: (pattern) =>
+        set((s) => (s.allowList.includes(pattern)
+          ? s
+          : { allowList: [...s.allowList, pattern] })),
+
+      removeFromAllowList: (pattern) =>
+        set((s) => ({ allowList: s.allowList.filter((p) => p !== pattern) })),
+
+      setPanelWidth: (px) => set({ panelWidthPx: Math.max(320, Math.min(1400, px)) }),
+      setKeepAliveAcrossTabs: (v) => set({ keepAliveAcrossTabs: v }),
+
+      resolveUrl: (id) => {
+        const s = get().perTerminal.get(id);
+        if (!s) return null;
+        return s.userOverride ?? s.detectedUrl;
+      },
+    }),
+    {
+      name: 'preview-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({
+        globalOpen: s.globalOpen,
+        allowList: s.allowList,
+        keepAliveAcrossTabs: s.keepAliveAcrossTabs,
+        panelWidthPx: s.panelWidthPx,
+      }),
+    },
+  ),
+);
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run src/store/previewStore.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/store/previewStore.ts src/store/previewStore.test.ts
+git commit -m "feat(preview): zustand store (per-terminal state, allow-list, persist)"
+```
+
+---
+
+## Task 5: PreviewPanel component (M1 minimum)
+
+**Files:**
+- Create: `src/components/PreviewPanel.tsx`
+
+- [ ] **Step 1: Implement the minimal panel**
+
+The panel renders when `globalOpen && activeTerminalId && resolvedUrl` are all truthy. If the resolved URL is not allow-listed, render a blocked-state placeholder. Reload is triggered by remounting the iframe when `reloadCounter` changes (key trick).
+
+```tsx
+// src/components/PreviewPanel.tsx
+import { useMemo } from 'react';
+import { useTerminalStore } from '../store/terminalStore';
+import { usePreviewStore } from '../store/previewStore';
+import { isUrlAllowed } from '../lib/preview/allowlist';
+
+export function PreviewPanel() {
+  const activeId = useTerminalStore((s) => s.activeTerminalId);
+  const globalOpen = usePreviewStore((s) => s.globalOpen);
+  const panelWidthPx = usePreviewStore((s) => s.panelWidthPx);
+  const allowList = usePreviewStore((s) => s.allowList);
+  const perTerminal = usePreviewStore((s) => s.perTerminal);
+  const resolveUrl = usePreviewStore((s) => s.resolveUrl);
+
+  const url = activeId ? resolveUrl(activeId) : null;
+  const state = activeId ? perTerminal.get(activeId) : undefined;
+  const reloadCounter = state?.reloadCounter ?? 0;
+
+  const allowed = useMemo(
+    () => (url ? isUrlAllowed(url, allowList) : false),
+    [url, allowList],
+  );
+
+  if (!globalOpen || !activeId) return null;
+
+  return (
+    <div
+      className="h-full flex flex-col bg-bg-secondary border-l border-white/[0.06] overflow-hidden"
+      style={{ width: panelWidthPx }}
+      data-testid="preview-panel"
+    >
+      <div className="px-3 py-2 border-b border-white/[0.06] flex items-center justify-between shrink-0">
+        <div className="text-text-primary text-[12px] font-medium">Preview</div>
+        <div className="text-text-tertiary text-[11px] truncate max-w-[65%]">
+          {url ?? 'no url'}
+        </div>
+      </div>
+
+      <div className="flex-1 relative bg-black">
+        {!url && (
+          <div className="absolute inset-0 flex items-center justify-center text-text-tertiary text-[12px]">
+            Waiting for a dev-server URL…
+          </div>
+        )}
+        {url && !allowed && (
+          <div className="absolute inset-0 flex items-center justify-center text-center p-6">
+            <div className="max-w-sm">
+              <div className="text-text-primary text-[13px] font-semibold mb-1">
+                URL not allowed
+              </div>
+              <div className="text-text-tertiary text-[11.5px]">
+                <code className="text-text-secondary">{url}</code> is outside the preview allow-list.
+                Add it in Settings → Preview.
+              </div>
+            </div>
+          </div>
+        )}
+        {url && allowed && (
+          <iframe
+            key={`${url}#${reloadCounter}`}
+            src={url}
+            title="Preview"
+            className="absolute inset-0 w-full h-full border-0"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PreviewPanel.tsx
+git commit -m "feat(preview): minimal PreviewPanel component (iframe + blocked state)"
+```
+
+---
+
+## Task 6: Wire detector into App.tsx and mount PreviewPanel
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Locate the `terminal-output` listener**
+
+The listener currently lives around `src/App.tsx:415`. Read it first to confirm the shape:
+```
+const unlisten = listen<{ id: string; data: number[] }>('terminal-output', (event) => {
+  const { id, data } = event.payload;
+  handleTerminalOutput(id, new Uint8Array(data));
+  ...
+});
+```
+
+- [ ] **Step 2: Add detector import at top of file (with the other lib imports)**
+
+```tsx
+import { detectUrl } from './lib/preview/detector';
+import { usePreviewStore } from './store/previewStore';
+```
+
+Also add `PreviewPanel` to the component imports:
+
+```tsx
+import { PreviewPanel } from './components/PreviewPanel';
+```
+
+- [ ] **Step 3: Add detector call inside the existing `terminal-output` listener**
+
+Modify the existing effect so that AFTER `handleTerminalOutput(id, new Uint8Array(data));` it also runs:
+
+```tsx
+try {
+  const text = new TextDecoder().decode(new Uint8Array(data));
+  const found = detectUrl(text);
+  if (found) {
+    const cur = usePreviewStore.getState().perTerminal.get(id);
+    if (cur?.detectedUrl !== found) {
+      usePreviewStore.getState().setDetectedUrl(id, found);
+    }
+  }
+} catch { /* ignore decode errors */ }
+```
+
+Place it right after the existing `loopMatch` detection block. The `TextDecoder` allocation per chunk is fine — the loop-mode detector already does the same thing on the line above.
+
+- [ ] **Step 4: Mount `<PreviewPanel/>` in the dock area**
+
+Inside the right-side panel `AnimatePresence` cluster (after `<HintsPanel/>`, before `<ToolStripe side="right"/>`), add:
+
+```tsx
+<PreviewPanel />
+```
+
+`PreviewPanel` handles its own visibility (returns null unless `globalOpen && activeId`), so wrapping it in another `AnimatePresence` is unnecessary — but ensure it renders BETWEEN the other right-docked panels and the right-side `<ToolStripe/>` so it stacks correctly.
+
+- [ ] **Step 5: Type check + smoke build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: no TS errors, build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(preview): wire url detector into terminal-output stream + mount panel"
+```
+
+---
+
+## Task 7: ToolStripe toggle icon + keyboard shortcut
+
+**Files:**
+- Modify: `src/components/ToolStripe.tsx`
+- Modify: `src/hooks/useKeyboardShortcuts.ts`
+
+- [ ] **Step 1: Read `ToolStripe.tsx` to find existing toggle pattern**
+
+Look for how `changesOpen`, `hintsOpen`, `orchestrationOpen` toggles are rendered on the right side. Match the pattern (icon, tooltip, click handler).
+
+- [ ] **Step 2: Add a Preview toggle**
+
+Import `usePreviewStore`. On the right side, add a button that:
+- Icon: use a "monitor" or "eye" icon from `lucide-react` (already a dep). `Monitor` is the natural choice.
+- Tooltip: `Preview (Ctrl+Shift+V)` — final shortcut confirmed in Step 4.
+- Active state: `globalOpen === true` renders with the same active styling as sibling toggles.
+- onClick: `usePreviewStore.getState().toggleGlobal()`.
+
+Follow the exact JSX pattern of the adjacent toggle. This is a small mechanical edit — don't refactor surrounding code.
+
+- [ ] **Step 3: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Wire shortcut**
+
+Read `src/hooks/useKeyboardShortcuts.ts` first. Find the block that maps keys → handlers.
+
+Add a new binding. Preference order (use the first free one):
+- `Ctrl+Shift+V`
+- `Ctrl+Shift+G`
+- `Ctrl+Alt+P`
+
+Handler: `usePreviewStore.getState().toggleGlobal()`.
+
+If none of the three are free (very unlikely), pick another modifier combo and note the choice in the commit message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ToolStripe.tsx src/hooks/useKeyboardShortcuts.ts
+git commit -m "feat(preview): ToolStripe toggle + Ctrl+Shift+V shortcut"
+```
+
+---
+
+## Task 8: M1 verification
+
+- [ ] **Step 1: Full type + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 2: All tests**
+
+Run: `npx vitest run`
+Expected: existing suite green + 4 new files (allowlist, detector, framework, previewStore) contribute ~35 new tests, all passing.
+
+- [ ] **Step 3: Manual QA in a scratch Vite project (or existing one)**
+
+Because the Tauri dev app can't be automated (see project memory), verify by hand:
+
+1. Launch `npm run tauri dev`.
+2. Create a terminal in any Vite project. Run `npm run dev`. 
+3. Toggle preview via `ToolStripe` icon or `Ctrl+Shift+V`. Panel should appear on the right.
+4. Once Vite prints `➜  Local: http://localhost:5173/`, the iframe should populate within one output chunk.
+5. Switch to another (non-web) terminal. Preview panel should show "Waiting for a dev-server URL…"
+6. Switch back. iframe should re-mount with the same URL (`reloadCounter` unchanged → same `key`).
+7. Try setting `allowList = []` and pointing a manual override at `https://example.com` — should show the "URL not allowed" blocked state.
+
+- [ ] **Step 4: M1 tag commit**
+
+```bash
+git commit --allow-empty -m "chore(preview): M1 foundation shipped — panel + detector + toggle"
+```
+
+---
+
+# MILESTONE 2 — URL bar + auto-detect UX + profile flag
+
+## Task 9: PreviewToolbar with URL bar, reload, external open
+
+**Files:**
+- Create: `src/components/PreviewToolbar.tsx`
+- Modify: `src/components/PreviewPanel.tsx` (replace the plain header with the toolbar)
+
+- [ ] **Step 1: Implement toolbar**
+
+```tsx
+// src/components/PreviewToolbar.tsx
+import { useEffect, useState } from 'react';
+import { RotateCw, ExternalLink, X } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { usePreviewStore } from '../store/previewStore';
+import { isUrlAllowed } from '../lib/preview/allowlist';
+
+interface Props { terminalId: string; url: string | null; allowed: boolean }
+
+export function PreviewToolbar({ terminalId, url, allowed }: Props) {
+  const allowList = usePreviewStore((s) => s.allowList);
+  const setUserOverride = usePreviewStore((s) => s.setUserOverride);
+  const reload = usePreviewStore((s) => s.reload);
+  const toggleGlobal = usePreviewStore((s) => s.toggleGlobal);
+
+  const [draft, setDraft] = useState(url ?? '');
+  const [invalid, setInvalid] = useState(false);
+
+  useEffect(() => { setDraft(url ?? ''); setInvalid(false); }, [url]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    if (!isUrlAllowed(trimmed, allowList)) { setInvalid(true); return; }
+    setUserOverride(terminalId, trimmed);
+  };
+
+  const openExternal = () => { if (url && allowed) void invoke('open_external_url', { url }); };
+
+  return (
+    <div className="px-2 py-1.5 border-b border-white/[0.06] flex items-center gap-1.5 shrink-0">
+      <button
+        onClick={() => reload(terminalId)}
+        disabled={!url}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
+        title="Reload"
+      >
+        <RotateCw size={14} />
+      </button>
+      <input
+        value={draft}
+        onChange={(e) => { setDraft(e.target.value); setInvalid(false); }}
+        onKeyDown={(e) => { if (e.key === 'Enter') commit(); }}
+        onBlur={commit}
+        spellCheck={false}
+        placeholder="http://localhost:5173"
+        className={`flex-1 bg-elevation-2 border rounded px-2 py-1 text-[11.5px] text-text-primary outline-none ${
+          invalid ? 'border-red-500/60' : 'border-white/[0.06] focus:border-accent-primary/60'
+        }`}
+      />
+      <button
+        onClick={openExternal}
+        disabled={!url || !allowed}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
+        title="Open in browser"
+      >
+        <ExternalLink size={14} />
+      </button>
+      <button
+        onClick={toggleGlobal}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary"
+        title="Close preview"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace the plain header in `PreviewPanel.tsx`**
+
+Delete the current `<div className="px-3 py-2 border-b ...">` block. Import and render `<PreviewToolbar terminalId={activeId} url={url} allowed={allowed}/>` in its place.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/PreviewToolbar.tsx src/components/PreviewPanel.tsx
+git commit -m "feat(preview): toolbar (url bar + reload + external open + close)"
+```
+
+---
+
+## Task 10: Rust `PreviewProfile`
+
+**Files:**
+- Modify: `src-tauri/src/config.rs`
+
+- [ ] **Step 1: Read current `ConfigProfile` to match style**
+
+Understand the existing derives and field visibility.
+
+- [ ] **Step 2: Add the struct + field**
+
+```rust
+// src-tauri/src/config.rs (append below existing structs, add field to ConfigProfile)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PreviewProfile {
+    pub enabled: bool,
+    pub url_override: Option<String>,
+    pub framework_hint: Option<String>,
+}
+
+// In ConfigProfile — add this field, keeping serde defaults so old rows keep parsing:
+// #[serde(default)]
+// pub preview: Option<PreviewProfile>,
+```
+
+Place the field near the end of `ConfigProfile` and mark it `#[serde(default)]` so profiles serialized before this change deserialize with `preview: None`.
+
+- [ ] **Step 3: Add a round-trip test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn preview_profile_default_and_roundtrip() {
+        let p = PreviewProfile { enabled: true, url_override: Some("http://localhost:3000".into()), framework_hint: Some("vite".into()) };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: PreviewProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.enabled, true);
+        assert_eq!(back.url_override.as_deref(), Some("http://localhost:3000"));
+    }
+    #[test]
+    fn missing_preview_deserializes_as_none_on_config_profile() {
+        // Simulate an old serialized ConfigProfile without the preview field.
+        let json = r#"{"name":"x","working_directory":"/tmp","claude_args":[],"env_vars":{}}"#;
+        let cfg: ConfigProfile = serde_json::from_str(json).unwrap();
+        assert!(cfg.preview.is_none());
+    }
+}
+```
+
+Note: the second test requires that all other fields have serde defaults or are still present in the JSON above. If `ConfigProfile` has additional non-defaultable fields (e.g. `id`, timestamps), extend the JSON accordingly — but the field being tested is `preview`, so keep the fixture minimal.
+
+- [ ] **Step 4: Run Rust tests**
+
+Run: `cd src-tauri && cargo test preview_profile -- --nocapture`
+Expected: 2 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/config.rs
+git commit -m "feat(preview): ConfigProfile.preview (backwards-compatible via serde default)"
+```
+
+---
+
+## Task 11: DB migration for `preview_json` column
+
+**Files:**
+- Modify: `src-tauri/src/database.rs`
+
+- [ ] **Step 1: Read the current profiles table schema**
+
+Find the `CREATE TABLE IF NOT EXISTS profiles (...)` block and the profile read/write functions.
+
+- [ ] **Step 2: Add migration**
+
+Add to the schema init: `preview_json TEXT` column with default NULL. Because SQLite allows `ALTER TABLE ADD COLUMN` at any time and this is additive, follow the existing migration pattern in `database.rs`. If the project already has a migration versioning system (e.g. `PRAGMA user_version`), add a new migration step. Otherwise use `ALTER TABLE profiles ADD COLUMN preview_json TEXT` inside a defensive `let _ = ...;` (SQLite raises if the column exists — swallow that specific error).
+
+- [ ] **Step 3: Update profile serialization**
+
+- On save: `serde_json::to_string(&profile.preview).ok()` → `preview_json` column (NULL if `None`).
+- On load: read `preview_json`; if non-null, `serde_json::from_str::<Option<PreviewProfile>>` → assign.
+- Follow existing `env_vars` serialization pattern (it's already stored as JSON in a TEXT column).
+
+- [ ] **Step 4: Rust test**
+
+Add a test that saves a profile with `preview: Some(...)`, reads it back, and confirms round-trip equality.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd src-tauri && cargo test`
+Expected: existing suite + new test PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/database.rs
+git commit -m "feat(preview): sqlite profiles.preview_json column + round-trip"
+```
+
+---
+
+## Task 12: ProfileModal — "Has GUI preview" checkbox
+
+**Files:**
+- Modify: `src/components/ProfileModal.tsx`
+
+- [ ] **Step 1: Read the modal to find where to add fields**
+
+Locate the form section — likely a series of labeled inputs. Match the visual pattern.
+
+- [ ] **Step 2: Add fields**
+
+- A `<label>` with a checkbox "Has GUI preview" bound to `profile.preview?.enabled`.
+- When checked, reveal an optional `<input>` "Preview URL (optional override)" bound to `profile.preview?.url_override`.
+- Save handler serializes into a `preview: PreviewProfile | undefined` field on the profile before invoking `save_profile`.
+
+Keep changes surgical — don't refactor unrelated fields.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ProfileModal.tsx
+git commit -m "feat(preview): ProfileModal 'Has GUI preview' checkbox + url override"
+```
+
+---
+
+## Task 13: PreviewInlineHint
+
+**Files:**
+- Create: `src/components/PreviewInlineHint.tsx`
+- Modify: `src/App.tsx` (mount it)
+
+- [ ] **Step 1: Implement hint**
+
+```tsx
+// src/components/PreviewInlineHint.tsx
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useTerminalStore } from '../store/terminalStore';
+import { usePreviewStore } from '../store/previewStore';
+
+const AUTO_DISMISS_MS = 6000;
+
+export function PreviewInlineHint() {
+  const activeId = useTerminalStore((s) => s.activeTerminalId);
+  const globalOpen = usePreviewStore((s) => s.globalOpen);
+  const perTerminal = usePreviewStore((s) => s.perTerminal);
+  const dismissInlineHint = usePreviewStore((s) => s.dismissInlineHint);
+  const toggleGlobal = usePreviewStore((s) => s.toggleGlobal);
+
+  const state = activeId ? perTerminal.get(activeId) : undefined;
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!state || globalOpen) { setVisible(false); return; }
+    if (state.inlineHintDismissed) { setVisible(false); return; }
+    if (!state.detectedUrl) { setVisible(false); return; }
+    setVisible(true);
+    const t = setTimeout(() => { if (activeId) dismissInlineHint(activeId); }, AUTO_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [state?.detectedUrl, state?.inlineHintDismissed, globalOpen, activeId, dismissInlineHint, state]);
+
+  const url = state?.detectedUrl;
+  return (
+    <AnimatePresence>
+      {visible && activeId && url && (
+        <motion.div
+          initial={{ y: 24, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 24, opacity: 0 }}
+          className="fixed bottom-8 right-6 z-50 bg-elevation-3 ring-1 ring-white/[0.08] rounded-md shadow-lg px-3 py-2 flex items-center gap-2"
+        >
+          <span className="text-text-secondary text-[12px]">
+            Detected <code className="text-text-primary">{url}</code>
+          </span>
+          <button
+            onClick={() => { toggleGlobal(); dismissInlineHint(activeId); }}
+            className="text-[12px] font-medium text-accent-primary hover:text-accent-secondary"
+          >
+            Open preview
+          </button>
+          <button
+            onClick={() => dismissInlineHint(activeId)}
+            className="text-[12px] text-text-tertiary hover:text-text-secondary"
+          >
+            Dismiss
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+- [ ] **Step 2: Mount in `App.tsx`**
+
+Add `<PreviewInlineHint/>` alongside `<ToastContainer/>` near the end of the root layout.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/PreviewInlineHint.tsx src/App.tsx
+git commit -m "feat(preview): inline hint on ad-hoc dev-server detection"
+```
+
+---
+
+## Task 14: terminalStore seeding + cleanup
+
+**Files:**
+- Modify: `src/store/terminalStore.ts`
+
+- [ ] **Step 1: On `createTerminal`, seed the preview store**
+
+Inside `createTerminal` (after the terminal instance is created in the store), read the profile if the caller passed one (or reconstruct minimal state), then:
+
+```ts
+import { usePreviewStore } from './previewStore';
+// ...inside createTerminal, right after adding the new instance to the map:
+const previewInit = {
+  isOpen: profile?.preview?.enabled ?? false,
+  frameworkHint: (profile?.preview?.framework_hint as FrameworkHint | undefined) ?? 'unknown',
+  userOverride: profile?.preview?.url_override ?? null,
+};
+usePreviewStore.getState().seedTerminal(newId, previewInit);
+// If profile.preview.enabled, open the panel too:
+if (profile?.preview?.enabled && !usePreviewStore.getState().globalOpen) {
+  usePreviewStore.getState().toggleGlobal();
+}
+```
+
+Note: `createTerminal` in this codebase may not currently accept a full `profile` — check the signature. If not, thread the `preview` block through by adding a small optional parameter, or read it from an in-memory profile cache. Don't over-engineer; a minimal `previewInit?: Partial<PreviewState>` param works if profile plumbing is deep.
+
+- [ ] **Step 2: On `closeTerminal`, drop preview state**
+
+```ts
+usePreviewStore.getState().removeTerminal(id);
+```
+
+Place inside `closeTerminal` right after the terminal is removed from the store map, mirroring the existing `unreadTerminalIds` cleanup.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/store/terminalStore.ts
+git commit -m "feat(preview): seed store on createTerminal, cleanup on close"
+```
+
+---
+
+## Task 15: Framework hint from package.json on terminal create
+
+**Files:**
+- Modify: `src/store/terminalStore.ts`
+
+- [ ] **Step 1: Add a helper**
+
+In `terminalStore.ts` (or a new tiny helper file), add a fire-and-forget async function that reads `<cwd>/package.json` via `@tauri-apps/plugin-fs` and calls `usePreviewStore.getState().seedTerminal(id, { frameworkHint })`.
+
+```ts
+import { readTextFile } from '@tauri-apps/plugin-fs';
+import { detectFramework } from '../lib/preview/framework';
+
+async function seedFrameworkHint(terminalId: string, cwd: string) {
+  try {
+    const raw = await readTextFile(`${cwd}/package.json`);
+    const pkg = JSON.parse(raw);
+    const { hint } = detectFramework(pkg);
+    if (hint !== 'unknown') {
+      usePreviewStore.getState().seedTerminal(terminalId, { frameworkHint: hint });
+    }
+  } catch { /* no package.json, or unreadable — silent */ }
+}
+```
+
+Call `void seedFrameworkHint(newId, workingDirectory);` right after the initial `seedTerminal` call from Task 14.
+
+- [ ] **Step 2: Verify capability**
+
+Check `src-tauri/capabilities/default.json`. Ensure `fs:read-text-file` or the equivalent permission covers reading files under the terminal's working directory. If it does not, extend the capability to allow reading `**/package.json` scoped to user home / project dirs.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/store/terminalStore.ts src-tauri/capabilities/default.json
+git commit -m "feat(preview): seed framework hint from package.json on terminal create"
+```
+
+---
+
+## Task 16: Preview settings section
+
+**Files:**
+- Create: `src/components/settings/PreviewSettingsSection.tsx`
+- Modify: the settings window / navigator to include the new section.
+
+- [ ] **Step 1: Implement section**
+
+- Header: "Preview".
+- List of allow-list entries with per-row Delete button.
+- Input + "Add" button for new patterns (e.g. `*.ngrok.io`). Validate that the pattern is non-empty; `*.hostname.tld` is the only supported shape (documented in a tiny help line).
+- Toggle: "Keep preview alive across tab switches" (bound to `keepAliveAcrossTabs`).
+
+Reuse existing settings-section styling from an adjacent section (e.g. Notifications).
+
+- [ ] **Step 2: Wire into settings navigator**
+
+Read `src/components/settings/SettingsWindow.tsx` (or wherever section navigation lives) and add "Preview" as a new entry pointing at `PreviewSettingsSection`.
+
+- [ ] **Step 3: Type check + build**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/settings/PreviewSettingsSection.tsx src/components/settings/SettingsWindow.tsx
+git commit -m "feat(preview): settings section (allow-list + keep-alive toggle)"
+```
+
+---
+
+## Task 17: M2 verification + changelog
+
+- [ ] **Step 1: Full type + build**
+
+Run: `npx tsc --noEmit && npx vite build && npx vitest run && cd src-tauri && cargo test`
+Expected: everything green.
+
+- [ ] **Step 2: Manual QA**
+
+1. Create a profile with "Has GUI preview" checked and URL override `http://localhost:3000`. Launch a terminal from that profile in a Next.js project. Verify: preview panel opens automatically, iframe loads override URL immediately.
+2. In the same terminal, run `npm run dev`. Once Next prints its URL, verify the panel keeps the user override (override wins over detected).
+3. Uncheck override, restart. Confirm detected URL fills in automatically after `npm run dev`.
+4. Open a non-GUI-profile terminal, run `npm run dev` in a Vite project. Verify inline hint appears within a few seconds. Click "Open preview" — panel opens, hint dismisses.
+5. Enter `https://example.com` in the URL bar. Panel shows blocked state. Add `example.com` to the allow-list in Settings. URL now loads.
+6. Close the terminal. Verify no console errors — state is dropped.
+7. Restart the app. Confirm `allowList` and `panelWidthPx` persist; `perTerminal` does not.
+
+- [ ] **Step 3: Changelog entry**
+
+Add to `src/changelog.json` a new top entry for the next version — sample text:
+
+```json
+{
+  "version": "1.28.0",
+  "date": "2026-07-23",
+  "title": "Live preview for GUI projects",
+  "items": [
+    "New right-docked Preview panel with auto-detected dev-server URL (Vite, Next.js, Astro, Nuxt, SvelteKit, Remix, Angular, CRA, Expo).",
+    "Per-profile 'Has GUI preview' flag opens the panel automatically for a profile.",
+    "Inline hint offers to open the preview when a URL is detected in any terminal.",
+    "Allow-list in Settings — localhost is always allowed; add glob patterns like *.ngrok.io for tunnels."
+  ]
+}
+```
+
+Confirm actual version target via `package.json` before locking in the number.
+
+- [ ] **Step 4: Commit + M2 tag**
+
+```bash
+git add src/changelog.json
+git commit -m "docs(changelog): 1.28.0 preview panel"
+git commit --allow-empty -m "chore(preview): M2 shipped — url bar + auto-detect + profile flag"
+```
+
+---
+
+# MILESTONE 3 — Polish (device frames, resize, back/forward, pop-out)
+
+Deferred until M1 + M2 are merged and verified. When ready, invoke `superpowers:writing-plans` again with the same spec (`docs/superpowers/specs/2026-07-23-preview-panel-design.md`) to generate M3 task-level detail. M3 scope from the spec:
+
+- Drag-resize handle on the left edge of `PreviewPanel` (persist `panelWidthPx`).
+- Device mode toggle (desktop / tablet 768px / mobile 375px) — pure CSS wrapping.
+- Back/forward navigation using `history` + `historyIndex` in the store; capture iframe `location.href` on load events (guarded — cross-origin will throw; that's fine, we track only what we set).
+- Dev-server network-status pill (probe iframe URL with a `HEAD` fetch from the parent window, show green/red dot).
+- Pop-out via `WebviewWindow` — reuse the detached-window infra; label prefix `preview-*`; capability entry.
+
+---
+
+## Self-review — spec coverage
+
+Cross-checking the spec against the plan:
+
+- **Section 1 (Overview / dock architecture)** → Task 5, Task 6. ✓
+- **Section 2 (Architecture / data flow)** → Task 6 (listener wiring), Task 4 (store), Task 14 (cleanup). ✓
+- **Section 3 (New files)** → Tasks 1-5, 9, 13, 15, 16 cover all 11 new files listed in the spec. ✓
+- **Section 3 (Modified files)** → Tasks 6, 7, 10, 11, 12, 14, 15. `changelog.json` in Task 17. ✓
+- **Section 4 (Preview state)** → Task 4. ✓
+- **Section 5 (Detection)** → Task 2 (URL regex + ANSI strip), Task 3 (framework), Task 15 (package.json read). ✓
+- **Section 6 (Trigger rules)** → Task 14 (auto-open on profile flag), Task 13 (inline hint), Task 7 (manual toggle + shortcut). ✓
+- **Section 7 (Per-tab behavior)** → Task 5 (default single iframe), Task 16 (keep-alive toggle in settings). `visibility: hidden` keep-alive rendering itself lands in M3 or is added as a small follow-up if we want to close M2 with parity.
+- **Section 8 (Security)** → Task 1 (allow-list), Task 9 (URL bar validation), Task 5 (blocked-state render). ✓
+- **Section 9 (Stages)** → Stage 1 = M1 (Tasks 1-8), Stage 2 = Task 9, Stage 3 = Tasks 10-16, Stages 4-7 = M3.
+- **Section 10 (Verification)** → Task 8 (M1), Task 17 (M2). ✓
+
+**Gap found:** the spec calls for `keepAliveAcrossTabs` to actually render multiple iframes with `visibility: hidden`, but Task 5 only implements the single-iframe path. This is fine for M1 (the toggle is off by default), but M2 should extend `PreviewPanel` to honour `keepAliveAcrossTabs`. Adding a small M2 sub-step:
+
+## Task 16.5: Honour keep-alive toggle (extends Task 5)
+
+**Files:**
+- Modify: `src/components/PreviewPanel.tsx`
+
+- [ ] **Step 1: Adjust PreviewPanel render logic**
+
+When `keepAliveAcrossTabs` is true, iterate over all `perTerminal` entries with a non-null resolved URL and render an iframe per entry. Only the entry whose id matches `activeTerminalId` is visible; all others are `visibility: hidden; pointer-events: none;`.
+
+- [ ] **Step 2: Type check + build + test**
+
+Run: `npx tsc --noEmit && npx vite build && npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PreviewPanel.tsx
+git commit -m "feat(preview): honour keepAliveAcrossTabs (multi-iframe hidden mount)"
+```
+
+---
+
+## Notes for the implementing engineer
+
+- Every task is intended to be executable by a fresh subagent given only the spec + this plan + the current codebase. Don't infer requirements not written down.
+- Where a step says "check the existing pattern in file X" — do that read before editing. The paste-as-file plan (already merged) is a good reference for how M2's `terminalStore` seeding maps onto the existing store shape.
+- The keyboard shortcut choice is the most likely conflict. If `Ctrl+Shift+V` collides, the fallbacks are `Ctrl+Shift+G`, `Ctrl+Alt+P`. Record the final choice in the commit message.
+- Don't add polish features from M3 to M1 or M2 tasks. Ship the milestone, then invoke `writing-plans` for M3.

--- a/docs/superpowers/specs/2026-07-23-preview-panel-design.md
+++ b/docs/superpowers/specs/2026-07-23-preview-panel-design.md
@@ -1,0 +1,249 @@
+# Preview Panel — Base44/Lovable/Dyad-style live web preview
+
+**Date:** 2026-07-23
+**Goal:** Add a right-docked, resizable live-preview panel for terminals running web dev
+servers. Auto-detects the dev-server URL from stdout and from `package.json`, honours a
+per-profile "has GUI" flag, and can be toggled from a `ToolStripe` icon or keyboard shortcut.
+
+## Overview
+
+A ClaudeTerminal tab already IS the "prompting" pane (Claude Code lives in the terminal),
+so we only need to add the preview surface. The panel slots in alongside the existing
+right-side dockable panels (`FileChangesPanel`, `OrchestrationPanel`, `HintsPanel`) and is
+wider + resizable, defaulting to ~50% of the main content area.
+
+## Architecture
+
+Pure frontend, no backend/IPC changes required (aside from an optional additive
+`ConfigProfile` field, see Section 3). The Rust reader thread already emits
+`terminal-output` events; a passive frontend detector subscribes to the same stream that
+`App.tsx:415` already listens on, so removing the detector would not affect terminal I/O.
+
+```
+Rust: TerminalManager.reader_thread ──"terminal-output"──▶ frontend listener
+                                                             │
+   existing: handleTerminalOutput(id, bytes) ──▶ xterm.js    │
+   NEW:      previewDetector.consume(id, bytes) ──▶ previewStore.setDetectedUrl
+                                                             │
+                                                             ▼
+                                                     <PreviewPanel/>
+```
+
+**Invariants:**
+- Detection is passive — no critical path.
+- State is per-terminal; the panel is a singleton (one live iframe at a time by default).
+- No new IPC. `fs:read-text-file` for `package.json`, existing `open_external_url` for the
+  external browser button, existing `WebviewWindow` for pop-out.
+
+## New files
+
+| Path | Purpose |
+|---|---|
+| `src/components/PreviewPanel.tsx` | Docked panel: header, iframe surface, drag-resize handle |
+| `src/components/PreviewToolbar.tsx` | URL bar, reload, external open, device toggle, back/forward, pop-out, close |
+| `src/components/PreviewInlineHint.tsx` | Small "Detected `http://…` — Open preview" toast strip for ad-hoc terminals |
+| `src/components/settings/PreviewSettingsSection.tsx` | Allow-list editor, default device mode, `keepAliveAcrossTabs` |
+| `src/store/previewStore.ts` | Zustand slice (see Section 3) |
+| `src/lib/preview/detector.ts` | Pure `detectUrl(text): string \| null` — regex + priority |
+| `src/lib/preview/framework.ts` | Pure `detectFramework(packageJson): FrameworkHint` |
+| `src/lib/preview/allowlist.ts` | Pure `isUrlAllowed(url, allowList): boolean` |
+| `src/lib/preview/__tests__/detector.test.ts` | Vitest against known dev-server output fixtures |
+| `src/lib/preview/__tests__/framework.test.ts` | Vitest — `package.json` → framework mapping |
+| `src/lib/preview/__tests__/allowlist.test.ts` | Vitest — scheme, hostname, glob match |
+
+## Modified files
+
+| Path | Change |
+|---|---|
+| `src/App.tsx` | Register detector in the `terminal-output` listener; render `<PreviewPanel/>` in the right-panel dock area |
+| `src/components/ToolStripe.tsx` | Add a preview toggle icon (right side, next to changes/hints/orchestration) |
+| `src/components/ProfileModal.tsx` | Add a "Has GUI preview" checkbox + optional URL override input |
+| `src/hooks/useKeyboardShortcuts.ts` | Bind a preview-toggle shortcut (default `Ctrl+Shift+V`; verify no conflict before landing) |
+| `src/store/terminalStore.ts` | On `createTerminal`, seed `previewStore` with framework hint + profile `preview` block. On `closeTerminal`, call `previewStore.removeTerminal(id)` |
+| `src-tauri/src/config.rs` | Add `preview: Option<PreviewProfile>` to `ConfigProfile` (backwards compatible via `#[serde(default)]`) |
+| `src-tauri/src/database.rs` | Migration: add nullable `preview_json TEXT` column to `profiles`. Existing rows read as `NULL` → `preview: None` |
+| `src-tauri/capabilities/default.json` | Ensure `fs:read-text-file` allows reading `package.json` under a terminal's `working_directory`; ensure `shell:open` is scoped for external browser opens |
+
+## Preview state
+
+```ts
+// src/store/previewStore.ts
+type DeviceName = 'desktop' | 'tablet' | 'mobile';
+interface DeviceMode { name: DeviceName; width: number; height?: number }
+
+type FrameworkHint =
+  | 'nextjs' | 'vite' | 'astro' | 'nuxt' | 'sveltekit' | 'remix'
+  | 'angular' | 'cra' | 'expo' | 'unknown';
+
+interface PreviewState {
+  isOpen: boolean;              // panel visible when this terminal is active
+  detectedUrl: string | null;   // last URL scraped from stdout
+  userOverride: string | null;  // URL manually entered — wins over detectedUrl
+  frameworkHint: FrameworkHint;
+  deviceMode: DeviceMode;
+  history: string[];
+  historyIndex: number;
+  lastError: string | null;
+  reloadCounter: number;        // bump to force iframe remount on Reload
+}
+
+interface PreviewStoreState {
+  perTerminal: Map<string, PreviewState>;
+  globalOpen: boolean;          // master toggle
+  allowList: string[];          // e.g. ["*.ngrok.io", "*.trycloudflare.com"]
+  keepAliveAcrossTabs: boolean; // opt-in "keep all iframes mounted"
+  panelWidthPx: number;         // resizable, persisted
+
+  seedTerminal(id: string, initial: Partial<PreviewState>): void;
+  setDetectedUrl(id: string, url: string): void;
+  setUserOverride(id: string, url: string): void;
+  removeTerminal(id: string): void;
+  toggleGlobal(): void;
+  setDeviceMode(id: string, mode: DeviceMode): void;
+  reload(id: string): void;
+  goBack(id: string): void;
+  goForward(id: string): void;
+  addToAllowList(pattern: string): void;
+  setPanelWidth(px: number): void;
+}
+```
+
+**Persistence:** `allowList`, `keepAliveAcrossTabs`, `panelWidthPx`, `globalOpen` are
+persisted via `zustand/middleware/persist` (matches existing `appStore` pattern).
+`perTerminal` is **not** persisted (ephemeral like `terminalStore`).
+
+**Rust `PreviewProfile`:**
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PreviewProfile {
+    pub enabled: bool,             // "This profile has a GUI"
+    pub url_override: Option<String>,
+    pub framework_hint: Option<String>,
+}
+// In ConfigProfile:
+#[serde(default)]
+pub preview: Option<PreviewProfile>,
+```
+
+## Detection
+
+**URL regex (frontend):**
+
+```ts
+const URL_PATTERN = /(?:Local[:\s]+|➜\s+Local:\s+|Listening on\s+|Server ready at\s+|ready\s+-\s+started server on\s+)?(https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d{1,5}))/gi;
+```
+
+Priority: most recent match in the chunk wins. Input is stripped of ANSI escape codes
+before matching (dev-server output usually contains `\x1b[...m` colour codes):
+
+```ts
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+const stripAnsi = (s: string) => s.replace(ANSI_PATTERN, '');
+```
+
+**Fixtures** (`detector.test.ts` must exercise all of these):
+
+- Vite: `➜  Local:   http://localhost:5173/`
+- Next.js 13-14: `- Local:        http://localhost:3000`
+- Next.js 15+: `▲ Next.js 15.0.0\n- Local: http://localhost:3000`
+- CRA: `Local:            http://localhost:3000`
+- Astro: `┃ Local    http://localhost:4321/`
+- Nuxt: `➜ Local:    http://localhost:3000/`
+- SvelteKit: `➜  Local:   http://localhost:5173/`
+- Angular: `Angular Live Development Server is listening on localhost:4200`
+- Remix: `[remix-serve] http://localhost:3000`
+- Expo web: `Web is waiting on http://localhost:19006`
+
+**Framework hint (`framework.ts`):** priority `scripts.dev` > `dependencies` >
+`devDependencies`. Mapping:
+
+- `next` → `'nextjs'` (default port 3000)
+- `vite` → `'vite'` (default port 5173)
+- `@angular/core` → `'angular'` (default port 4200)
+- `astro` → `'astro'` (default port 4321)
+- `nuxt` → `'nuxt'` (default port 3000)
+- `@sveltejs/kit` → `'sveltekit'` (default port 5173)
+- `@remix-run/dev` → `'remix'` (default port 3000)
+- `react-scripts` → `'cra'` (default port 3000)
+- `expo` → `'expo'` (default port 8081, web 19006)
+- Otherwise → `'unknown'`
+
+Framework hint drives only the pre-detection "waiting for X dev server…" copy; the
+scraped URL always overrides the guessed default port once seen.
+
+## Trigger rules (when the panel appears)
+
+- **Profile flagged `preview.enabled = true`:** panel opens automatically the first time
+  the terminal produces any output (immediately if `userOverride` is set).
+- **Any terminal, ad-hoc:** on first detection of a localhost URL, `PreviewInlineHint`
+  slides in for ~6 s ("Detected `http://localhost:5173` — Open preview"). Click opens the
+  panel and stops the hint from re-showing for that terminal.
+- **Manual:** the `ToolStripe` right-side icon toggles `globalOpen`. Shortcut
+  `Ctrl+Shift+V` if free, else fall back in order to `Ctrl+Shift+G`, `Ctrl+Alt+P`;
+  final chosen binding is recorded in the implementation plan, not the spec.
+
+## Per-tab behavior
+
+Default: single iframe, active-tab-driven. When the active terminal changes, the current
+iframe unmounts and the new terminal's iframe mounts. If `keepAliveAcrossTabs` is on,
+all iframes stay mounted with `visibility: hidden` for inactive tabs (opt-in from
+Settings — costs one live iframe + dev-server WebSocket per open terminal).
+
+## Security
+
+**URL allow-list (`allowlist.ts`):**
+
+- Always allow `http://localhost:*`, `http://127.0.0.1:*`, `http://0.0.0.0:*`, `https://`
+  variants of the same.
+- Match user-defined glob patterns (e.g. `*.ngrok.io`) using a small hand-rolled matcher
+  (no `minimatch` dependency): `*` matches one hostname label, `.` is literal, everything
+  else is literal. Reject `ngrok.io.evil.com` (dot boundary check).
+- Everything else → rejected. Panel shows "URL not allowed. Add hostname to Preview
+  allow-list in Settings." with a one-click "Open Settings" button.
+
+**Iframe attributes:** no `sandbox`, no `referrerpolicy` override. Same trust level as
+`npm run dev` in the terminal.
+
+**URL bar:** free-form input, re-validated via `isUrlAllowed` on every change. Invalid
+URLs surface an inline error and don't touch the iframe `src`.
+
+**Pop-out (Q6 D):** reuses `WebviewWindow`. The new detached window loads the preview URL
+directly (not the React bundle). Capability: extend `webviewWindow:allow-create` with a
+label prefix `preview-*`.
+
+## Implementation stages (Q6 D — staged for early ship-ability)
+
+Each stage is testable + shippable:
+
+1. iframe surface + reload + external-open (minimum viable preview)
+2. URL bar + allow-list validation (Q7-B satisfied)
+3. Framework detection + inline hint + auto-open on profile flag (Q5-C satisfied)
+4. Drag-resize handle + Settings integration
+5. Device frame toggle (desktop/tablet/mobile CSS wrappers, no emulation)
+6. Back/forward navigation + dev-server network-status pill
+7. Pop-out into detached `WebviewWindow`
+
+## Non-goals
+
+- Screen capture / native GUI preview (Q1 — deferred).
+- Multiple simultaneous iframes without `keepAliveAcrossTabs` (Q4 — deferred).
+- Full mobile emulator (real touch events, viewport meta emulation) — device frames are
+  CSS-only.
+- Editing the previewed page from within the panel (this is a preview, not a canvas).
+- Port scanning (Q3 D — rejected).
+
+## Verification
+
+- Unit tests: `detectUrl` (10 fixtures), `detectFramework` (per-package fixture), 
+  `isUrlAllowed` (localhost variants, glob match, hostname boundary), `previewStore` 
+  (lifecycle, keep-alive toggle, override priority).
+- Component tests: `PreviewPanel` renders iframe only for a valid allowed URL; renders 
+  waiting/blocked/error states appropriately.
+- `npx tsc --noEmit`, `vite build`, existing vitest suite green.
+- Manual: launch `npm run tauri dev` in a Vite project via ClaudeTerminal, verify (a) 
+  auto-open on profile flag, (b) URL detected within 5s of dev-server ready, (c) 
+  `ToolStripe` toggle works, (d) tab switch swaps iframe, (e) `closeTerminal` releases 
+  state (spot-check via React DevTools).
+- Security review: run the security-review skill against the diff before merging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tauri-apps/plugin-updater": "^2.0.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-serialize": "^0.13.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
@@ -1861,6 +1862,15 @@
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
       "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.13.0.tgz",
+      "integrity": "sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
     },
     "node_modules/@xterm/addon-unicode11": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tauri-apps/plugin-updater": "^2.0.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -541,6 +541,8 @@ dependencies = [
  "trash",
  "url",
  "uuid",
+ "webview2-com",
+ "windows-core 0.61.2",
  "zip 2.4.2",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,15 @@ tiny_http = "0.12"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 flate2 = "1"
 
+# On Windows, we reach into the underlying CoreWebView2 to disable the
+# default browser context menu (Back/Refresh/Save-as/Inspect) — otherwise
+# right-click → Refresh inside the preview iframe reloads the top-level
+# app and closes every open terminal. Matches the version Tauri already
+# pulls in transitively so nothing extra needs to compile.
+[target.'cfg(target_os = "windows")'.dependencies]
+webview2-com = "0.38"
+windows-core = "0.61"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1499,6 +1499,54 @@ pub struct FileDiffResult {
     pub is_binary: bool,
 }
 
+/// Reject a single git pathspec that isn't a plain repo-relative path.
+/// Mirrors `validate_file_list`'s per-entry checks. The diff/show commands pass
+/// a frontend-supplied file path straight into git args, so this is both a
+/// traversal guard and defense-in-depth for the arg-handling seams.
+fn validate_git_pathspec(file: &str) -> Result<(), String> {
+    if file.is_empty() || file.contains('\0') {
+        return Err("Invalid file path".to_string());
+    }
+    if file.starts_with('/') || file.starts_with('\\') || file.contains("..") {
+        return Err(format!("Invalid file path: {}", file));
+    }
+    Ok(())
+}
+
+/// Build the `+`-prefixed pseudo-diff for a new/untracked file, capping size and
+/// sniffing for binary the same way `read_text_file` does. Returns a short
+/// human-readable marker (not an error) when the file can't be previewed, so the
+/// diff pane degrades gracefully instead of reading an unbounded file into RAM.
+fn build_new_file_diff(full_path: &std::path::Path, file_path: &str) -> String {
+    const MAX_DIFF_FILE_BYTES: u64 = 5 * 1024 * 1024; // 5 MB, matches read_text_file
+    match std::fs::metadata(full_path) {
+        Ok(m) if m.len() > MAX_DIFF_FILE_BYTES => {
+            return format!("File is too large to preview ({} bytes).", m.len());
+        }
+        Ok(_) => {}
+        Err(_) => return String::from("Unable to read file contents"),
+    }
+    let bytes = match std::fs::read(full_path) {
+        Ok(b) => b,
+        Err(_) => return String::from("Unable to read file contents"),
+    };
+    let sniff = bytes.len().min(8192);
+    if bytes[..sniff].contains(&0u8) {
+        return String::from("Binary file - preview not available");
+    }
+    let content = match String::from_utf8(bytes) {
+        Ok(c) => c,
+        Err(_) => return String::from("File is not valid UTF-8"),
+    };
+    let lines: Vec<String> = content.lines().map(|l| format!("+{}", l)).collect();
+    format!(
+        "--- /dev/null\n+++ b/{}\n@@ -0,0 +1,{} @@\n{}",
+        file_path,
+        lines.len(),
+        lines.join("\n")
+    )
+}
+
 #[command]
 pub async fn get_file_diff(
     state: State<'_, AppState>,
@@ -1507,6 +1555,7 @@ pub async fn get_file_diff(
     staged: bool,
 ) -> Result<FileDiffResult, String> {
     wrap_cmd("get_file_diff", async move {
+        validate_git_pathspec(&file_path)?;
         let working_directory = {
             let terminals = state.terminals.lock().await;
             let configs = terminals.get_all_configs();
@@ -1539,21 +1588,9 @@ pub async fn get_file_diff(
 
         let diff_text = if is_new_file {
             // For untracked/new files, read the file and format as all-added
+            // (size-capped + binary-sniffed - see build_new_file_diff).
             let full_path = std::path::Path::new(&working_directory).join(&file_path);
-            match std::fs::read_to_string(&full_path) {
-                Ok(content) => {
-                    let lines: Vec<String> = content.lines().enumerate().map(|(_, line)| {
-                        format!("+{}", line)
-                    }).collect();
-                    format!(
-                        "--- /dev/null\n+++ b/{}\n@@ -0,0 +1,{} @@\n{}",
-                        file_path,
-                        lines.len(),
-                        lines.join("\n")
-                    )
-                }
-                Err(_) => String::from("Unable to read file contents")
-            }
+            build_new_file_diff(&full_path, &file_path)
         } else if is_deleted_file {
             // For deleted files, show content from HEAD
             let show_output = git_command(&["show", &format!("HEAD:{}", file_path)])
@@ -3706,6 +3743,7 @@ pub async fn get_path_file_diff(
 ) -> Result<FileDiffResult, String> {
     wrap_cmd("get_path_file_diff", async move {
         validate_path_is_trusted(&state, &path).await?;
+        validate_git_pathspec(&file_path)?;
         // `file_path` is repo-root-relative (porcelain output) - resolve against
         // the root in case `path` is a subdirectory of the repo.
         let path = resolve_repo_root(&path)?;
@@ -3727,18 +3765,7 @@ pub async fn get_path_file_diff(
 
         let diff_text = if is_new_file {
             let full_path = std::path::Path::new(&path).join(&file_path);
-            match std::fs::read_to_string(&full_path) {
-                Ok(content) => {
-                    let lines: Vec<String> = content.lines().map(|line| format!("+{}", line)).collect();
-                    format!(
-                        "--- /dev/null\n+++ b/{}\n@@ -0,0 +1,{} @@\n{}",
-                        file_path,
-                        lines.len(),
-                        lines.join("\n")
-                    )
-                }
-                Err(_) => String::from("Unable to read file contents"),
-            }
+            build_new_file_diff(&full_path, &file_path)
         } else if is_deleted_file {
             let show_output = git_command(&["show", &format!("HEAD:{}", file_path)])
                 .current_dir(&path)
@@ -4157,7 +4184,8 @@ pub async fn get_git_head_content(
 ) -> Result<String, String> {
     wrap_cmd("get_git_head_content", async move {
         validate_path_is_trusted(&state, &path).await?;
-        if file.is_empty() || file.starts_with('-') {
+        validate_git_pathspec(&file)?;
+        if file.starts_with('-') {
             return Err("Invalid file path".to_string());
         }
         // git uses forward slashes in ref specs, even on Windows.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -796,6 +796,39 @@ pub(crate) fn shell_command(program: &str, args: &[&str]) -> std::process::Comma
     }
 }
 
+/// Build a Command that runs `git` with the given args.
+///
+/// SECURITY: On Windows we must NOT route git through `cmd /C` the way the
+/// generic `shell_command` helper does for `.cmd`/`.bat` shims (npm/claude).
+/// `git` is a real `.exe`, so we invoke it directly. Going through cmd.exe
+/// lets cmd metacharacters (`& | ( ) ^ !`) in user-controlled args — branch
+/// names, file paths, remotes coming from a hostile repository — break out
+/// into command execution, because Rust's std only quotes args containing
+/// whitespace and its cmd.exe caret-escaping (the CVE-2024-24576 fix) only
+/// triggers when the spawned program itself is a `.bat`/`.cmd`, not `cmd.exe`.
+/// Spawning `git.exe` directly means args are passed as literal argv elements
+/// (no shell interprets them), which closes the whole injection family.
+///
+/// On Unix we keep using the login shell (`shell_command`) because git's PATH
+/// resolution can depend on the interactive shell environment there, and the
+/// single-quote escaping in `shell_command` already makes injection impossible.
+pub(crate) fn git_command(args: &[&str]) -> std::process::Command {
+    #[cfg(target_os = "windows")]
+    {
+        let mut cmd = std::process::Command::new("git");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        cmd
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        shell_command("git", args)
+    }
+}
+
 /// Pick a sensible "version" string from a command's stdout.
 ///
 /// With the shell helper now using `-lic`, an interactive shell's init may
@@ -998,7 +1031,11 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::
 /// overwrite an existing entry at the destination - UI should ask the user
 /// first if they really want to replace it.
 #[command]
-pub async fn rename_path(from: String, to: String) -> Result<(), String> {
+pub async fn rename_path(
+    state: State<'_, AppState>,
+    from: String,
+    to: String,
+) -> Result<(), String> {
     wrap_cmd("rename_path", async move {
         validate_path(&from)?;
         validate_path(&to)?;
@@ -1007,6 +1044,9 @@ pub async fn rename_path(from: String, to: String) -> Result<(), String> {
         if !from_p.exists() {
             return Err("Source path does not exist".to_string());
         }
+        // Confine to an active terminal's working directory. `to` shares
+        // `from`'s parent (enforced below), so trusting the source is enough.
+        validate_path_is_trusted(&state, &from).await?;
         if to_p.exists() {
             return Err("A file with that name already exists".to_string());
         }
@@ -1023,13 +1063,15 @@ pub async fn rename_path(from: String, to: String) -> Result<(), String> {
 /// handles Windows (SHFileOperation), macOS (NSFileManager trashItem), and
 /// Linux (XDG trash spec) - entries can be restored manually by the user.
 #[command]
-pub async fn trash_path(path: String) -> Result<(), String> {
+pub async fn trash_path(state: State<'_, AppState>, path: String) -> Result<(), String> {
     wrap_cmd("trash_path", async move {
         validate_path(&path)?;
         let p = std::path::PathBuf::from(&path);
         if !p.exists() {
             return Err("Path does not exist".to_string());
         }
+        // Only allow trashing paths under an active terminal's working directory.
+        validate_path_is_trusted(&state, &path).await?;
         trash::delete(&p).map_err(|e| e.to_string())
     })
     .await
@@ -1039,7 +1081,11 @@ pub async fn trash_path(path: String) -> Result<(), String> {
 /// Refuses to overwrite an existing entry; refuses to move a folder into
 /// itself or any of its descendants (which would leave the source orphaned).
 #[command]
-pub async fn move_into_dir(source: String, dest_dir: String) -> Result<(), String> {
+pub async fn move_into_dir(
+    state: State<'_, AppState>,
+    source: String,
+    dest_dir: String,
+) -> Result<(), String> {
     wrap_cmd("move_into_dir", async move {
         validate_path(&source)?;
         validate_path(&dest_dir)?;
@@ -1051,6 +1097,9 @@ pub async fn move_into_dir(source: String, dest_dir: String) -> Result<(), Strin
         if !dst_dir.is_dir() {
             return Err("Destination is not a folder".to_string());
         }
+        // Both endpoints must live under an active terminal's working directory.
+        validate_path_is_trusted(&state, &source).await?;
+        validate_path_is_trusted(&state, &dest_dir).await?;
         let name = src
             .file_name()
             .ok_or_else(|| "Source has no file name".to_string())?;
@@ -1084,7 +1133,11 @@ pub async fn move_into_dir(source: String, dest_dir: String) -> Result<(), Strin
 
 /// Copy a file or folder into `dest_dir` (keeps the original basename).
 #[command]
-pub async fn copy_into_dir(source: String, dest_dir: String) -> Result<(), String> {
+pub async fn copy_into_dir(
+    state: State<'_, AppState>,
+    source: String,
+    dest_dir: String,
+) -> Result<(), String> {
     wrap_cmd("copy_into_dir", async move {
         validate_path(&source)?;
         validate_path(&dest_dir)?;
@@ -1096,6 +1149,9 @@ pub async fn copy_into_dir(source: String, dest_dir: String) -> Result<(), Strin
         if !dst_dir.is_dir() {
             return Err("Destination is not a folder".to_string());
         }
+        // Both endpoints must live under an active terminal's working directory.
+        validate_path_is_trusted(&state, &source).await?;
+        validate_path_is_trusted(&state, &dest_dir).await?;
         let name = src
             .file_name()
             .ok_or_else(|| "Source has no file name".to_string())?;
@@ -1312,7 +1368,7 @@ pub async fn get_terminal_changes(
         };
 
         // Check if it's a git repo and get branch name
-        let branch_output = shell_command("git", &["rev-parse", "--abbrev-ref", "HEAD"])
+        let branch_output = git_command(&["rev-parse", "--abbrev-ref", "HEAD"])
             .current_dir(&working_directory)
             .output();
 
@@ -1339,7 +1395,7 @@ pub async fn get_terminal_changes(
         let repo_root = resolve_repo_root(&working_directory).ok();
 
         // Get changed files
-        let status_output = shell_command("git", &["status", "--porcelain"])
+        let status_output = git_command(&["status", "--porcelain"])
             .current_dir(&working_directory)
             .output()
             .map_err(|e| format!("Failed to run git status: {}", e))?;
@@ -1450,7 +1506,7 @@ pub async fn get_file_diff(
         let working_directory = resolve_repo_root(&working_directory)?;
 
         // Run git status for this specific file to determine its status
-        let status_output = shell_command("git", &["status", "--porcelain", "--", &file_path])
+        let status_output = git_command(&["status", "--porcelain", "--", &file_path])
             .current_dir(&working_directory)
             .output()
             .map_err(|e| format!("Failed to run git status: {}", e))?;
@@ -1484,7 +1540,7 @@ pub async fn get_file_diff(
             }
         } else if is_deleted_file {
             // For deleted files, show content from HEAD
-            let show_output = shell_command("git", &["show", &format!("HEAD:{}", file_path)])
+            let show_output = git_command(&["show", &format!("HEAD:{}", file_path)])
                 .current_dir(&working_directory)
                 .output();
             match show_output {
@@ -1511,7 +1567,7 @@ pub async fn get_file_diff(
             args.push("--");
             args.push(&file_path);
 
-            let diff_output = shell_command("git", &args)
+            let diff_output = git_command(&args)
                 .current_dir(&working_directory)
                 .output()
                 .map_err(|e| format!("Failed to run git diff: {}", e))?;
@@ -1520,7 +1576,7 @@ pub async fn get_file_diff(
 
             // If unstaged diff is empty, try staged diff (file might be fully staged)
             if text.trim().is_empty() && !staged {
-                let staged_output = shell_command("git", &["diff", "--cached", "--", &file_path])
+                let staged_output = git_command(&["diff", "--cached", "--", &file_path])
                     .current_dir(&working_directory)
                     .output()
                     .map_err(|e| format!("Failed to run git diff --cached: {}", e))?;
@@ -1615,7 +1671,7 @@ pub async fn get_worktree_info(
         }
 
         // Check if inside a git work tree
-        let inside_wt = shell_command("git", &["rev-parse", "--is-inside-work-tree"])
+        let inside_wt = git_command(&["rev-parse", "--is-inside-work-tree"])
             .current_dir(&path)
             .output();
 
@@ -1633,7 +1689,7 @@ pub async fn get_worktree_info(
         }
 
         // Get worktree root (--show-toplevel)
-        let toplevel = shell_command("git", &["rev-parse", "--show-toplevel"])
+        let toplevel = git_command(&["rev-parse", "--show-toplevel"])
             .current_dir(&path)
             .output()
             .ok()
@@ -1641,14 +1697,14 @@ pub async fn get_worktree_info(
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
         // Get git-dir and git-common-dir to detect if this is a linked worktree
-        let git_dir = shell_command("git", &["rev-parse", "--git-dir"])
+        let git_dir = git_command(&["rev-parse", "--git-dir"])
             .current_dir(&path)
             .output()
             .ok()
             .filter(|o| o.status.success())
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
-        let git_common_dir = shell_command("git", &["rev-parse", "--git-common-dir"])
+        let git_common_dir = git_command(&["rev-parse", "--git-common-dir"])
             .current_dir(&path)
             .output()
             .ok()
@@ -1681,7 +1737,7 @@ pub async fn get_worktree_info(
         });
 
         // Get current branch
-        let current_branch = shell_command("git", &["rev-parse", "--abbrev-ref", "HEAD"])
+        let current_branch = git_command(&["rev-parse", "--abbrev-ref", "HEAD"])
             .current_dir(&path)
             .output()
             .ok()
@@ -1705,7 +1761,7 @@ pub async fn get_worktree_info(
 
 /// Internal helper to list worktrees for a given path (no authorization check).
 fn list_worktrees_internal(path: &str) -> Result<Vec<WorktreeInfo>, String> {
-    let output = shell_command("git", &["worktree", "list", "--porcelain"])
+    let output = git_command(&["worktree", "list", "--porcelain"])
         .current_dir(path)
         .output()
         .map_err(|e| format!("Failed to run git worktree list: {}", e))?;
@@ -1786,7 +1842,7 @@ pub async fn get_repo_branches(
     wrap_cmd("get_repo_branches", async move {
         validate_path_is_trusted(&state, &path).await?;
 
-        let output = shell_command("git", &["branch", "--format=%(refname:short)"])
+        let output = git_command(&["branch", "--format=%(refname:short)"])
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to list branches: {}", e))?;
@@ -1815,7 +1871,7 @@ pub struct StashEntry {
 }
 
 fn run_git(path: &str, args: &[&str]) -> Result<String, String> {
-    let out = shell_command("git", args)
+    let out = git_command(args)
         .current_dir(path)
         .output()
         .map_err(|e| format!("Failed to run git {}: {}", args.join(" "), e))?;
@@ -2388,7 +2444,7 @@ pub async fn checkout_branch(
         if branch.chars().any(|c| c.is_control() || c == ' ' || c == '~' || c == '^' || c == ':' || c == '?' || c == '*' || c == '[') {
             return Err("Invalid branch name".to_string());
         }
-        let output = shell_command("git", &["checkout", &branch])
+        let output = git_command(&["checkout", &branch])
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git checkout: {}", e))?;
@@ -2425,11 +2481,11 @@ pub async fn create_worktree(
         }
 
         let output = if create_branch {
-            shell_command("git", &["worktree", "add", "-b", &branch, &worktree_path])
+            git_command(&["worktree", "add", "-b", &branch, &worktree_path])
                 .current_dir(&repo_path)
                 .output()
         } else {
-            shell_command("git", &["worktree", "add", &worktree_path, &branch])
+            git_command(&["worktree", "add", &worktree_path, &branch])
                 .current_dir(&repo_path)
                 .output()
         };
@@ -2480,7 +2536,7 @@ pub async fn remove_worktree(
             vec!["worktree", "remove", &worktree_path]
         };
 
-        let output = shell_command("git", &args)
+        let output = git_command(&args)
             .current_dir(&repo_path)
             .output()
             .map_err(|e| format!("Failed to remove worktree: {}", e))?;
@@ -3185,7 +3241,10 @@ pub async fn list_memory_files(project_path: Option<String>) -> Result<Vec<Memor
         };
 
         if let Some(ref specific_project) = project_path {
-            // Scan only the specific project
+            // Scan only the specific project. Confine it to ~/.claude so a
+            // caller can't enumerate `<arbitrary>/memory` anywhere on disk
+            // (e.g. leaking file names/sizes from ~/.ssh).
+            validate_claude_path(specific_project)?;
             let target = std::path::Path::new(specific_project);
             if target.exists() && target.is_dir() {
                 scan_project(target, &mut files);
@@ -3379,7 +3438,7 @@ pub struct ScannedGitRepo {
 }
 
 fn git_branch_for(path: &std::path::Path) -> Option<String> {
-    let out = shell_command("git", &["rev-parse", "--abbrev-ref", "HEAD"])
+    let out = git_command(&["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(path)
         .output()
         .ok()?;
@@ -3389,13 +3448,13 @@ fn git_branch_for(path: &std::path::Path) -> Option<String> {
 }
 
 fn git_is_worktree(path: &std::path::Path) -> bool {
-    let git_dir = shell_command("git", &["rev-parse", "--git-dir"])
+    let git_dir = git_command(&["rev-parse", "--git-dir"])
         .current_dir(path)
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
-    let common = shell_command("git", &["rev-parse", "--git-common-dir"])
+    let common = git_command(&["rev-parse", "--git-common-dir"])
         .current_dir(path)
         .output()
         .ok()
@@ -3412,7 +3471,7 @@ fn git_is_worktree(path: &std::path::Path) -> bool {
 }
 
 fn git_dirty(path: &std::path::Path) -> bool {
-    shell_command("git", &["status", "--porcelain"])
+    git_command(&["status", "--porcelain"])
         .current_dir(path)
         .output()
         .ok()
@@ -3423,7 +3482,7 @@ fn git_dirty(path: &std::path::Path) -> bool {
 
 fn git_ahead_behind(path: &std::path::Path) -> (u32, u32) {
     // rev-list --count --left-right HEAD...@{u}   → "ahead\tbehind"
-    let out = shell_command("git", &["rev-list", "--count", "--left-right", "HEAD...@{u}"])
+    let out = git_command(&["rev-list", "--count", "--left-right", "HEAD...@{u}"])
         .current_dir(path)
         .output();
     let Ok(out) = out else { return (0, 0); };
@@ -3523,7 +3582,7 @@ pub async fn get_path_changes(
     wrap_cmd("get_path_changes", async move {
         validate_path_is_trusted(&state, &path).await?;
 
-        let branch_output = shell_command("git", &["rev-parse", "--abbrev-ref", "HEAD"])
+        let branch_output = git_command(&["rev-parse", "--abbrev-ref", "HEAD"])
             .current_dir(&path)
             .output();
 
@@ -3549,7 +3608,7 @@ pub async fn get_path_changes(
 
         let repo_root = resolve_repo_root(&path).ok();
 
-        let status_output = shell_command("git", &["status", "--porcelain"])
+        let status_output = git_command(&["status", "--porcelain"])
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git status: {}", e))?;
@@ -3635,7 +3694,7 @@ pub async fn get_path_file_diff(
         // the root in case `path` is a subdirectory of the repo.
         let path = resolve_repo_root(&path)?;
 
-        let status_output = shell_command("git", &["status", "--porcelain", "--", &file_path])
+        let status_output = git_command(&["status", "--porcelain", "--", &file_path])
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git status: {}", e))?;
@@ -3665,7 +3724,7 @@ pub async fn get_path_file_diff(
                 Err(_) => String::from("Unable to read file contents"),
             }
         } else if is_deleted_file {
-            let show_output = shell_command("git", &["show", &format!("HEAD:{}", file_path)])
+            let show_output = git_command(&["show", &format!("HEAD:{}", file_path)])
                 .current_dir(&path)
                 .output();
             match show_output {
@@ -3687,14 +3746,14 @@ pub async fn get_path_file_diff(
             args.push("--");
             args.push(&file_path);
 
-            let diff_output = shell_command("git", &args)
+            let diff_output = git_command(&args)
                 .current_dir(&path)
                 .output()
                 .map_err(|e| format!("Failed to run git diff: {}", e))?;
 
             let text = String::from_utf8_lossy(&diff_output.stdout).to_string();
             if text.trim().is_empty() && !staged {
-                let staged_output = shell_command("git", &["diff", "--cached", "--", &file_path])
+                let staged_output = git_command(&["diff", "--cached", "--", &file_path])
                     .current_dir(&path)
                     .output()
                     .map_err(|e| format!("Failed to run git diff --cached: {}", e))?;
@@ -3746,7 +3805,7 @@ pub async fn git_create_branch(
             args.push(b);
         }
 
-        let output = shell_command("git", &args)
+        let output = git_command(&args)
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git checkout -b: {}", e))?;
@@ -3790,7 +3849,7 @@ pub async fn get_upstream_branch(
 ) -> Result<Option<String>, String> {
     wrap_cmd("get_upstream_branch", async move {
         validate_path_is_trusted(&state, &path).await?;
-        let output = shell_command("git", &[
+        let output = git_command(&[
             "rev-parse",
             "--abbrev-ref",
             "--symbolic-full-name",
@@ -3872,7 +3931,7 @@ pub async fn git_pull_branch(
         args.push(&remote);
         args.push(&branch);
 
-        let output = shell_command("git", &args)
+        let output = git_command(&args)
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git pull: {}", e))?;
@@ -3904,7 +3963,7 @@ pub async fn git_pull_branch(
         };
 
         if stashed {
-            let pop = shell_command("git", &["stash", "pop"])
+            let pop = git_command(&["stash", "pop"])
                 .current_dir(&path)
                 .output()
                 .map_err(|e| format!("Failed to run git stash pop: {}", e))?;
@@ -4088,7 +4147,7 @@ pub async fn get_git_head_content(
         // git uses forward slashes in ref specs, even on Windows.
         let normalized = file.replace('\\', "/");
         let spec = format!("HEAD:{}", normalized);
-        let output = shell_command("git", &["show", &spec])
+        let output = git_command(&["show", &spec])
             .current_dir(&path)
             .output()
             .map_err(|e| format!("Failed to run git show: {}", e))?;
@@ -4148,7 +4207,7 @@ pub async fn git_discard_file(
         }
 
         // Tracked file - reset index + worktree for just this file to HEAD.
-        let output = shell_command("git", &["checkout", "HEAD", "--", &file])
+        let output = git_command(&["checkout", "HEAD", "--", &file])
             .current_dir(&root)
             .output()
             .map_err(|e| format!("Failed to run git checkout: {}", e))?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -325,11 +325,19 @@ pub async fn create_terminal(
                     "[session-resume] '{}' recorded --continue target session {}",
                     config.label, newest.id
                 );
-                let mut m = state.terminals.lock().await;
-                m.update_claude_session_id(&config.id, newest.id.clone());
+                {
+                    let mut m = state.terminals.lock().await;
+                    m.update_claude_session_id(&config.id, newest.id.clone());
+                }
+                // Persist to history so the Session Timeline can `--resume` it.
+                {
+                    let db = state.db.lock().await;
+                    let _ = db.update_session_claude_id(&config.id, &newest.id);
+                }
             }
         } else {
             let manager = state.terminals.clone();
+            let db_for_detect = state.db.clone();
             let detect_id = config.id.clone();
             let detect_label = config.label.clone();
             let cwd_for_log = working_directory.clone();
@@ -374,8 +382,15 @@ pub async fn create_terminal(
                                 "[session-detect] '{}' bound to session {} (cwd={})",
                                 detect_label, session_id, cwd_for_log
                             );
-                            let mut m = manager.lock().await;
-                            m.update_claude_session_id(&detect_id, session_id.clone());
+                            {
+                                let mut m = manager.lock().await;
+                                m.update_claude_session_id(&detect_id, session_id.clone());
+                            }
+                            // Mirror onto the history row for later `--resume`.
+                            {
+                                let db = db_for_detect.lock().await;
+                                let _ = db.update_session_claude_id(&detect_id, &session_id);
+                            }
                             last_recorded = Some(session_id);
                         }
                     }
@@ -391,6 +406,7 @@ pub async fn create_terminal(
                 &config.label,
                 &config.created_at.to_rfc3339(),
                 Some(&log_path),
+                Some(&config.working_directory),
             ) {
                 eprintln!("Failed to insert session history: {}", e);
             }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,6 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PreviewProfile {
+    pub enabled: bool,
+    pub url_override: Option<String>,
+    pub framework_hint: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigProfile {
     pub id: String,
@@ -10,6 +18,8 @@ pub struct ConfigProfile {
     pub claude_args: Vec<String>,
     pub env_vars: HashMap<String, String>,
     pub is_default: bool,
+    #[serde(default)]
+    pub preview: Option<PreviewProfile>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -268,6 +278,7 @@ mod tests {
             claude_args: vec!["--model".to_string(), "opus".to_string()],
             env_vars: env,
             is_default: true,
+            preview: None,
         }
     }
 
@@ -296,6 +307,7 @@ mod tests {
             claude_args: vec![],
             env_vars: HashMap::new(),
             is_default: false,
+            preview: None,
         };
         let json = serde_json::to_string(&p).unwrap();
         let back: ConfigProfile = serde_json::from_str(&json).unwrap();
@@ -303,6 +315,40 @@ mod tests {
         assert_eq!(back.description, None);
         assert!(back.claude_args.is_empty());
         assert!(back.env_vars.is_empty());
+    }
+
+    #[test]
+    fn preview_profile_default_and_roundtrip() {
+        let p = PreviewProfile {
+            enabled: true,
+            url_override: Some("http://localhost:3000".into()),
+            framework_hint: Some("vite".into()),
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: PreviewProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.enabled, true);
+        assert_eq!(back.url_override.as_deref(), Some("http://localhost:3000"));
+        assert_eq!(back.framework_hint.as_deref(), Some("vite"));
+    }
+
+    #[test]
+    fn missing_preview_deserializes_as_none_on_config_profile() {
+        // Simulate an old serialized ConfigProfile without the preview field.
+        // Include every non-defaultable field (id, name, working_directory,
+        // claude_args, env_vars, is_default) so serde is not asked to
+        // synthesise them - the assertion under test is that `preview`
+        // defaults to None when absent.
+        let json = r#"{
+            "id": "p1",
+            "name": "x",
+            "description": null,
+            "working_directory": "/tmp",
+            "claude_args": [],
+            "env_vars": {},
+            "is_default": false
+        }"#;
+        let cfg: ConfigProfile = serde_json::from_str(json).unwrap();
+        assert!(cfg.preview.is_none());
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -12,6 +12,13 @@ pub struct SessionHistoryEntry {
     pub started_at: String,
     pub ended_at: Option<String>,
     pub log_path: Option<String>,
+    /// Working directory the session ran in - needed to resume it in the right
+    /// place. Added in a later release, so NULL for pre-migration rows.
+    pub working_directory: Option<String>,
+    /// The Claude session UUID, captured once detected, so a resume can use
+    /// `--resume <id>` exactly instead of `--continue`. NULL until detected or
+    /// for pre-migration rows.
+    pub claude_session_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -77,7 +84,9 @@ impl Database {
                 label TEXT NOT NULL,
                 started_at TEXT NOT NULL,
                 ended_at TEXT,
-                log_path TEXT
+                log_path TEXT,
+                working_directory TEXT,
+                claude_session_id TEXT
             );
 
             CREATE TABLE IF NOT EXISTS snippets (
@@ -124,7 +133,22 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_changelist_files_list ON changelist_files(changelist_id);
             ",
         )
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+        // Migrations for databases created before these columns existed.
+        // `CREATE TABLE IF NOT EXISTS` never alters an existing table, so add
+        // the columns here. ADD COLUMN errors with "duplicate column name" when
+        // already present (fresh installs, or a second launch) - treat that as
+        // success and propagate anything else.
+        for column in ["working_directory TEXT", "claude_session_id TEXT"] {
+            let sql = format!("ALTER TABLE session_history ADD COLUMN {}", column);
+            if let Err(e) = conn.execute(&sql, []) {
+                if !e.to_string().contains("duplicate column name") {
+                    return Err(e.to_string());
+                }
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn conn(&self) -> &Connection {
@@ -280,12 +304,31 @@ impl Database {
 
     // Session history methods
 
-    pub fn insert_session_history(&self, terminal_id: &str, label: &str, started_at: &str, log_path: Option<&str>) -> Result<i64, String> {
+    pub fn insert_session_history(
+        &self,
+        terminal_id: &str,
+        label: &str,
+        started_at: &str,
+        log_path: Option<&str>,
+        working_directory: Option<&str>,
+    ) -> Result<i64, String> {
         self.conn.execute(
-            "INSERT INTO session_history (terminal_id, label, started_at, log_path) VALUES (?1, ?2, ?3, ?4)",
-            params![terminal_id, label, started_at, log_path],
+            "INSERT INTO session_history (terminal_id, label, started_at, log_path, working_directory) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![terminal_id, label, started_at, log_path, working_directory],
         ).map_err(|e| e.to_string())?;
         Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Persist the detected Claude session id onto the terminal's currently-open
+    /// history row (the one without an ended_at) so a later resume can use
+    /// `--resume <id>` precisely. Idempotent - overwrites on redetection (e.g.
+    /// after `/clear` rotates the id).
+    pub fn update_session_claude_id(&self, terminal_id: &str, claude_session_id: &str) -> Result<(), String> {
+        self.conn.execute(
+            "UPDATE session_history SET claude_session_id = ?1 WHERE terminal_id = ?2 AND ended_at IS NULL",
+            params![claude_session_id, terminal_id],
+        ).map_err(|e| e.to_string())?;
+        Ok(())
     }
 
     pub fn update_session_ended(&self, terminal_id: &str, ended_at: &str) -> Result<(), String> {
@@ -298,7 +341,7 @@ impl Database {
 
     pub fn get_session_history(&self) -> Result<Vec<SessionHistoryEntry>, String> {
         let mut stmt = self.conn
-            .prepare("SELECT id, terminal_id, label, started_at, ended_at, log_path FROM session_history ORDER BY started_at DESC LIMIT 100")
+            .prepare("SELECT id, terminal_id, label, started_at, ended_at, log_path, working_directory, claude_session_id FROM session_history ORDER BY started_at DESC LIMIT 100")
             .map_err(|e| e.to_string())?;
 
         let entries = stmt.query_map([], |row| {
@@ -309,6 +352,8 @@ impl Database {
                 started_at: row.get(3)?,
                 ended_at: row.get(4)?,
                 log_path: row.get(5)?,
+                working_directory: row.get(6)?,
+                claude_session_id: row.get(7)?,
             })
         }).map_err(|e| e.to_string())?;
 
@@ -585,23 +630,27 @@ mod tests {
     fn session_history_insert_then_close_sets_ended_at() {
         let db = Database::new_in_memory().unwrap();
         let id = db
-            .insert_session_history("t1", "label", "2026-01-01T00:00:00Z", Some("/log/path"))
+            .insert_session_history("t1", "label", "2026-01-01T00:00:00Z", Some("/log/path"), Some("/work/dir"))
             .unwrap();
         assert!(id > 0);
+        // Claude session id is detected after spawn and stamped onto the open row.
+        db.update_session_claude_id("t1", "sess-abc").unwrap();
         db.update_session_ended("t1", "2026-01-01T01:00:00Z").unwrap();
 
         let entries = db.get_session_history().unwrap();
         let found = entries.iter().find(|e| e.id == id).expect("entry present");
         assert_eq!(found.ended_at.as_deref(), Some("2026-01-01T01:00:00Z"));
         assert_eq!(found.log_path.as_deref(), Some("/log/path"));
+        assert_eq!(found.working_directory.as_deref(), Some("/work/dir"));
+        assert_eq!(found.claude_session_id.as_deref(), Some("sess-abc"));
     }
 
     #[test]
     fn get_log_path_for_terminal_returns_the_most_recent_non_null_path() {
         let db = Database::new_in_memory().unwrap();
-        db.insert_session_history("t1", "old", "2026-01-01T00:00:00Z", Some("/old"))
+        db.insert_session_history("t1", "old", "2026-01-01T00:00:00Z", Some("/old"), None)
             .unwrap();
-        db.insert_session_history("t1", "new", "2026-01-02T00:00:00Z", Some("/new"))
+        db.insert_session_history("t1", "new", "2026-01-02T00:00:00Z", Some("/new"), None)
             .unwrap();
 
         assert_eq!(

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -60,6 +60,7 @@ impl Database {
         conn.execute_batch(
             "
             PRAGMA journal_mode=WAL;
+            PRAGMA foreign_keys=ON;
 
             CREATE TABLE IF NOT EXISTS profiles (
                 id TEXT PRIMARY KEY,
@@ -192,13 +193,29 @@ impl Database {
             .map_err(|e| e.to_string())?;
 
         let profiles = stmt.query_map([], |row| {
+            let id: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let args_raw: String = row.get(4)?;
+            let env_raw: String = row.get(5)?;
+            // Malformed JSON here means a profile launches with no args / no env
+            // vars - a silent behaviour change that's hard to diagnose. Log it
+            // (with the profile identity) before falling back, rather than
+            // swallowing it, so it shows up in stderr/telemetry.
+            let claude_args = serde_json::from_str(&args_raw).unwrap_or_else(|e| {
+                eprintln!("[profiles] corrupt claude_args for '{}' ({}): {}", name, id, e);
+                Default::default()
+            });
+            let env_vars = serde_json::from_str(&env_raw).unwrap_or_else(|e| {
+                eprintln!("[profiles] corrupt env_vars for '{}' ({}): {}", name, id, e);
+                Default::default()
+            });
             Ok(ConfigProfile {
-                id: row.get(0)?,
-                name: row.get(1)?,
+                id,
+                name,
                 description: row.get(2)?,
                 working_directory: row.get(3)?,
-                claude_args: serde_json::from_str(&row.get::<_, String>(4)?).unwrap_or_default(),
-                env_vars: serde_json::from_str(&row.get::<_, String>(5)?).unwrap_or_default(),
+                claude_args,
+                env_vars,
                 is_default: row.get::<_, i32>(6)? != 0,
             })
         }).map_err(|e| e.to_string())?;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -217,6 +217,7 @@ impl Database {
                 claude_args,
                 env_vars,
                 is_default: row.get::<_, i32>(6)? != 0,
+                preview: None,
             })
         }).map_err(|e| e.to_string())?;
 
@@ -497,6 +498,7 @@ mod tests {
             claude_args: vec!["--model".to_string(), "opus".to_string()],
             env_vars: env,
             is_default: false,
+            preview: None,
         }
     }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -69,7 +69,8 @@ impl Database {
                 working_directory TEXT NOT NULL,
                 claude_args TEXT NOT NULL,
                 env_vars TEXT NOT NULL,
-                is_default INTEGER DEFAULT 0
+                is_default INTEGER DEFAULT 0,
+                preview_json TEXT
             );
 
             CREATE TABLE IF NOT EXISTS workspaces (
@@ -149,6 +150,18 @@ impl Database {
                 }
             }
         }
+        // Same pattern for the profiles table: `preview_json` is nullable JSON
+        // storing the profile's PreviewProfile (see config.rs). NULL means the
+        // profile has no preview config, matching the Option<PreviewProfile>
+        // shape in Rust.
+        for column in ["preview_json TEXT"] {
+            let sql = format!("ALTER TABLE profiles ADD COLUMN {}", column);
+            if let Err(e) = conn.execute(&sql, []) {
+                if !e.to_string().contains("duplicate column name") {
+                    return Err(e.to_string());
+                }
+            }
+        }
         Ok(())
     }
 
@@ -171,9 +184,19 @@ impl Database {
             .map_err(|e| format!("Failed to serialize claude_args: {}", e))?;
         let env_vars_json = serde_json::to_string(&profile.env_vars)
             .map_err(|e| format!("Failed to serialize env_vars: {}", e))?;
+        // preview_json mirrors env_vars: JSON in a TEXT column, but nullable -
+        // Option<PreviewProfile>::None persists as SQL NULL so old rows and
+        // opted-out profiles are indistinguishable on read.
+        let preview_json: Option<String> = match &profile.preview {
+            Some(preview) => Some(
+                serde_json::to_string(preview)
+                    .map_err(|e| format!("Failed to serialize preview: {}", e))?,
+            ),
+            None => None,
+        };
         self.conn.execute(
-            "INSERT OR REPLACE INTO profiles (id, name, description, working_directory, claude_args, env_vars, is_default)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT OR REPLACE INTO profiles (id, name, description, working_directory, claude_args, env_vars, is_default, preview_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 profile.id,
                 profile.name,
@@ -182,6 +205,7 @@ impl Database {
                 claude_args_json,
                 env_vars_json,
                 profile.is_default as i32,
+                preview_json,
             ],
         ).map_err(|e| e.to_string())?;
         Ok(())
@@ -189,7 +213,7 @@ impl Database {
 
     pub fn get_profiles(&self) -> Result<Vec<ConfigProfile>, String> {
         let mut stmt = self.conn
-            .prepare("SELECT id, name, description, working_directory, claude_args, env_vars, is_default FROM profiles")
+            .prepare("SELECT id, name, description, working_directory, claude_args, env_vars, is_default, preview_json FROM profiles")
             .map_err(|e| e.to_string())?;
 
         let profiles = stmt.query_map([], |row| {
@@ -209,6 +233,17 @@ impl Database {
                 eprintln!("[profiles] corrupt env_vars for '{}' ({}): {}", name, id, e);
                 Default::default()
             });
+            // preview_json is nullable; a NULL column and a JSON `null` both
+            // yield `None`. Corrupt JSON falls back to `None` with a log line,
+            // matching the defensive treatment of claude_args / env_vars above.
+            let preview_raw: Option<String> = row.get(7)?;
+            let preview: Option<crate::config::PreviewProfile> = match preview_raw {
+                Some(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+                    eprintln!("[profiles] corrupt preview for '{}' ({}): {}", name, id, e);
+                    None
+                }),
+                None => None,
+            };
             Ok(ConfigProfile {
                 id,
                 name,
@@ -217,7 +252,7 @@ impl Database {
                 claude_args,
                 env_vars,
                 is_default: row.get::<_, i32>(6)? != 0,
-                preview: None,
+                preview,
             })
         }).map_err(|e| e.to_string())?;
 
@@ -483,6 +518,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::PreviewProfile;
     use crate::terminal::{TerminalConfig, TerminalStatus};
     use chrono::{Duration, Utc};
     use std::collections::HashMap;
@@ -536,6 +572,35 @@ mod tests {
         assert_eq!(loaded[0].id, "p1");
         assert_eq!(loaded[0].claude_args, vec!["--model", "opus"]);
         assert_eq!(loaded[0].env_vars.get("FOO"), Some(&"bar".to_string()));
+    }
+
+    #[test]
+    fn profile_round_trips_preview_when_present_and_absent() {
+        let db = Database::new_in_memory().unwrap();
+
+        // With preview -> round-trips exact field values.
+        let mut with_preview = make_profile("p-with", "with");
+        with_preview.preview = Some(PreviewProfile {
+            enabled: true,
+            url_override: Some("http://localhost:3000".to_string()),
+            framework_hint: Some("vite".to_string()),
+        });
+        db.save_profile(&with_preview).unwrap();
+
+        // Without preview -> persists as SQL NULL and reads back as None.
+        let without_preview = make_profile("p-none", "none");
+        db.save_profile(&without_preview).unwrap();
+
+        let loaded = db.get_profiles().unwrap();
+        let with_loaded = loaded.iter().find(|p| p.id == "p-with").unwrap();
+        let without_loaded = loaded.iter().find(|p| p.id == "p-none").unwrap();
+
+        let preview = with_loaded.preview.as_ref().expect("preview persisted");
+        assert_eq!(preview.enabled, true);
+        assert_eq!(preview.url_override.as_deref(), Some("http://localhost:3000"));
+        assert_eq!(preview.framework_hint.as_deref(), Some("vite"));
+
+        assert!(without_loaded.preview.is_none(), "None preview must stay None across a round-trip");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -85,6 +85,27 @@ fn main() {
                 lsp: Arc::new(Mutex::new(lsp_manager)),
             });
 
+            // WebView2 ships a default browser context menu with "Refresh" that
+            // reloads the top-level document — clicking it inside the preview
+            // iframe closes every open terminal. Parent-window JS can't cancel
+            // that click (iframes are separate documents), and WebView2 also
+            // auto-confirms `beforeunload` in Tauri, so the ONLY reliable
+            // block is turning the default context menu off at the shell
+            // level. Applies to every webview created by this process.
+            #[cfg(target_os = "windows")]
+            {
+                for (_, w) in app.webview_windows() {
+                    let _ = w.with_webview(|webview| unsafe {
+                        if let Ok(core) = webview.controller().CoreWebView2() {
+                            if let Ok(settings) = core.Settings() {
+                                let _ = settings
+                                    .SetAreDefaultContextMenusEnabled(false.into());
+                            }
+                        }
+                    });
+                }
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/otel_receiver.rs
+++ b/src-tauri/src/otel_receiver.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 /// One terminal's metrics extracted from a single OTLP/JSON export.
@@ -156,15 +157,33 @@ pub fn parse_otlp_metrics(body: &str) -> Vec<SessionMetricUpdate> {
 /// export (e.g. cost-only) leaves previously-accumulated token totals intact.
 pub struct MetricsAggregator {
     by_terminal: HashMap<String, SessionMetricUpdate>,
+    // Recently-closed terminal ids. Claude's OTLP exporter flushes on shutdown
+    // (~3s cadence), so a final export can arrive AFTER forget() and would
+    // otherwise re-insert a dead terminal via apply()'s or_insert - growing the
+    // map for the app's lifetime. We drop exports for tombstoned ids. Bounded
+    // ring so the tombstone set can't grow without bound either.
+    closed: std::collections::VecDeque<String>,
+    closed_set: std::collections::HashSet<String>,
 }
+
+const MAX_CLOSED_TOMBSTONES: usize = 512;
 
 impl MetricsAggregator {
     pub fn new() -> Self {
-        Self { by_terminal: HashMap::new() }
+        Self {
+            by_terminal: HashMap::new(),
+            closed: std::collections::VecDeque::new(),
+            closed_set: std::collections::HashSet::new(),
+        }
     }
 
     /// Add a delta export into the running total and return the full snapshot.
-    pub fn apply(&mut self, u: SessionMetricUpdate) -> SessionMetricUpdate {
+    /// Returns `None` for a terminal that has already been closed (a late
+    /// export), so the caller neither stores nor emits it.
+    pub fn apply(&mut self, u: SessionMetricUpdate) -> Option<SessionMetricUpdate> {
+        if self.closed_set.contains(&u.terminal_id) {
+            return None;
+        }
         let entry = self
             .by_terminal
             .entry(u.terminal_id.clone())
@@ -186,12 +205,21 @@ impl MetricsAggregator {
         add_u(&mut entry.tokens_cache_creation, u.tokens_cache_creation);
         add_u(&mut entry.lines_added, u.lines_added);
         add_u(&mut entry.lines_removed, u.lines_removed);
-        entry.clone()
+        Some(entry.clone())
     }
 
-    /// Drop a terminal's accumulated metrics (called when a terminal closes).
+    /// Drop a terminal's accumulated metrics (called when a terminal closes) and
+    /// tombstone its id so a late export can't resurrect it.
     pub fn forget(&mut self, terminal_id: &str) {
         self.by_terminal.remove(terminal_id);
+        if self.closed_set.insert(terminal_id.to_string()) {
+            self.closed.push_back(terminal_id.to_string());
+            if self.closed.len() > MAX_CLOSED_TOMBSTONES {
+                if let Some(old) = self.closed.pop_front() {
+                    self.closed_set.remove(&old);
+                }
+            }
+        }
     }
 }
 
@@ -211,15 +239,31 @@ pub fn start(app: tauri::AppHandle) -> std::io::Result<(u16, Arc<Mutex<MetricsAg
         // claude CLI posting small OTLP payloads (a few KB); the bound stops a
         // misbehaving local process from OOMing us with a giant body.
         const MAX_OTLP_BODY_BYTES: usize = 4 * 1024 * 1024;
+        // Parse the constant response header once, not per request (the old
+        // per-request `.unwrap()` was a panic point in a long-lived thread).
+        let json_header: tiny_http::Header = "Content-Type: application/json"
+            .parse()
+            .expect("static header literal is always valid");
         for mut request in server.incoming_requests() {
             // Reject oversized payloads up front via Content-Length.
             if request.body_length().is_some_and(|n| n > MAX_OTLP_BODY_BYTES) {
                 let _ = request.respond(tiny_http::Response::empty(413));
                 continue;
             }
-            // Only metrics POSTs carry a body we care about.
+            // Only metrics POSTs carry a body we care about. Cap the read itself
+            // (not just Content-Length) so a chunked / length-less request can't
+            // stream an unbounded body and OOM us. Read one byte past the limit
+            // to detect overflow.
             let mut body = String::new();
-            let _ = request.as_reader().read_to_string(&mut body);
+            {
+                let mut limited =
+                    request.as_reader().take(MAX_OTLP_BODY_BYTES as u64 + 1);
+                let _ = limited.read_to_string(&mut body);
+            }
+            if body.len() > MAX_OTLP_BODY_BYTES {
+                let _ = request.respond(tiny_http::Response::empty(413));
+                continue;
+            }
 
             let updates = parse_otlp_metrics(&body);
             {
@@ -228,19 +272,19 @@ pub fn start(app: tauri::AppHandle) -> std::io::Result<(u16, Arc<Mutex<MetricsAg
                     Err(p) => p.into_inner(), // poisoned: recover, telemetry is non-critical
                 };
                 for u in updates {
-                    let merged = guard.apply(u);
-                    use tauri::Emitter;
-                    if let Err(e) = app.emit("terminal-metrics", &merged) {
-                        eprintln!("Failed to emit terminal-metrics: {}", e);
+                    // None => export for an already-closed terminal; skip it.
+                    if let Some(merged) = guard.apply(u) {
+                        use tauri::Emitter;
+                        if let Err(e) = app.emit("terminal-metrics", &merged) {
+                            eprintln!("Failed to emit terminal-metrics: {}", e);
+                        }
                     }
                 }
             }
             // OTLP expects 200 with an (empty) JSON body.
             let response = tiny_http::Response::from_string("{}")
                 .with_status_code(200)
-                .with_header(
-                    "Content-Type: application/json".parse::<tiny_http::Header>().unwrap(),
-                );
+                .with_header(json_header.clone());
             let _ = request.respond(response);
         }
         eprintln!("[otel_receiver] accept loop exited - telemetry collection stopped");
@@ -289,7 +333,7 @@ mod tests {
             tokens_input: Some(100),
             ..Default::default()
         };
-        let merged1 = agg.apply(first);
+        let merged1 = agg.apply(first).expect("live terminal");
         assert_eq!(merged1.cost_usd, Some(0.01));
         assert_eq!(merged1.tokens_input, Some(100));
 
@@ -301,11 +345,24 @@ mod tests {
             tokens_output: Some(40),
             ..Default::default()
         };
-        let merged2 = agg.apply(second);
+        let merged2 = agg.apply(second).expect("live terminal");
         // Use epsilon comparison because 0.01 + 0.05 = 0.060000000000000005 in IEEE 754.
         assert!((merged2.cost_usd.unwrap() - 0.06).abs() < 1e-10, "expected ~0.06, got {:?}", merged2.cost_usd); // 0.01 + 0.05
         assert_eq!(merged2.tokens_input, Some(100)); // unchanged (no delta)
         assert_eq!(merged2.tokens_output, Some(40));
+    }
+
+    #[test]
+    fn aggregator_drops_exports_for_closed_terminals() {
+        let mut agg = MetricsAggregator::new();
+        assert!(agg
+            .apply(SessionMetricUpdate { terminal_id: "A".into(), cost_usd: Some(0.01), ..Default::default() })
+            .is_some());
+        agg.forget("A");
+        // A late export after close must not resurrect the terminal.
+        assert!(agg
+            .apply(SessionMetricUpdate { terminal_id: "A".into(), cost_usd: Some(0.02), ..Default::default() })
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,4 +1,4 @@
-use portable_pty::{native_pty_system, CommandBuilder, PtyPair, PtySize};
+use portable_pty::{native_pty_system, Child, CommandBuilder, PtyPair, PtySize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{BufWriter, Read, Write};
@@ -41,6 +41,11 @@ pub struct Terminal {
     /// Kept alive to maintain the PTY connection
     pub pty_pair: PtyPair,
     pub writer: Box<dyn Write + Send>,
+    /// The spawned child process. Kept so `close()` can `kill()` it: on Windows
+    /// a ConPTY read can block indefinitely after the writer/PTY is dropped, so
+    /// relying on EOF alone leaks the reader thread and orphans the process.
+    /// Killing the child forces EOF and lets the reader thread exit.
+    pub child: Box<dyn Child + Send + Sync>,
     /// Handle to the reader thread for cleanup on close
     pub reader_handle: Option<JoinHandle<()>>,
     /// When this terminal last received user input (any `write()`). The
@@ -236,7 +241,7 @@ impl TerminalManager {
         }
 
         // Spawn the command
-        let _child = pty_pair.slave.spawn_command(cmd)
+        let child = pty_pair.slave.spawn_command(cmd)
             .map_err(|e| format!("Failed to spawn command: {}", e))?;
 
         let config = TerminalConfig {
@@ -326,6 +331,7 @@ impl TerminalManager {
                 config: config.clone(),
                 pty_pair,
                 writer,
+                child,
                 reader_handle: Some(reader_handle),
                 last_input_at: None,
             },
@@ -397,7 +403,7 @@ impl TerminalManager {
             cmd.cwd(&working_directory);
         }
 
-        let _child = pty_pair.slave.spawn_command(cmd)
+        let child = pty_pair.slave.spawn_command(cmd)
             .map_err(|e| format!("Failed to spawn npm run {}: {}", script_name, e))?;
 
         let id = Uuid::new_v4().to_string();
@@ -449,6 +455,7 @@ impl TerminalManager {
                 config: config.clone(),
                 pty_pair,
                 writer,
+                child,
                 reader_handle: Some(reader_handle),
                 last_input_at: None,
             },
@@ -507,7 +514,7 @@ impl TerminalManager {
             cmd.cwd(&working_directory);
         }
 
-        let _child = pty_pair.slave.spawn_command(cmd)
+        let child = pty_pair.slave.spawn_command(cmd)
             .map_err(|e| format!("Failed to spawn shell: {}", e))?;
 
         let id = Uuid::new_v4().to_string();
@@ -559,6 +566,7 @@ impl TerminalManager {
                 config: config.clone(),
                 pty_pair,
                 writer,
+                child,
                 reader_handle: Some(reader_handle),
                 last_input_at: None,
             },
@@ -606,19 +614,26 @@ impl TerminalManager {
     }
 
     pub fn close(&mut self, id: &str) -> Result<(), String> {
-        if let Some(terminal) = self.terminals.remove(id) {
-            // Dropping the terminal drops the writer and PTY pair, which signals EOF
-            // to the reader thread. The reader thread will exit on its next read attempt
-            // and clean up asynchronously. We do NOT join the reader thread here because
-            // on Windows, PTY reads can block indefinitely even after the writer is dropped,
-            // which would deadlock the mutex and freeze the entire application.
+        if let Some(mut terminal) = self.terminals.remove(id) {
+            // Kill the child process first. On Windows a ConPTY read can block
+            // indefinitely even after the writer/PTY is dropped, so EOF alone
+            // is not guaranteed - the reader thread (and the process itself)
+            // would leak. Killing the child forces the read to unblock so the
+            // thread exits. `kill()` is non-blocking (TerminateProcess / SIGKILL),
+            // so it can't deadlock the mutex; we still don't join the reader.
+            let _ = terminal.child.kill();
+            // Dropping the terminal then drops the writer and PTY pair.
             drop(terminal);
         }
         Ok(())
     }
 
     pub fn close_all(&mut self) {
-        // Clear all terminals at once - reader threads clean up asynchronously
+        // Kill every child so their reader threads unblock and no processes are
+        // orphaned, then clear. Reader threads still clean up asynchronously.
+        for terminal in self.terminals.values_mut() {
+            let _ = terminal.child.kill();
+        }
         self.terminals.clear();
     }
 

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -36,6 +36,21 @@ pub enum TerminalStatus {
     Stopped,
 }
 
+/// True when a PTY read error is just the normal teardown of a closing terminal
+/// rather than a genuine mid-session failure. On Windows, killing the child (see
+/// `close`) or the user exiting tears the pipe down and surfaces as a broken-pipe
+/// / invalid-handle error on the reader's next read instead of a clean EOF. We
+/// treat those as EOF: break quietly, without an error banner or telemetry.
+fn is_benign_close_error(e: &std::io::Error) -> bool {
+    use std::io::ErrorKind;
+    if matches!(e.kind(), ErrorKind::BrokenPipe | ErrorKind::UnexpectedEof) {
+        return true;
+    }
+    // Windows: ERROR_INVALID_HANDLE (6), ERROR_BROKEN_PIPE (109),
+    // ERROR_NO_DATA / "pipe is being closed" (232).
+    matches!(e.raw_os_error(), Some(6) | Some(109) | Some(232))
+}
+
 pub struct Terminal {
     pub config: TerminalConfig,
     /// Kept alive to maintain the PTY connection
@@ -298,6 +313,12 @@ impl TerminalManager {
                         }
                     }
                     Err(e) => {
+                        // Normal close/teardown (esp. Windows ConPTY after the
+                        // child is killed) surfaces as a read error rather than
+                        // EOF - exit quietly, no banner, no telemetry.
+                        if is_benign_close_error(&e) {
+                            break;
+                        }
                         eprintln!("Error reading from pty: {}", e);
                         // Capture so we hear about broken-mid-session terminals.
                         // RustCommand (not RustPanic) because the PTY is a
@@ -439,6 +460,11 @@ impl TerminalManager {
                         if tx.blocking_send((terminal_id.clone(), data)).is_err() { break; }
                     }
                     Err(e) => {
+                        // Quiet exit on normal close teardown (see the claude
+                        // reader above); only surface genuine mid-session errors.
+                        if is_benign_close_error(&e) {
+                            break;
+                        }
                         let _ = tx.blocking_send((
                             terminal_id.clone(),
                             format!("\r\n[Error: {}]\r\n", e).into_bytes(),
@@ -550,6 +576,11 @@ impl TerminalManager {
                         if tx.blocking_send((terminal_id.clone(), data)).is_err() { break; }
                     }
                     Err(e) => {
+                        // Quiet exit on normal close teardown (see the claude
+                        // reader above); only surface genuine mid-session errors.
+                        if is_benign_close_error(&e) {
+                            break;
+                        }
                         let _ = tx.blocking_send((
                             terminal_id.clone(),
                             format!("\r\n[Error: {}]\r\n", e).into_bytes(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { WhatsNewModal } from './components/WhatsNewModal';
 import { ClaudeConfigModal } from './components/ClaudeConfigModal';
 import { OrchestrationPanel } from './components/OrchestrationPanel';
 import { PreviewPanel } from './components/PreviewPanel';
+import { PreviewInlineHint } from './components/PreviewInlineHint';
 import { GlobalSearchModal } from './components/GlobalSearchModal';
 import { SessionTimeline } from './components/SessionTimeline';
 import { MemoryEditor } from './components/MemoryEditor';
@@ -838,6 +839,7 @@ function App() {
         </div>
       )}
 
+      <PreviewInlineHint />
       <ToastContainer />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -433,13 +433,18 @@ function App() {
       }
 
       // Passive dev-server URL detection for the preview panel.
+      // Script-runner children (`npm run dev`, etc.) emit output under their
+      // own terminal id but the user is looking at the parent tab, so route
+      // the URL to the parent when this terminal is a script child.
       try {
         const text = new TextDecoder().decode(new Uint8Array(data));
         const found = detectUrl(text);
         if (found) {
-          const cur = usePreviewStore.getState().perTerminal.get(id);
+          const term = useTerminalStore.getState().terminals.get(id);
+          const targetId = term?.scriptParentId ?? id;
+          const cur = usePreviewStore.getState().perTerminal.get(targetId);
           if (cur?.detectedUrl !== found) {
-            usePreviewStore.getState().setDetectedUrl(id, found);
+            usePreviewStore.getState().setDetectedUrl(targetId, found);
           }
         }
       } catch { /* ignore decode errors */ }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import { usePreviewStore } from './store/previewStore';
 import { toast } from './store/toastStore';
 import { detectUrl } from './lib/preview/detector';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { usePreventWebviewReload } from './hooks/usePreventWebviewReload';
 import { useNotification } from './hooks/useNotification';
 import { useSessionStateDetection } from './hooks/useSessionStateDetection';
 import {
@@ -140,6 +141,7 @@ function App() {
   const hasAdoptedRef = useRef(false);
 
   useKeyboardShortcuts();
+  usePreventWebviewReload();
   useSessionStateDetection();
 
   // v1.22.0 - apply theme/density/accent/motion/scale on store change.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { AutoUpdater } from './components/AutoUpdater';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { ClaudeConfigModal } from './components/ClaudeConfigModal';
 import { OrchestrationPanel } from './components/OrchestrationPanel';
+import { PreviewPanel } from './components/PreviewPanel';
 import { GlobalSearchModal } from './components/GlobalSearchModal';
 import { SessionTimeline } from './components/SessionTimeline';
 import { MemoryEditor } from './components/MemoryEditor';
@@ -40,7 +41,9 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { TerminalConfig } from './store/terminalStore';
 import { useAppStore } from './store/appStore';
 import { useTerminalStore } from './store/terminalStore';
+import { usePreviewStore } from './store/previewStore';
 import { toast } from './store/toastStore';
+import { detectUrl } from './lib/preview/detector';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useNotification } from './hooks/useNotification';
 import { useSessionStateDetection } from './hooks/useSessionStateDetection';
@@ -427,6 +430,18 @@ function App() {
       } catch {
         // Ignore decode errors
       }
+
+      // Passive dev-server URL detection for the preview panel.
+      try {
+        const text = new TextDecoder().decode(new Uint8Array(data));
+        const found = detectUrl(text);
+        if (found) {
+          const cur = usePreviewStore.getState().perTerminal.get(id);
+          if (cur?.detectedUrl !== found) {
+            usePreviewStore.getState().setDetectedUrl(id, found);
+          }
+        }
+      } catch { /* ignore decode errors */ }
     });
 
     return () => {
@@ -757,6 +772,8 @@ function App() {
                 </div>
               )}
             </AnimatePresence>
+
+            <PreviewPanel />
 
             <ToolStripe side="right" />
           </div>

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "1.28.0",
+    "date": "2026-07-23",
+    "features": [
+      { "title": "Live preview panel for GUI projects", "description": "A new right-docked Preview panel renders your dev server side-by-side with the terminal. Detects the URL automatically from Vite, Next.js, Astro, Nuxt, SvelteKit, Remix, Angular, CRA, and Expo dev-server output. Toggle it from the right toolbar or Ctrl+Alt+P. Includes URL bar, reload, and open-in-browser." },
+      { "title": "Profiles that have a GUI", "description": "Profiles gained a 'Has GUI preview' checkbox with optional URL override — terminals launched from a GUI profile open the preview panel automatically. Ad-hoc terminals get a subtle inline hint when a dev-server URL is detected." },
+      { "title": "Preview allow-list", "description": "Localhost is always allowed. To preview through a tunnel, add hostname globs (e.g. *.ngrok.io) in Settings → Preview. Anything outside the allow-list is blocked with a clear inline explanation." }
+    ]
+  },
+  {
     "version": "1.27.1",
     "date": "2026-07-09",
     "features": [

--- a/src/components/ClaudeConfigModal.tsx
+++ b/src/components/ClaudeConfigModal.tsx
@@ -69,6 +69,11 @@ function SettingsTab() {
   const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  // Set when the settings file can't be READ (permission/IO/too-large). While
+  // set, we render an error panel instead of the editor so a Save can never
+  // overwrite a real-but-unreadable settings.json with empty content. A missing
+  // file is NOT an error - the backend returns "{}" for it via the success path.
+  const [loadError, setLoadError] = useState('');
 
   useEffect(() => {
     loadSettings();
@@ -76,15 +81,23 @@ function SettingsTab() {
 
   const loadSettings = async () => {
     setLoading(true);
+    setLoadError('');
     try {
       const raw = await invoke<string>('read_claude_settings');
-      // Pretty-print the JSON
-      const formatted = JSON.stringify(JSON.parse(raw), null, 2);
+      let formatted: string;
+      try {
+        // Pretty-print when it parses.
+        formatted = JSON.stringify(JSON.parse(raw), null, 2);
+      } catch {
+        // File exists but isn't valid JSON (hand-edited typo, etc.). Show the
+        // raw content verbatim so the user can fix it - never replace it with
+        // "{}". Save re-validates the JSON before writing.
+        formatted = raw;
+      }
       setContent(formatted);
       setOriginalContent(formatted);
     } catch (err) {
-      setContent('{}');
-      setOriginalContent('{}');
+      setLoadError(String(err));
     }
     setLoading(false);
   };
@@ -118,6 +131,25 @@ function SettingsTab() {
     return (
       <div className="h-full flex items-center justify-center text-text-tertiary text-[13px]">
         Loading settings...
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-3 px-8 text-center">
+        <AlertCircle size={28} className="text-error" />
+        <p className="text-text-primary text-[13px] font-medium">
+          Couldn't read ~/.claude/settings.json
+        </p>
+        <p className="text-text-tertiary text-[12px] max-w-md break-words">{loadError}</p>
+        <p className="text-text-tertiary text-[11px] max-w-md">
+          Editing is disabled so your existing settings aren't overwritten. Fix the
+          file permissions and try again.
+        </p>
+        <Button variant="secondary" size="sm" onClick={loadSettings} className="mt-1">
+          Retry
+        </Button>
       </div>
     );
   }

--- a/src/components/NewTerminalModal.tsx
+++ b/src/components/NewTerminalModal.tsx
@@ -157,7 +157,10 @@ export function NewTerminalModal() {
       const parentDir = repoPath.replace(/[\\/][^\\/]*$/, '');
       const repoName = repoPath.replace(/^.*[\\/]/, '');
       const sanitized = newBranchName.replace(/\//g, '-');
-      setNewWorktreePath(`${parentDir}\\${repoName}-${sanitized}`);
+      // Match the repo path's separator so the prefilled path is valid on
+      // macOS/Linux too (hardcoding '\\' produced broken paths there).
+      const sep = repoPath.includes('\\') ? '\\' : '/';
+      setNewWorktreePath(`${parentDir}${sep}${repoName}-${sanitized}`);
     }
   }, [newBranchName, worktreeDetect, workingDirectory]);
 

--- a/src/components/NewTerminalModal.tsx
+++ b/src/components/NewTerminalModal.tsx
@@ -12,6 +12,12 @@ import { Modal } from './ui/Modal';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
+interface PreviewProfile {
+  enabled: boolean;
+  url_override?: string | null;
+  framework_hint?: string | null;
+}
+
 interface ConfigProfile {
   id: string;
   name: string;
@@ -20,6 +26,7 @@ interface ConfigProfile {
   claude_args: string[];
   env_vars: Record<string, string>;
   is_default: boolean;
+  preview?: PreviewProfile | null;
 }
 
 const TAG_COLORS = [
@@ -278,6 +285,15 @@ export function NewTerminalModal() {
           finalArgs.unshift('--worktree');
         }
 
+        const previewInit = selectedProfile?.preview?.enabled
+          ? {
+              isOpen: true,
+              userOverride: selectedProfile.preview.url_override ?? null,
+              frameworkHint: (selectedProfile.preview.framework_hint ?? 'unknown') as
+                import('../lib/preview/framework').FrameworkHint,
+            }
+          : undefined;
+
         newTerminalId = await createTerminal(
           label,
           workingDirectory,
@@ -285,6 +301,10 @@ export function NewTerminalModal() {
           envVars,
           colorTag,
           nickname || undefined,
+          undefined,
+          undefined,
+          undefined,
+          previewInit,
         );
       }
 

--- a/src/components/PreviewInlineHint.tsx
+++ b/src/components/PreviewInlineHint.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useTerminalStore } from '../store/terminalStore';
+import { usePreviewStore } from '../store/previewStore';
+
+const AUTO_DISMISS_MS = 6000;
+
+export function PreviewInlineHint() {
+  const activeId = useTerminalStore((s) => s.activeTerminalId);
+  const globalOpen = usePreviewStore((s) => s.globalOpen);
+  const perTerminal = usePreviewStore((s) => s.perTerminal);
+  const dismissInlineHint = usePreviewStore((s) => s.dismissInlineHint);
+  const toggleGlobal = usePreviewStore((s) => s.toggleGlobal);
+
+  const state = activeId ? perTerminal.get(activeId) : undefined;
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!state || globalOpen) { setVisible(false); return; }
+    if (state.inlineHintDismissed) { setVisible(false); return; }
+    if (!state.detectedUrl) { setVisible(false); return; }
+    setVisible(true);
+    const t = setTimeout(() => { if (activeId) dismissInlineHint(activeId); }, AUTO_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [state?.detectedUrl, state?.inlineHintDismissed, globalOpen, activeId, dismissInlineHint, state]);
+
+  const url = state?.detectedUrl;
+  return (
+    <AnimatePresence>
+      {visible && activeId && url && (
+        <motion.div
+          initial={{ y: 24, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 24, opacity: 0 }}
+          className="fixed bottom-8 right-6 z-50 bg-elevation-3 ring-1 ring-white/[0.08] rounded-md shadow-lg px-3 py-2 flex items-center gap-2"
+        >
+          <span className="text-text-secondary text-[12px]">
+            Detected <code className="text-text-primary">{url}</code>
+          </span>
+          <button
+            onClick={() => { toggleGlobal(); dismissInlineHint(activeId); }}
+            className="text-[12px] font-medium text-accent-primary hover:text-accent-secondary"
+          >
+            Open preview
+          </button>
+          <button
+            onClick={() => dismissInlineHint(activeId)}
+            className="text-[12px] text-text-tertiary hover:text-text-secondary"
+          >
+            Dismiss
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -11,6 +11,7 @@ export function PreviewPanel() {
   const allowList = usePreviewStore((s) => s.allowList);
   const perTerminal = usePreviewStore((s) => s.perTerminal);
   const resolveUrl = usePreviewStore((s) => s.resolveUrl);
+  const keepAliveAcrossTabs = usePreviewStore((s) => s.keepAliveAcrossTabs);
 
   const url = activeId ? resolveUrl(activeId) : null;
   const state = activeId ? perTerminal.get(activeId) : undefined;
@@ -20,6 +21,23 @@ export function PreviewPanel() {
     () => (url ? isUrlAllowed(url, allowList) : false),
     [url, allowList],
   );
+
+  // When keep-alive is on, render an iframe per terminal with a resolved URL;
+  // only the active tab's iframe is visible, the rest are hidden but stay
+  // mounted so their preview state (scroll, form fields, etc.) survives a tab
+  // switch. Filter to allowed URLs only — blocked URLs get the same placeholder
+  // as the single-iframe path.
+  const keepAliveEntries = useMemo(() => {
+    if (!keepAliveAcrossTabs) return [] as Array<{ id: string; url: string; reloadCounter: number }>;
+    const out: Array<{ id: string; url: string; reloadCounter: number }> = [];
+    for (const [id, s] of perTerminal) {
+      const u = s.userOverride ?? s.detectedUrl;
+      if (u && isUrlAllowed(u, allowList)) {
+        out.push({ id, url: u, reloadCounter: s.reloadCounter });
+      }
+    }
+    return out;
+  }, [keepAliveAcrossTabs, perTerminal, allowList]);
 
   if (!globalOpen || !activeId) return null;
 
@@ -50,7 +68,7 @@ export function PreviewPanel() {
             </div>
           </div>
         )}
-        {url && allowed && (
+        {url && allowed && !keepAliveAcrossTabs && (
           <iframe
             key={`${url}#${reloadCounter}`}
             src={url}
@@ -58,6 +76,21 @@ export function PreviewPanel() {
             className="absolute inset-0 w-full h-full border-0"
           />
         )}
+        {url && allowed && keepAliveAcrossTabs && keepAliveEntries.map(({ id, url: entryUrl, reloadCounter: rc }) => {
+          const isActive = id === activeId;
+          return (
+            <iframe
+              key={`${id}:${entryUrl}#${rc}`}
+              src={entryUrl}
+              title={`Preview (${id})`}
+              className="absolute inset-0 w-full h-full border-0"
+              style={{
+                visibility: isActive ? 'visible' : 'hidden',
+                pointerEvents: isActive ? 'auto' : 'none',
+              }}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -23,14 +23,30 @@ export function PreviewPanel() {
     [url, allowList],
   );
 
+  // In dev mode the app itself is served from http://localhost:5173, so a
+  // preview pointed there would load ClaudeTerminal recursively into an
+  // iframe — a Reload click looks like the whole app restarted. Refuse to
+  // iframe our own origin. In production `window.location.origin` is
+  // `tauri://localhost` (or similar), which never matches a detected URL.
+  const isSelfPreview = useMemo(() => {
+    if (!url) return false;
+    try {
+      return new URL(url).origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }, [url]);
+
   const keepAliveEntries = useMemo(() => {
     if (!keepAliveAcrossTabs) return [] as Array<{ id: string; url: string; reloadCounter: number }>;
     const out: Array<{ id: string; url: string; reloadCounter: number }> = [];
+    const selfOrigin = window.location.origin;
     for (const [id, s] of perTerminal) {
       const u = s.userOverride ?? s.detectedUrl;
-      if (u && isUrlAllowed(u, allowList)) {
-        out.push({ id, url: u, reloadCounter: s.reloadCounter });
-      }
+      if (!u || !isUrlAllowed(u, allowList)) continue;
+      // Skip self-preview entries so a keep-alive iframe never embeds the app in itself.
+      try { if (new URL(u).origin === selfOrigin) continue; } catch { continue; }
+      out.push({ id, url: u, reloadCounter: s.reloadCounter });
     }
     return out;
   }, [keepAliveAcrossTabs, perTerminal, allowList]);
@@ -102,7 +118,7 @@ export function PreviewPanel() {
               Waiting for a dev-server URL…
             </div>
           )}
-          {url && !allowed && (
+          {url && !allowed && !isSelfPreview && (
             <div className="absolute inset-0 flex items-center justify-center text-center p-6">
               <div className="max-w-sm">
                 <div className="text-text-primary text-[13px] font-semibold mb-1">
@@ -115,7 +131,20 @@ export function PreviewPanel() {
               </div>
             </div>
           )}
-          {url && allowed && !keepAliveAcrossTabs && (
+          {url && isSelfPreview && (
+            <div className="absolute inset-0 flex items-center justify-center text-center p-6">
+              <div className="max-w-sm">
+                <div className="text-text-primary text-[13px] font-semibold mb-1">
+                  Can't preview ClaudeTerminal itself
+                </div>
+                <div className="text-text-tertiary text-[11.5px]">
+                  <code className="text-text-secondary">{url}</code> is ClaudeTerminal's own dev
+                  server. Point the preview at your app's URL (a different port).
+                </div>
+              </div>
+            </div>
+          )}
+          {url && allowed && !isSelfPreview && !keepAliveAcrossTabs && (
             <iframe
               key={`${url}#${reloadCounter}`}
               src={url}
@@ -123,7 +152,7 @@ export function PreviewPanel() {
               className="absolute inset-0 w-full h-full border-0"
             />
           )}
-          {url && allowed && keepAliveAcrossTabs && keepAliveEntries.map(({ id, url: entryUrl, reloadCounter: rc }) => {
+          {url && allowed && !isSelfPreview && keepAliveAcrossTabs && keepAliveEntries.map(({ id, url: entryUrl, reloadCounter: rc }) => {
             const isActive = id === activeId;
             return (
               <iframe

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTerminalStore } from '../store/terminalStore';
 import { usePreviewStore } from '../store/previewStore';
 import { isUrlAllowed } from '../lib/preview/allowlist';
@@ -8,6 +8,7 @@ export function PreviewPanel() {
   const activeId = useTerminalStore((s) => s.activeTerminalId);
   const globalOpen = usePreviewStore((s) => s.globalOpen);
   const panelWidthPx = usePreviewStore((s) => s.panelWidthPx);
+  const setPanelWidth = usePreviewStore((s) => s.setPanelWidth);
   const allowList = usePreviewStore((s) => s.allowList);
   const perTerminal = usePreviewStore((s) => s.perTerminal);
   const resolveUrl = usePreviewStore((s) => s.resolveUrl);
@@ -22,11 +23,6 @@ export function PreviewPanel() {
     [url, allowList],
   );
 
-  // When keep-alive is on, render an iframe per terminal with a resolved URL;
-  // only the active tab's iframe is visible, the rest are hidden but stay
-  // mounted so their preview state (scroll, form fields, etc.) survives a tab
-  // switch. Filter to allowed URLs only — blocked URLs get the same placeholder
-  // as the single-iframe path.
   const keepAliveEntries = useMemo(() => {
     if (!keepAliveAcrossTabs) return [] as Array<{ id: string; url: string; reloadCounter: number }>;
     const out: Array<{ id: string; url: string; reloadCounter: number }> = [];
@@ -39,58 +35,120 @@ export function PreviewPanel() {
     return out;
   }, [keepAliveAcrossTabs, perTerminal, allowList]);
 
+  // Drag-to-resize: the panel sits on the RIGHT of the window, so the resize
+  // handle lives on its LEFT edge. Dragging left widens the panel, dragging
+  // right shrinks it. Deltas are computed from the pointer's initial x, so a
+  // fast drag can't drift out of sync with the stored width.
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStartRef = useRef<{ x: number; width: number } | null>(null);
+
+  const onHandleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragStartRef.current = { x: e.clientX, width: panelWidthPx };
+    setIsResizing(true);
+  }, [panelWidthPx]);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMove = (e: MouseEvent) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+      // Left-edge handle on a right-docked panel: negative Δx = wider panel.
+      setPanelWidth(start.width + (start.x - e.clientX));
+    };
+    const onUp = () => {
+      dragStartRef.current = null;
+      setIsResizing(false);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [isResizing, setPanelWidth]);
+
   if (!globalOpen || !activeId) return null;
 
   return (
     <div
-      className="h-full flex flex-col bg-bg-secondary border-l border-white/[0.06] overflow-hidden"
+      className="h-full flex bg-bg-secondary border-l border-white/[0.06] overflow-hidden relative"
       style={{ width: panelWidthPx }}
       data-testid="preview-panel"
     >
-      <PreviewToolbar terminalId={activeId} url={url} allowed={allowed} />
+      {/* Resize handle — 4px wide invisible strip on the left edge, with a
+          hover state that reveals a hairline in the accent colour. */}
+      <div
+        onMouseDown={onHandleMouseDown}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize preview panel"
+        title="Drag to resize"
+        className={`absolute left-0 top-0 bottom-0 w-1 z-10 cursor-col-resize
+          hover:bg-accent-primary/50 active:bg-accent-primary
+          ${isResizing ? 'bg-accent-primary' : 'bg-transparent'}
+          transition-colors`}
+        data-testid="preview-resize-handle"
+      />
 
-      <div className="flex-1 relative bg-black">
-        {!url && (
-          <div className="absolute inset-0 flex items-center justify-center text-text-tertiary text-[12px]">
-            Waiting for a dev-server URL…
-          </div>
-        )}
-        {url && !allowed && (
-          <div className="absolute inset-0 flex items-center justify-center text-center p-6">
-            <div className="max-w-sm">
-              <div className="text-text-primary text-[13px] font-semibold mb-1">
-                URL not allowed
-              </div>
-              <div className="text-text-tertiary text-[11.5px]">
-                <code className="text-text-secondary">{url}</code> is outside the preview allow-list.
-                Add it in Settings → Preview.
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <PreviewToolbar terminalId={activeId} url={url} allowed={allowed} />
+
+        <div className="flex-1 relative bg-black">
+          {!url && (
+            <div className="absolute inset-0 flex items-center justify-center text-text-tertiary text-[12px]">
+              Waiting for a dev-server URL…
+            </div>
+          )}
+          {url && !allowed && (
+            <div className="absolute inset-0 flex items-center justify-center text-center p-6">
+              <div className="max-w-sm">
+                <div className="text-text-primary text-[13px] font-semibold mb-1">
+                  URL not allowed
+                </div>
+                <div className="text-text-tertiary text-[11.5px]">
+                  <code className="text-text-secondary">{url}</code> is outside the preview allow-list.
+                  Add it in Settings → Preview.
+                </div>
               </div>
             </div>
-          </div>
-        )}
-        {url && allowed && !keepAliveAcrossTabs && (
-          <iframe
-            key={`${url}#${reloadCounter}`}
-            src={url}
-            title="Preview"
-            className="absolute inset-0 w-full h-full border-0"
-          />
-        )}
-        {url && allowed && keepAliveAcrossTabs && keepAliveEntries.map(({ id, url: entryUrl, reloadCounter: rc }) => {
-          const isActive = id === activeId;
-          return (
+          )}
+          {url && allowed && !keepAliveAcrossTabs && (
             <iframe
-              key={`${id}:${entryUrl}#${rc}`}
-              src={entryUrl}
-              title={`Preview (${id})`}
+              key={`${url}#${reloadCounter}`}
+              src={url}
+              title="Preview"
               className="absolute inset-0 w-full h-full border-0"
-              style={{
-                visibility: isActive ? 'visible' : 'hidden',
-                pointerEvents: isActive ? 'auto' : 'none',
-              }}
             />
-          );
-        })}
+          )}
+          {url && allowed && keepAliveAcrossTabs && keepAliveEntries.map(({ id, url: entryUrl, reloadCounter: rc }) => {
+            const isActive = id === activeId;
+            return (
+              <iframe
+                key={`${id}:${entryUrl}#${rc}`}
+                src={entryUrl}
+                title={`Preview (${id})`}
+                className="absolute inset-0 w-full h-full border-0"
+                style={{
+                  visibility: isActive ? 'visible' : 'hidden',
+                  pointerEvents: isActive ? 'auto' : 'none',
+                }}
+              />
+            );
+          })}
+
+          {/* While dragging, an invisible overlay swallows pointer events so
+              the mouse doesn't get "captured" by the iframe below (iframes
+              are separate documents and would interrupt the mousemove). */}
+          {isResizing && (
+            <div
+              className="absolute inset-0 z-20 cursor-col-resize"
+              data-testid="preview-drag-shield"
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { useTerminalStore } from '../store/terminalStore';
+import { usePreviewStore } from '../store/previewStore';
+import { isUrlAllowed } from '../lib/preview/allowlist';
+
+export function PreviewPanel() {
+  const activeId = useTerminalStore((s) => s.activeTerminalId);
+  const globalOpen = usePreviewStore((s) => s.globalOpen);
+  const panelWidthPx = usePreviewStore((s) => s.panelWidthPx);
+  const allowList = usePreviewStore((s) => s.allowList);
+  const perTerminal = usePreviewStore((s) => s.perTerminal);
+  const resolveUrl = usePreviewStore((s) => s.resolveUrl);
+
+  const url = activeId ? resolveUrl(activeId) : null;
+  const state = activeId ? perTerminal.get(activeId) : undefined;
+  const reloadCounter = state?.reloadCounter ?? 0;
+
+  const allowed = useMemo(
+    () => (url ? isUrlAllowed(url, allowList) : false),
+    [url, allowList],
+  );
+
+  if (!globalOpen || !activeId) return null;
+
+  return (
+    <div
+      className="h-full flex flex-col bg-bg-secondary border-l border-white/[0.06] overflow-hidden"
+      style={{ width: panelWidthPx }}
+      data-testid="preview-panel"
+    >
+      <div className="px-3 py-2 border-b border-white/[0.06] flex items-center justify-between shrink-0">
+        <div className="text-text-primary text-[12px] font-medium">Preview</div>
+        <div className="text-text-tertiary text-[11px] truncate max-w-[65%]">
+          {url ?? 'no url'}
+        </div>
+      </div>
+
+      <div className="flex-1 relative bg-black">
+        {!url && (
+          <div className="absolute inset-0 flex items-center justify-center text-text-tertiary text-[12px]">
+            Waiting for a dev-server URL…
+          </div>
+        )}
+        {url && !allowed && (
+          <div className="absolute inset-0 flex items-center justify-center text-center p-6">
+            <div className="max-w-sm">
+              <div className="text-text-primary text-[13px] font-semibold mb-1">
+                URL not allowed
+              </div>
+              <div className="text-text-tertiary text-[11.5px]">
+                <code className="text-text-secondary">{url}</code> is outside the preview allow-list.
+                Add it in Settings → Preview.
+              </div>
+            </div>
+          </div>
+        )}
+        {url && allowed && (
+          <iframe
+            key={`${url}#${reloadCounter}`}
+            src={url}
+            title="Preview"
+            className="absolute inset-0 w-full h-full border-0"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useTerminalStore } from '../store/terminalStore';
 import { usePreviewStore } from '../store/previewStore';
 import { isUrlAllowed } from '../lib/preview/allowlist';
+import { PreviewToolbar } from './PreviewToolbar';
 
 export function PreviewPanel() {
   const activeId = useTerminalStore((s) => s.activeTerminalId);
@@ -28,12 +29,7 @@ export function PreviewPanel() {
       style={{ width: panelWidthPx }}
       data-testid="preview-panel"
     >
-      <div className="px-3 py-2 border-b border-white/[0.06] flex items-center justify-between shrink-0">
-        <div className="text-text-primary text-[12px] font-medium">Preview</div>
-        <div className="text-text-tertiary text-[11px] truncate max-w-[65%]">
-          {url ?? 'no url'}
-        </div>
-      </div>
+      <PreviewToolbar terminalId={activeId} url={url} allowed={allowed} />
 
       <div className="flex-1 relative bg-black">
         {!url && (

--- a/src/components/PreviewToolbar.tsx
+++ b/src/components/PreviewToolbar.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { RotateCw, ExternalLink, X } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { usePreviewStore } from '../store/previewStore';
+import { isUrlAllowed } from '../lib/preview/allowlist';
+
+interface Props { terminalId: string; url: string | null; allowed: boolean }
+
+export function PreviewToolbar({ terminalId, url, allowed }: Props) {
+  const allowList = usePreviewStore((s) => s.allowList);
+  const setUserOverride = usePreviewStore((s) => s.setUserOverride);
+  const reload = usePreviewStore((s) => s.reload);
+  const toggleGlobal = usePreviewStore((s) => s.toggleGlobal);
+
+  const [draft, setDraft] = useState(url ?? '');
+  const [invalid, setInvalid] = useState(false);
+
+  useEffect(() => { setDraft(url ?? ''); setInvalid(false); }, [url]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    if (!isUrlAllowed(trimmed, allowList)) { setInvalid(true); return; }
+    setUserOverride(terminalId, trimmed);
+  };
+
+  const openExternal = () => { if (url && allowed) void invoke('open_external_url', { url }); };
+
+  return (
+    <div className="px-2 py-1.5 border-b border-white/[0.06] flex items-center gap-1.5 shrink-0">
+      <button
+        onClick={() => reload(terminalId)}
+        disabled={!url}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
+        title="Reload"
+      >
+        <RotateCw size={14} />
+      </button>
+      <input
+        value={draft}
+        onChange={(e) => { setDraft(e.target.value); setInvalid(false); }}
+        onKeyDown={(e) => { if (e.key === 'Enter') commit(); }}
+        onBlur={commit}
+        spellCheck={false}
+        placeholder="http://localhost:5173"
+        className={`flex-1 bg-elevation-2 border rounded px-2 py-1 text-[11.5px] text-text-primary outline-none ${
+          invalid ? 'border-red-500/60' : 'border-white/[0.06] focus:border-accent-primary/60'
+        }`}
+      />
+      <button
+        onClick={openExternal}
+        disabled={!url || !allowed}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
+        title="Open in browser"
+      >
+        <ExternalLink size={14} />
+      </button>
+      <button
+        onClick={toggleGlobal}
+        className="p-1 rounded hover:bg-white/[0.05] text-text-secondary"
+        title="Close preview"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/PreviewToolbar.tsx
+++ b/src/components/PreviewToolbar.tsx
@@ -29,6 +29,7 @@ export function PreviewToolbar({ terminalId, url, allowed }: Props) {
   return (
     <div className="px-2 py-1.5 border-b border-white/[0.06] flex items-center gap-1.5 shrink-0">
       <button
+        type="button"
         onClick={() => reload(terminalId)}
         disabled={!url}
         className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
@@ -48,6 +49,7 @@ export function PreviewToolbar({ terminalId, url, allowed }: Props) {
         }`}
       />
       <button
+        type="button"
         onClick={openExternal}
         disabled={!url || !allowed}
         className="p-1 rounded hover:bg-white/[0.05] text-text-secondary disabled:opacity-40"
@@ -56,6 +58,7 @@ export function PreviewToolbar({ terminalId, url, allowed }: Props) {
         <ExternalLink size={14} />
       </button>
       <button
+        type="button"
         onClick={toggleGlobal}
         className="p-1 rounded hover:bg-white/[0.05] text-text-secondary"
         title="Close preview"

--- a/src/components/PreviewToolbar.tsx
+++ b/src/components/PreviewToolbar.tsx
@@ -42,7 +42,7 @@ export function PreviewToolbar({ terminalId, url, allowed }: Props) {
         onKeyDown={(e) => { if (e.key === 'Enter') commit(); }}
         onBlur={commit}
         spellCheck={false}
-        placeholder="http://localhost:5173"
+        placeholder="Waiting for dev-server URL…"
         className={`flex-1 bg-elevation-2 border rounded px-2 py-1 text-[11.5px] text-text-primary outline-none ${
           invalid ? 'border-red-500/60' : 'border-white/[0.06] focus:border-accent-primary/60'
         }`}

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -8,6 +8,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { Button } from './ui/Button';
 import { Modal } from './ui/Modal';
 
+interface PreviewProfile {
+  enabled: boolean;
+  url_override?: string | null;
+  framework_hint?: string | null;
+}
+
 interface ConfigProfile {
   id: string;
   name: string;
@@ -16,6 +22,7 @@ interface ConfigProfile {
   claude_args: string[];
   env_vars: Record<string, string>;
   is_default: boolean;
+  preview?: PreviewProfile | null;
 }
 
 export function ProfileModal() {
@@ -280,6 +287,55 @@ export function ProfileModal() {
                     className="rounded border-border-light bg-bg-primary text-accent-primary focus:ring-accent-primary"
                   />
                   <label htmlFor="is_default" className="text-text-primary text-[13px]">Set as default profile</label>
+                </div>
+
+                <div className="border-t border-[var(--ij-divider-soft)] pt-4 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="preview_enabled"
+                      checked={selectedProfile.preview?.enabled ?? false}
+                      onChange={(e) => {
+                        const enabled = e.target.checked;
+                        const nextPreview: PreviewProfile | null = enabled
+                          ? {
+                              enabled: true,
+                              url_override: selectedProfile.preview?.url_override ?? null,
+                              framework_hint: selectedProfile.preview?.framework_hint ?? null,
+                            }
+                          : null;
+                        setSelectedProfile({ ...selectedProfile, preview: nextPreview });
+                      }}
+                      className="rounded border-border-light bg-bg-primary text-accent-primary focus:ring-accent-primary"
+                    />
+                    <label htmlFor="preview_enabled" className="text-text-primary text-[13px]">
+                      Has GUI preview
+                    </label>
+                  </div>
+                  {selectedProfile.preview?.enabled && (
+                    <div>
+                      <label className="block text-text-secondary text-[12px] mb-1.5">
+                        Preview URL (optional override)
+                      </label>
+                      <input
+                        type="text"
+                        value={selectedProfile.preview?.url_override ?? ''}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          setSelectedProfile({
+                            ...selectedProfile,
+                            preview: {
+                              enabled: true,
+                              url_override: value ? value : null,
+                              framework_hint: selectedProfile.preview?.framework_hint ?? null,
+                            },
+                          });
+                        }}
+                        className="w-full bg-bg-primary ring-1 ring-border-light rounded-md h-9 px-3 text-text-primary text-[13px] focus:outline-none focus:ring-accent-primary transition-colors"
+                        placeholder="http://localhost:3000"
+                      />
+                    </div>
+                  )}
                 </div>
 
                 {saveError && (

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -4,6 +4,7 @@ import { X, Clock, Play, Search, RotateCw } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '../store/appStore';
 import { useTerminalStore } from '../store/terminalStore';
+import { toast } from '../store/toastStore';
 
 interface SessionHistoryEntry {
   id: number;
@@ -12,6 +13,8 @@ interface SessionHistoryEntry {
   started_at: string;
   ended_at: string | null;
   log_path: string | null;
+  working_directory: string | null;
+  claude_session_id: string | null;
 }
 
 function formatDuration(start: string, end: string | null): string {
@@ -80,10 +83,21 @@ export function SessionTimeline() {
       ];
       const colorTag = colorTags[terminals.size % colorTags.length];
 
-      await createTerminal(label, '.', ['--continue'], {}, colorTag);
+      // Resume in the directory the session actually ran in - not the app's cwd.
+      // Fall back to '.' only for pre-migration rows that never stored a cwd.
+      const cwd = session.working_directory || '.';
+      if (session.claude_session_id) {
+        // Exact resume of THIS conversation via --resume <id> (8th arg).
+        await createTerminal(label, cwd, [], {}, colorTag, undefined, undefined, session.claude_session_id);
+      } else {
+        // No id captured (older row, or Claude never wrote a session file):
+        // continue the most recent session in that directory (9th arg).
+        await createTerminal(label, cwd, [], {}, colorTag, undefined, undefined, undefined, true);
+      }
       closeSessionTimeline();
     } catch (err) {
       console.error('Failed to resume session:', err);
+      toast.error('Could not resume session', String(err));
     } finally {
       setResuming(null);
     }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -6,6 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SearchAddon } from '@xterm/addon-search';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { SerializeAddon } from '@xterm/addon-serialize';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { useTerminalStore } from '../store/terminalStore';
@@ -48,6 +49,7 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
   const terminalRef = useRef<Terminal | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const serializeAddonRef = useRef<SerializeAddon | null>(null);
   const [searchVisible, setSearchVisible] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   // Right-click context menu (copy / paste). null when closed; otherwise the
@@ -68,6 +70,7 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
   const writeToTerminal = useTerminalStore.getState().writeToTerminal;
   const resizeTerminal = useTerminalStore.getState().resizeTerminal;
   const setXterm = useTerminalStore.getState().setXterm;
+  const stashTerminalBuffer = useTerminalStore.getState().stashTerminalBuffer;
 
   // Terminal appearance settings (issue #21). Scrollback and BiDi need a
   // recreate when they change (xterm caches buffer at construction; the
@@ -165,12 +168,15 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
       });
     });
     const searchAddon = new SearchAddon();
+    const serializeAddon = new SerializeAddon();
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
     terminal.loadAddon(searchAddon);
+    terminal.loadAddon(serializeAddon);
     searchAddonRef.current = searchAddon;
     fitAddonRef.current = fitAddon;
+    serializeAddonRef.current = serializeAddon;
 
     // BiDi (issue #21): opt-in Unicode11 addon enables grapheme-aware width
     // calculation and the proposed BiDi rendering path in xterm. Off by
@@ -403,9 +409,28 @@ export function TerminalView({ terminalId }: TerminalViewProps) {
       resizeObserver.disconnect();
       terminal.textarea?.removeEventListener('blur', handleBlur);
       container.removeEventListener('mouseup', handleMouseUp);
+      // Snapshot the buffer (viewport + scrollback, with colors) before we
+      // dispose, so remounting in a different view (tab -> grid/split and back,
+      // or a scrollback/bidi settings change) can replay it instead of showing
+      // an empty terminal. Serialization is bounded by xterm's scrollback size.
+      // Skipped implicitly for terminals being permanently closed - their store
+      // instance is already gone, so stashTerminalBuffer is a no-op.
+      try {
+        const snapshot = serializeAddonRef.current?.serialize();
+        if (snapshot) {
+          stashTerminalBuffer(terminalId, snapshot);
+        }
+      } catch {
+        /* serialize failed - fall back to an empty terminal on remount */
+      }
       searchAddonRef.current = null;
       fitAddonRef.current = null;
+      serializeAddonRef.current = null;
       terminalRef.current = null;
+      // Clear the store's reference BEFORE disposing so live PTY output can't
+      // be written to a disposed terminal (see handleTerminalOutput). Both are
+      // synchronous, so no terminal-output callback runs between them.
+      setXterm(terminalId, null);
       webglAddon?.dispose();
       terminal.dispose();
     };

--- a/src/components/ToolStripe.tsx
+++ b/src/components/ToolStripe.tsx
@@ -1,6 +1,7 @@
-import { PanelLeft, FileDiff, Users, Lightbulb, Settings } from 'lucide-react';
+import { PanelLeft, FileDiff, Users, Lightbulb, Monitor, Settings } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useAppStore } from '../store/appStore';
+import { usePreviewStore } from '../store/previewStore';
 import { Tooltip } from './ui/Tooltip';
 
 type Side = 'left' | 'right';
@@ -58,6 +59,8 @@ export function ToolStripe({ side }: { side: Side }) {
   const orchestrationOpen = useAppStore((s) => s.orchestrationOpen);
   const hintsOpen = useAppStore((s) => s.hintsOpen);
   const settingsOpen = useAppStore((s) => s.settingsOpen);
+  const previewOpen = usePreviewStore((s) => s.globalOpen);
+  const togglePreview = usePreviewStore((s) => s.toggleGlobal);
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleChanges = useAppStore((s) => s.toggleChanges);
   const toggleOrchestration = useAppStore((s) => s.toggleOrchestration);
@@ -71,6 +74,7 @@ export function ToolStripe({ side }: { side: Side }) {
           { id: 'changes', label: 'Git', shortcut: 'F2', Icon: FileDiff, active: changesOpen, onClick: toggleChanges },
           { id: 'teams', label: 'Agent Teams', shortcut: 'F4', Icon: Users, active: orchestrationOpen, onClick: toggleOrchestration },
           { id: 'hints', label: 'Commands', shortcut: 'F1', Icon: Lightbulb, active: hintsOpen, onClick: toggleHints },
+          { id: 'preview', label: 'Preview', shortcut: 'Ctrl+Alt+P', Icon: Monitor, active: previewOpen, onClick: togglePreview },
         ];
 
   const bottom: StripeItem[] =

--- a/src/components/WorktreeModal.tsx
+++ b/src/components/WorktreeModal.tsx
@@ -53,7 +53,10 @@ export function WorktreeModal() {
     if (newBranchName && repoPath) {
       const parentDir = repoPath.replace(/[\\/][^\\/]*$/, '');
       const sanitized = newBranchName.replace(/\//g, '-');
-      setNewWorktreePath(`${parentDir}\\${repoName}-${sanitized}`);
+      // Match the repo path's separator so the prefilled path is valid on
+      // macOS/Linux too (hardcoding '\\' produced broken paths there).
+      const sep = repoPath.includes('\\') ? '\\' : '/';
+      setNewWorktreePath(`${parentDir}${sep}${repoName}-${sanitized}`);
     }
   }, [newBranchName, repoPath, repoName]);
 

--- a/src/components/settings/SettingsWindow.tsx
+++ b/src/components/settings/SettingsWindow.tsx
@@ -22,6 +22,7 @@ const pages: Record<string, React.LazyExoticComponent<React.ComponentType>> = {
   'claude.defaults':                      lazy(() => import('./categories/ClaudeDefaultsPage')),
   'claude.updates':                       lazy(() => import('./categories/ClaudeUpdatesPage')),
   'tools.launchers':                      lazy(() => import('./categories/ToolsLaunchersPage')),
+  'tools.preview':                        lazy(() => import('./categories/PreviewPage')),
   'privacy-about.privacy':                lazy(() => import('./categories/PrivacyPage')),
   'privacy-about.about':                  lazy(() => import('./categories/AboutPage')),
 };

--- a/src/components/settings/categories/PreviewPage.tsx
+++ b/src/components/settings/categories/PreviewPage.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { Trash2, Plus } from 'lucide-react';
+import { usePreviewStore } from '../../../store/previewStore';
+import { PageHeader, PageSection, SettingRow, Toggle } from '../SettingRow';
+import { registerSetting } from '../index';
+
+const cat = { group: 'tools', page: 'preview' } as const;
+registerSetting({
+  category: cat,
+  id: 'allowlist',
+  label: 'Preview allow-list',
+  keywords: ['preview', 'iframe', 'allow', 'domain', 'ngrok', 'tunnel'],
+});
+registerSetting({
+  category: cat,
+  id: 'keep-alive',
+  label: 'Keep preview alive across tabs',
+  keywords: ['preview', 'iframe', 'keep alive', 'tabs'],
+});
+
+export default function PreviewPage() {
+  const allowList = usePreviewStore((s) => s.allowList);
+  const keepAliveAcrossTabs = usePreviewStore((s) => s.keepAliveAcrossTabs);
+  const addToAllowList = usePreviewStore((s) => s.addToAllowList);
+  const removeFromAllowList = usePreviewStore((s) => s.removeFromAllowList);
+  const setKeepAliveAcrossTabs = usePreviewStore((s) => s.setKeepAliveAcrossTabs);
+
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setError('Enter a pattern like *.ngrok.io');
+      return;
+    }
+    // Only *.hostname.tld is supported by the allow-list matcher (single
+    // leading wildcard label). Reject obvious non-conforming shapes so users
+    // don't wonder why their pattern doesn't match at runtime.
+    if (!/^\*\.[^*\s]+$/.test(trimmed) && /[*]/.test(trimmed)) {
+      setError('Only patterns like *.hostname.tld are supported.');
+      return;
+    }
+    addToAllowList(trimmed);
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="Preview"
+        description="Right-docked live preview for dev servers. Localhost is always allowed; add tunnel domains here."
+      />
+
+      <PageSection
+        title="Allow-list"
+        description="Only URLs on localhost or matching one of these host patterns will load in the preview iframe. Use *.hostname.tld to allow one wildcard label (e.g. *.ngrok.io matches abc.ngrok.io)."
+      >
+        <div className="py-2 space-y-1.5">
+          {allowList.length === 0 && (
+            <p className="text-text-tertiary text-[12px] py-1">
+              No custom entries. Localhost (127.0.0.1, 0.0.0.0, localhost) is always allowed.
+            </p>
+          )}
+          {allowList.map((pattern) => (
+            <div
+              key={pattern}
+              className="flex items-center justify-between gap-2 bg-elevation-0 ring-1 ring-[var(--ij-divider-soft)] rounded-md px-2 h-8"
+            >
+              <code className="text-text-primary text-[12px] font-mono truncate">{pattern}</code>
+              <button
+                onClick={() => removeFromAllowList(pattern)}
+                className="p-1 rounded hover:bg-red-500/10 text-text-tertiary hover:text-red-400 transition-colors flex-shrink-0"
+                title="Remove"
+                aria-label={`Remove ${pattern}`}
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5 py-2 border-t border-[var(--ij-divider-soft)]">
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => { setDraft(e.target.value); setError(null); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+            placeholder="*.ngrok.io"
+            spellCheck={false}
+            className="flex-1 bg-elevation-0 text-text-primary text-[12px] font-mono px-2 h-8 rounded ring-1 ring-border-light focus:outline-none focus:ring-accent-primary transition-colors"
+          />
+          <button
+            onClick={handleAdd}
+            className="flex items-center gap-1 px-2.5 h-8 bg-accent-primary hover:bg-accent-secondary text-white rounded text-[12px] transition-colors"
+          >
+            <Plus size={13} />
+            Add
+          </button>
+        </div>
+        {error && <p className="text-red-400 text-[11.5px] pb-2">{error}</p>}
+      </PageSection>
+
+      <PageSection title="Behavior">
+        <SettingRow
+          label="Keep preview alive across tab switches"
+          description="Render an iframe for every terminal with a resolved URL and just hide the inactive ones. Uses more memory but avoids reloading state when you switch tabs."
+        >
+          <Toggle value={keepAliveAcrossTabs} onChange={setKeepAliveAcrossTabs} />
+        </SettingRow>
+      </PageSection>
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -46,6 +46,7 @@ export const CATEGORY_GROUPS: {
   ]},
   { id: 'tools', label: 'Tools', pages: [
     { id: 'launchers', label: 'Launchers' },
+    { id: 'preview',   label: 'Preview' },
   ]},
   { id: 'privacy-about', label: 'Privacy & About', pages: [
     { id: 'privacy', label: 'Privacy' },

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { MouseEvent, ReactNode } from 'react';
 import { motion } from 'framer-motion';
 import { X } from 'lucide-react';
@@ -40,6 +40,8 @@ export function Modal({
   panelClassName = 'w-full max-w-lg',
   scrimClassName = 'bg-black/55 z-50',
 }: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (!closeOnEscape) return;
     const onKey = (e: KeyboardEvent) => {
@@ -48,6 +50,53 @@ export function Modal({
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [closeOnEscape, onClose]);
+
+  // Focus management: move focus into the dialog on open, trap Tab within it,
+  // and restore focus to the trigger on close. Without this, Tab escapes behind
+  // the scrim and focus is never returned - a keyboard/screen-reader trap.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    const getFocusable = () =>
+      panel
+        ? Array.from(
+            panel.querySelectorAll<HTMLElement>(
+              'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            ),
+          ).filter((el) => el.offsetParent !== null)
+        : [];
+
+    const first = getFocusable()[0];
+    if (first) first.focus();
+    else panel?.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !panel) return;
+      const items = getFocusable();
+      if (items.length === 0) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+      const firstEl = items[0];
+      const lastEl = items[items.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === firstEl || !panel.contains(active)) {
+          e.preventDefault();
+          lastEl.focus();
+        }
+      } else if (active === lastEl || !panel.contains(active)) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      previouslyFocused?.focus?.();
+    };
+  }, []);
 
   const onScrimClick = (e: MouseEvent) => {
     if (closeOn === 'click' && e.target === e.currentTarget) onClose();
@@ -65,8 +114,10 @@ export function Modal({
     >
       <motion.div
         {...dialogMotion}
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
         // Stop bubbling so clicks inside the panel never reach the scrim handler.
         onClick={(e) => e.stopPropagation()}
         onDoubleClick={(e) => e.stopPropagation()}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -56,6 +56,20 @@ export function useKeyboardShortcuts() {
       const ctrl = e.ctrlKey || e.metaKey;
       const shift = e.shiftKey;
 
+      // Swallow F5 and Ctrl+R globally. WebView2's default reloads the
+      // top-level document, which throws away all open terminals (they
+      // aren't persisted). If the preview panel is open, route to the
+      // preview reload instead.
+      if (e.key === 'F5' || (ctrl && !shift && (e.key === 'r' || e.key === 'R'))) {
+        e.preventDefault();
+        const previewOpen = usePreviewStore.getState().globalOpen;
+        const activeId = activeIdRef.current;
+        if (previewOpen && activeId) {
+          usePreviewStore.getState().reload(activeId);
+        }
+        return;
+      }
+
       if (ctrl && shift && e.key === 'N') {
         e.preventDefault();
         useAppStore.getState().openNewTerminalModal();

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -44,6 +44,14 @@ export function useKeyboardShortcuts() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't hijack keys while the user is typing in a non-terminal editable
+      // surface (Settings/modal input, Monaco editor, global search box). These
+      // are app-global accelerators - in a text field the native control must
+      // win, otherwise Ctrl+P, Ctrl+W, F2 (Monaco rename), Ctrl+Shift+F/S/D,
+      // etc. get stolen mid-edit. The helper returns false for xterm's own
+      // textarea, so terminal-focused shortcuts still work.
+      if (isFocusInNonTerminalEditable()) return;
+
       const ctrl = e.ctrlKey || e.metaKey;
       const shift = e.shiftKey;
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useAppStore, DEFAULT_TERMINAL_FONT_SIZE } from '../store/appStore';
 import { useTerminalStore } from '../store/terminalStore';
+import { usePreviewStore } from '../store/previewStore';
 import { toast } from '../store/toastStore';
 import { captureClaudeInput } from '../lib/terminalInput';
 
@@ -95,6 +96,12 @@ export function useKeyboardShortcuts() {
             targetTerminalId: activeId,
           });
         })();
+      }
+
+      // Preview panel toggle: Ctrl+Alt+P (Ctrl+Shift+V and Ctrl+Shift+G are taken).
+      if (ctrl && e.altKey && !shift && (e.key === 'p' || e.key === 'P')) {
+        e.preventDefault();
+        usePreviewStore.getState().toggleGlobal();
       }
 
       // Split View: Ctrl+\

--- a/src/hooks/usePreventWebviewReload.ts
+++ b/src/hooks/usePreventWebviewReload.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useTerminalStore } from '../store/terminalStore';
+
+// WebView2's default context menu includes a "Refresh" item that reloads the
+// top-level document - which throws away every open terminal (they're not
+// persisted). F5 / Ctrl+R are intercepted by useKeyboardShortcuts. This hook
+// closes the remaining vectors:
+//
+//   1. Global `contextmenu` handler that suppresses the browser-native menu
+//      everywhere EXCEPT text inputs, xterm helper textareas, and Monaco
+//      editors — those retain native cut/copy/paste + spell-check.
+//   2. `beforeunload` handler that cancels any refresh attempt while
+//      terminals are open (belt-and-suspenders against menu vectors we
+//      haven't thought of).
+//
+// Tauri closes windows via the OS `close_requested` event, not through
+// `beforeunload`, so blocking beforeunload does NOT prevent the user from
+// actually closing the app.
+const NATIVE_MENU_SELECTORS = [
+  'input',
+  'textarea',
+  '.monaco-editor',
+  '.xterm-helper-textarea',
+  '[contenteditable="true"]',
+].join(', ');
+
+export function usePreventWebviewReload() {
+  useEffect(() => {
+    const onContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest(NATIVE_MENU_SELECTORS)) return;
+      e.preventDefault();
+    };
+
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      const hasTerminals = useTerminalStore.getState().terminals.size > 0;
+      if (!hasTerminals) return;
+      e.preventDefault();
+      // Some engines still require returnValue to be set.
+      e.returnValue = '';
+    };
+
+    window.addEventListener('contextmenu', onContextMenu);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('contextmenu', onContextMenu);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, []);
+}

--- a/src/lib/preview/allowlist.test.ts
+++ b/src/lib/preview/allowlist.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { isUrlAllowed } from './allowlist';
+
+describe('isUrlAllowed', () => {
+  it('always allows localhost variants', () => {
+    expect(isUrlAllowed('http://localhost:5173', [])).toBe(true);
+    expect(isUrlAllowed('http://127.0.0.1:3000', [])).toBe(true);
+    expect(isUrlAllowed('http://0.0.0.0:4321/', [])).toBe(true);
+    expect(isUrlAllowed('https://localhost:8443', [])).toBe(true);
+  });
+
+  it('rejects arbitrary hostnames without allow-list entry', () => {
+    expect(isUrlAllowed('http://evil.com', [])).toBe(false);
+    expect(isUrlAllowed('https://example.org', [])).toBe(false);
+  });
+
+  it('allows hostnames matching allow-list glob', () => {
+    expect(isUrlAllowed('https://abc.ngrok.io', ['*.ngrok.io'])).toBe(true);
+    expect(isUrlAllowed('https://abc.def.ngrok.io', ['*.ngrok.io'])).toBe(false); // one label only
+    expect(isUrlAllowed('https://foo.trycloudflare.com', ['*.trycloudflare.com'])).toBe(true);
+  });
+
+  it('rejects hostname-boundary tricks', () => {
+    // '*.ngrok.io' must NOT match 'ngrok.io.evil.com'
+    expect(isUrlAllowed('https://ngrok.io.evil.com', ['*.ngrok.io'])).toBe(false);
+    expect(isUrlAllowed('https://evilngrok.io', ['*.ngrok.io'])).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isUrlAllowed('not-a-url', [])).toBe(false);
+    expect(isUrlAllowed('', [])).toBe(false);
+    expect(isUrlAllowed('javascript:alert(1)', [])).toBe(false);
+    expect(isUrlAllowed('file:///etc/passwd', [])).toBe(false);
+  });
+
+  it('only accepts http/https schemes', () => {
+    expect(isUrlAllowed('ftp://localhost', [])).toBe(false);
+    expect(isUrlAllowed('data:text/html,<h1>x</h1>', [])).toBe(false);
+  });
+});

--- a/src/lib/preview/allowlist.ts
+++ b/src/lib/preview/allowlist.ts
@@ -1,0 +1,25 @@
+const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+function hostMatchesGlob(host: string, pattern: string): boolean {
+  // Only supports a single leading '*.' — 'foo.*' or 'a*b' are literal.
+  if (!pattern.startsWith('*.')) {
+    return host === pattern;
+  }
+  const suffix = pattern.slice(1); // '.ngrok.io'
+  // Must end with suffix AND the prefix must be exactly one dotless label.
+  if (!host.endsWith(suffix)) return false;
+  const prefix = host.slice(0, host.length - suffix.length);
+  return prefix.length > 0 && !prefix.includes('.');
+}
+
+export function isUrlAllowed(rawUrl: string, allowList: string[]): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  if (LOCALHOST_HOSTS.has(url.hostname)) return true;
+  return allowList.some((p) => hostMatchesGlob(url.hostname, p));
+}

--- a/src/lib/preview/detector.test.ts
+++ b/src/lib/preview/detector.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { detectUrl } from './detector';
+
+describe('detectUrl', () => {
+  const cases: Array<[string, string, string | null]> = [
+    ['Vite',       '➜  Local:   http://localhost:5173/',                        'http://localhost:5173'],
+    ['Next.js 13', '- Local:        http://localhost:3000',                     'http://localhost:3000'],
+    ['Next.js 15', '▲ Next.js 15.0.0\n- Local: http://localhost:3000',          'http://localhost:3000'],
+    ['CRA',        'Local:            http://localhost:3000',                    'http://localhost:3000'],
+    ['Astro',      '┃ Local    http://localhost:4321/',                          'http://localhost:4321'],
+    ['Nuxt',       '➜ Local:    http://localhost:3000/',                         'http://localhost:3000'],
+    ['SvelteKit',  '➜  Local:   http://localhost:5173/',                        'http://localhost:5173'],
+    ['Angular',    'Angular Live Development Server is listening on localhost:4200', null], // no scheme
+    ['Remix',      '[remix-serve] http://localhost:3000',                        'http://localhost:3000'],
+    ['Expo web',   'Web is waiting on http://localhost:19006',                   'http://localhost:19006'],
+  ];
+
+  for (const [label, input, expected] of cases) {
+    it(`detects ${label}`, () => {
+      expect(detectUrl(input)).toBe(expected);
+    });
+  }
+
+  it('strips ANSI escape codes before matching', () => {
+    expect(detectUrl('\x1b[32m➜\x1b[39m  \x1b[1mLocal:\x1b[22m   \x1b[36mhttp://localhost:5173/\x1b[39m'))
+      .toBe('http://localhost:5173');
+  });
+
+  it('returns most recent match when multiple are present', () => {
+    const text = 'http://localhost:3000\nreloading...\nhttp://localhost:5173';
+    expect(detectUrl(text)).toBe('http://localhost:5173');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(detectUrl('nothing here')).toBe(null);
+    expect(detectUrl('')).toBe(null);
+  });
+
+  it('handles Angular-style separately via detectHost helper (not required for M1)', () => {
+    // Angular prints "listening on localhost:4200" without scheme. For M1 we
+    // deliberately require a scheme. A future enhancement may add hostless
+    // parsing behind a framework hint.
+    expect(detectUrl('listening on localhost:4200')).toBe(null);
+  });
+});

--- a/src/lib/preview/detector.ts
+++ b/src/lib/preview/detector.ts
@@ -1,0 +1,17 @@
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+const URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d{1,5})/gi;
+
+const stripAnsi = (s: string): string => s.replace(ANSI_PATTERN, '');
+
+function trimTrailing(url: string): string {
+  // Drop trailing '/', punctuation, ANSI residue.
+  return url.replace(/[\/,;.)\]]+$/, '');
+}
+
+export function detectUrl(text: string): string | null {
+  if (!text) return null;
+  const clean = stripAnsi(text);
+  const matches = clean.match(URL_PATTERN);
+  if (!matches || matches.length === 0) return null;
+  return trimTrailing(matches[matches.length - 1]);
+}

--- a/src/lib/preview/framework.test.ts
+++ b/src/lib/preview/framework.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { detectFramework } from './framework';
+
+describe('detectFramework', () => {
+  it('detects Next.js from dependencies', () => {
+    expect(detectFramework({ dependencies: { next: '^14.0.0' } })).toEqual({
+      hint: 'nextjs', defaultPort: 3000,
+    });
+  });
+
+  it('detects Vite from devDependencies', () => {
+    expect(detectFramework({ devDependencies: { vite: '^5.0.0' } })).toEqual({
+      hint: 'vite', defaultPort: 5173,
+    });
+  });
+
+  it('prefers scripts.dev when it names a framework CLI', () => {
+    // e.g. custom scripts.dev pointing at astro dev
+    expect(detectFramework({
+      scripts: { dev: 'astro dev' },
+      dependencies: { vite: '^5.0.0' }, // vite is also present but astro wins from scripts
+    })).toEqual({ hint: 'astro', defaultPort: 4321 });
+  });
+
+  it('returns unknown when nothing matches', () => {
+    expect(detectFramework({ dependencies: { lodash: '^4.0.0' } })).toEqual({
+      hint: 'unknown', defaultPort: null,
+    });
+  });
+
+  it('returns unknown for empty object', () => {
+    expect(detectFramework({})).toEqual({ hint: 'unknown', defaultPort: null });
+  });
+
+  it('handles all supported frameworks', () => {
+    const cases: Array<[Record<string, unknown>, string, number]> = [
+      [{ dependencies: { next: '*' } }, 'nextjs', 3000],
+      [{ dependencies: { vite: '*' } }, 'vite', 5173],
+      [{ dependencies: { '@angular/core': '*' } }, 'angular', 4200],
+      [{ dependencies: { astro: '*' } }, 'astro', 4321],
+      [{ dependencies: { nuxt: '*' } }, 'nuxt', 3000],
+      [{ dependencies: { '@sveltejs/kit': '*' } }, 'sveltekit', 5173],
+      [{ dependencies: { '@remix-run/dev': '*' } }, 'remix', 3000],
+      [{ dependencies: { 'react-scripts': '*' } }, 'cra', 3000],
+      [{ dependencies: { expo: '*' } }, 'expo', 8081],
+    ];
+    for (const [pkg, hint, port] of cases) {
+      expect(detectFramework(pkg)).toEqual({ hint, defaultPort: port });
+    }
+  });
+});

--- a/src/lib/preview/framework.ts
+++ b/src/lib/preview/framework.ts
@@ -1,0 +1,43 @@
+export type FrameworkHint =
+  | 'nextjs' | 'vite' | 'astro' | 'nuxt' | 'sveltekit' | 'remix'
+  | 'angular' | 'cra' | 'expo' | 'unknown';
+
+export interface FrameworkInfo {
+  hint: FrameworkHint;
+  defaultPort: number | null;
+}
+
+// Order matters: entries earlier in the list win ties. `scripts.dev` scan uses
+// this array; dependencies scan iterates in the same order.
+const FRAMEWORKS: Array<{ hint: FrameworkHint; pkg: string; cliToken: string; port: number }> = [
+  { hint: 'nextjs',    pkg: 'next',              cliToken: 'next',       port: 3000  },
+  { hint: 'astro',     pkg: 'astro',             cliToken: 'astro',      port: 4321  },
+  { hint: 'nuxt',      pkg: 'nuxt',              cliToken: 'nuxt',       port: 3000  },
+  { hint: 'sveltekit', pkg: '@sveltejs/kit',     cliToken: 'svelte',     port: 5173  },
+  { hint: 'remix',     pkg: '@remix-run/dev',    cliToken: 'remix',      port: 3000  },
+  { hint: 'angular',   pkg: '@angular/core',     cliToken: 'ng ',        port: 4200  },
+  { hint: 'cra',       pkg: 'react-scripts',     cliToken: 'react-scripts', port: 3000 },
+  { hint: 'expo',      pkg: 'expo',              cliToken: 'expo',       port: 8081  },
+  { hint: 'vite',      pkg: 'vite',              cliToken: 'vite',       port: 5173  },
+];
+
+export function detectFramework(pkg: Record<string, unknown>): FrameworkInfo {
+  const scripts = (pkg.scripts ?? {}) as Record<string, string>;
+  const devScript = typeof scripts.dev === 'string' ? scripts.dev.toLowerCase() : '';
+
+  if (devScript) {
+    for (const fw of FRAMEWORKS) {
+      if (devScript.includes(fw.cliToken)) {
+        return { hint: fw.hint, defaultPort: fw.port };
+      }
+    }
+  }
+
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) } as Record<string, unknown>;
+  for (const fw of FRAMEWORKS) {
+    if (fw.pkg in deps) {
+      return { hint: fw.hint, defaultPort: fw.port };
+    }
+  }
+  return { hint: 'unknown', defaultPort: null };
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -930,12 +930,24 @@ export const useAppStore = create<AppState>()(
 
       // Command Palette actions (F1)
       recordPaletteUse: (key) =>
-        set((s) => ({
-          paletteUsage: {
+        set((s) => {
+          // Cap the persisted map so orphaned keys (e.g. snippet:<id> for a
+          // deleted snippet) can't accumulate forever toward the localStorage
+          // quota. Keep the most-recently-used entries.
+          const MAX_PALETTE_USAGE = 300;
+          const next: Record<string, { count: number; lastUsedTs: number }> = {
             ...s.paletteUsage,
             [key]: { count: (s.paletteUsage[key]?.count ?? 0) + 1, lastUsedTs: Date.now() },
-          },
-        })),
+          };
+          const keys = Object.keys(next);
+          if (keys.length <= MAX_PALETTE_USAGE) return { paletteUsage: next };
+          const kept = keys
+            .sort((a, b) => next[b].lastUsedTs - next[a].lastUsedTs)
+            .slice(0, MAX_PALETTE_USAGE);
+          const trimmed: Record<string, { count: number; lastUsedTs: number }> = {};
+          for (const k of kept) trimmed[k] = next[k];
+          return { paletteUsage: trimmed };
+        }),
       openCommandPalette: () => set({ commandPaletteOpen: true }),
       closeCommandPalette: () => set({ commandPaletteOpen: false }),
       toggleCommandPalette: () => set((state) => ({ commandPaletteOpen: !state.commandPaletteOpen })),

--- a/src/store/previewStore.test.ts
+++ b/src/store/previewStore.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePreviewStore } from './previewStore';
+
+describe('previewStore', () => {
+  beforeEach(() => {
+    usePreviewStore.setState({
+      perTerminal: new Map(),
+      globalOpen: false,
+      allowList: [],
+      keepAliveAcrossTabs: false,
+      panelWidthPx: 640,
+    });
+  });
+
+  it('seeds a terminal with defaults', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    const s = usePreviewStore.getState().perTerminal.get('t1');
+    expect(s).toBeDefined();
+    expect(s?.detectedUrl).toBeNull();
+    expect(s?.userOverride).toBeNull();
+    expect(s?.frameworkHint).toBe('unknown');
+    expect(s?.isOpen).toBe(false);
+  });
+
+  it('setDetectedUrl updates the state', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    expect(usePreviewStore.getState().perTerminal.get('t1')?.detectedUrl).toBe('http://localhost:5173');
+  });
+
+  it('userOverride wins over detectedUrl in resolveUrl', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    usePreviewStore.getState().setUserOverride('t1', 'http://localhost:3000');
+    // Consumers call resolveUrl to get the effective URL
+    const { resolveUrl } = usePreviewStore.getState();
+    expect(resolveUrl('t1')).toBe('http://localhost:3000');
+  });
+
+  it('resolveUrl falls back to detectedUrl when no override', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().setDetectedUrl('t1', 'http://localhost:5173');
+    expect(usePreviewStore.getState().resolveUrl('t1')).toBe('http://localhost:5173');
+  });
+
+  it('resolveUrl returns null when nothing is set', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    expect(usePreviewStore.getState().resolveUrl('t1')).toBeNull();
+  });
+
+  it('removeTerminal drops per-terminal state', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    usePreviewStore.getState().removeTerminal('t1');
+    expect(usePreviewStore.getState().perTerminal.has('t1')).toBe(false);
+  });
+
+  it('toggleGlobal flips globalOpen', () => {
+    expect(usePreviewStore.getState().globalOpen).toBe(false);
+    usePreviewStore.getState().toggleGlobal();
+    expect(usePreviewStore.getState().globalOpen).toBe(true);
+    usePreviewStore.getState().toggleGlobal();
+    expect(usePreviewStore.getState().globalOpen).toBe(false);
+  });
+
+  it('reload bumps reloadCounter', () => {
+    usePreviewStore.getState().seedTerminal('t1', {});
+    const before = usePreviewStore.getState().perTerminal.get('t1')?.reloadCounter ?? 0;
+    usePreviewStore.getState().reload('t1');
+    const after = usePreviewStore.getState().perTerminal.get('t1')?.reloadCounter ?? 0;
+    expect(after).toBe(before + 1);
+  });
+
+  it('addToAllowList deduplicates', () => {
+    usePreviewStore.getState().addToAllowList('*.ngrok.io');
+    usePreviewStore.getState().addToAllowList('*.ngrok.io');
+    expect(usePreviewStore.getState().allowList.filter((p) => p === '*.ngrok.io')).toHaveLength(1);
+  });
+});

--- a/src/store/previewStore.ts
+++ b/src/store/previewStore.ts
@@ -1,0 +1,143 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { FrameworkHint } from '../lib/preview/framework';
+
+export type DeviceName = 'desktop' | 'tablet' | 'mobile';
+export interface DeviceMode { name: DeviceName; width: number; height?: number }
+
+export const DEVICE_MODES: Record<DeviceName, DeviceMode> = {
+  desktop: { name: 'desktop', width: 0 }, // 0 = full width
+  tablet:  { name: 'tablet',  width: 768,  height: 1024 },
+  mobile:  { name: 'mobile',  width: 375,  height: 812  },
+};
+
+export interface PreviewState {
+  isOpen: boolean;
+  detectedUrl: string | null;
+  userOverride: string | null;
+  frameworkHint: FrameworkHint;
+  deviceMode: DeviceMode;
+  history: string[];
+  historyIndex: number;
+  lastError: string | null;
+  reloadCounter: number;
+  inlineHintDismissed: boolean;
+}
+
+const defaultPreviewState = (): PreviewState => ({
+  isOpen: false,
+  detectedUrl: null,
+  userOverride: null,
+  frameworkHint: 'unknown',
+  deviceMode: DEVICE_MODES.desktop,
+  history: [],
+  historyIndex: -1,
+  lastError: null,
+  reloadCounter: 0,
+  inlineHintDismissed: false,
+});
+
+interface PreviewStoreState {
+  perTerminal: Map<string, PreviewState>;
+  globalOpen: boolean;
+  allowList: string[];
+  keepAliveAcrossTabs: boolean;
+  panelWidthPx: number;
+
+  seedTerminal(id: string, initial: Partial<PreviewState>): void;
+  setDetectedUrl(id: string, url: string): void;
+  setUserOverride(id: string, url: string): void;
+  dismissInlineHint(id: string): void;
+  markOpen(id: string, open: boolean): void;
+  removeTerminal(id: string): void;
+  toggleGlobal(): void;
+  setDeviceMode(id: string, mode: DeviceMode): void;
+  reload(id: string): void;
+  addToAllowList(pattern: string): void;
+  removeFromAllowList(pattern: string): void;
+  setPanelWidth(px: number): void;
+  setKeepAliveAcrossTabs(v: boolean): void;
+  resolveUrl(id: string): string | null;
+}
+
+function withMutatedTerminal(
+  set: (fn: (s: PreviewStoreState) => Partial<PreviewStoreState>) => void,
+  id: string,
+  mutator: (s: PreviewState) => PreviewState,
+) {
+  set((state) => {
+    const next = new Map(state.perTerminal);
+    const cur = next.get(id) ?? defaultPreviewState();
+    next.set(id, mutator(cur));
+    return { perTerminal: next };
+  });
+}
+
+export const usePreviewStore = create<PreviewStoreState>()(
+  persist(
+    (set, get) => ({
+      perTerminal: new Map(),
+      globalOpen: false,
+      allowList: [],
+      keepAliveAcrossTabs: false,
+      panelWidthPx: 640,
+
+      seedTerminal: (id, initial) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, ...initial })),
+
+      setDetectedUrl: (id, url) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, detectedUrl: url, lastError: null })),
+
+      setUserOverride: (id, url) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, userOverride: url })),
+
+      dismissInlineHint: (id) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, inlineHintDismissed: true })),
+
+      markOpen: (id, open) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, isOpen: open })),
+
+      removeTerminal: (id) =>
+        set((state) => {
+          const next = new Map(state.perTerminal);
+          next.delete(id);
+          return { perTerminal: next };
+        }),
+
+      toggleGlobal: () => set((s) => ({ globalOpen: !s.globalOpen })),
+
+      setDeviceMode: (id, mode) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, deviceMode: mode })),
+
+      reload: (id) =>
+        withMutatedTerminal(set, id, (s) => ({ ...s, reloadCounter: s.reloadCounter + 1 })),
+
+      addToAllowList: (pattern) =>
+        set((s) => (s.allowList.includes(pattern)
+          ? s
+          : { allowList: [...s.allowList, pattern] })),
+
+      removeFromAllowList: (pattern) =>
+        set((s) => ({ allowList: s.allowList.filter((p) => p !== pattern) })),
+
+      setPanelWidth: (px) => set({ panelWidthPx: Math.max(320, Math.min(1400, px)) }),
+      setKeepAliveAcrossTabs: (v) => set({ keepAliveAcrossTabs: v }),
+
+      resolveUrl: (id) => {
+        const s = get().perTerminal.get(id);
+        if (!s) return null;
+        return s.userOverride ?? s.detectedUrl;
+      },
+    }),
+    {
+      name: 'preview-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({
+        globalOpen: s.globalOpen,
+        allowList: s.allowList,
+        keepAliveAcrossTabs: s.keepAliveAcrossTabs,
+        panelWidthPx: s.panelWidthPx,
+      }),
+    },
+  ),
+);

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -6,10 +6,44 @@ import { markTerminalActive, clearTerminalActivity } from '../lib/terminalActivi
 import { chunkUtf8Bytes } from '../lib/chunkUtf8';
 import type { SessionState } from '../lib/terminalState';
 import { mergeMetrics, emptyMetrics, type SessionMetrics, type TerminalMetricsPayload } from '../lib/sessionMetrics';
+import { usePreviewStore, type PreviewState } from './previewStore';
+import { detectFramework, type FrameworkHint } from '../lib/preview/framework';
 
 // Stay safely under the backend's 64 KB per-write cap so very large pastes
 // (multi-hundred KB) don't hit "Write payload too large".
 const TERMINAL_WRITE_CHUNK_BYTES = 60 * 1024;
+
+/**
+ * Best-effort framework detection for the Preview panel. Reads the terminal's
+ * cwd/package.json via the existing `list_package_scripts` IPC (no new Rust
+ * command or fs plugin required), reconstructs a minimal package.json shape,
+ * and seeds the preview store with the detected framework hint.
+ *
+ * The IPC only exposes `scripts.*` — not `dependencies` — so detection here is
+ * limited to the `scripts.dev` path of `detectFramework`, which matches the
+ * common case (`next dev`, `vite`, `astro dev`, `nuxt dev`, `svelte`, `ng serve`,
+ * `react-scripts start`, `expo start`, `remix dev`). That is enough for the
+ * default port and hint to feed downstream UX. Failures are swallowed silently.
+ */
+async function seedFrameworkHint(terminalId: string, cwd: string): Promise<void> {
+  if (!cwd) return;
+  try {
+    const scripts = await invoke<{ name: string; command: string }[]>(
+      'list_package_scripts',
+      { cwd },
+    );
+    if (!scripts || scripts.length === 0) return;
+    const scriptsMap: Record<string, string> = {};
+    for (const s of scripts) scriptsMap[s.name] = s.command;
+    const { hint } = detectFramework({ scripts: scriptsMap });
+    if (hint !== 'unknown') {
+      const seed: Partial<PreviewState> = { frameworkHint: hint as FrameworkHint };
+      usePreviewStore.getState().seedTerminal(terminalId, seed);
+    }
+  } catch {
+    // no package.json, invalid JSON, path not trusted — silent.
+  }
+}
 
 export interface TerminalConfig {
   id: string;
@@ -87,6 +121,7 @@ interface TerminalState {
     restoredOutput?: string,
     resumeSessionId?: string,
     continueRecent?: boolean,
+    previewInit?: Partial<PreviewState>,
   ) => Promise<string>;
   createShellTerminalTab: (
     label: string,
@@ -152,7 +187,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   bottomTerminalIds: [],
   activeBottomTerminalId: null,
 
-  createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput, resumeSessionId, continueRecent) => {
+  createTerminal: async (label, workingDirectory, claudeArgs, envVars, colorTag, nickname, restoredOutput, resumeSessionId, continueRecent, previewInit) => {
     try {
       const { useAppStore } = await import('./appStore');
       const costTracking = useAppStore.getState().costTrackingEnabled;
@@ -193,6 +228,23 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
       // Fetch git info in the background
       get().fetchGitInfo(config.id);
+
+      // Seed the preview store with any per-profile hints the caller passed in.
+      // Callers that don't know about the preview feature (grid, restore, tests)
+      // omit previewInit entirely, in which case we still seed with defaults so
+      // downstream reads never hit an undefined per-terminal state.
+      if (previewInit) {
+        usePreviewStore.getState().seedTerminal(config.id, previewInit);
+        // Auto-open the panel when a "Has GUI preview" profile launches a tab.
+        if (previewInit.isOpen && !usePreviewStore.getState().globalOpen) {
+          usePreviewStore.getState().toggleGlobal();
+        }
+      }
+
+      // Fire-and-forget: probe package.json for a framework hint. Runs even if
+      // the caller didn't pass previewInit — that way an ad-hoc terminal in a
+      // Vite/Next repo gets its hint auto-detected.
+      void seedFrameworkHint(config.id, workingDirectory);
 
       return config.id;
     } catch (error) {
@@ -309,6 +361,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newBudgetWarned = new Set(state.budgetWarnedIds);
       newBudgetWarned.delete(id);
       if (childId) newBudgetWarned.delete(childId);
+
+      // Drop preview state for this terminal (and any script child) - mirrors
+      // the unread/metrics/git-cache cleanup above so nothing points at a gone id.
+      usePreviewStore.getState().removeTerminal(id);
+      if (childId) usePreviewStore.getState().removeTerminal(childId);
 
       // Only pick a fallback from terminals that actually appear in the main
       // tab bar - script children and bottom-pane shells must never become

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -344,7 +344,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
       if (instance) {
-        instance.config.label = label;
+        // Immutable update: replace the instance/config objects rather than
+        // mutating them in place, so React.memo consumers keyed on config
+        // identity re-render and prior-state snapshots aren't corrupted.
+        newTerminals.set(id, { ...instance, config: { ...instance.config, label } });
       }
       return { terminals: newTerminals };
     });
@@ -357,7 +360,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
       if (instance) {
-        instance.config.nickname = nickname;
+        newTerminals.set(id, { ...instance, config: { ...instance.config, nickname } });
       }
       return { terminals: newTerminals };
     });
@@ -469,7 +472,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
       if (instance) {
-        instance.config.status = status;
+        newTerminals.set(id, { ...instance, config: { ...instance.config, status } });
       }
       return { terminals: newTerminals };
     });
@@ -480,7 +483,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
       if (instance) {
-        instance.loopInfo = info;
+        newTerminals.set(id, { ...instance, loopInfo: info });
       }
       return { terminals: newTerminals };
     });
@@ -491,7 +494,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
       if (instance) {
-        instance.sessionSummary = summary;
+        newTerminals.set(id, { ...instance, sessionSummary: summary });
       }
       return { terminals: newTerminals };
     });

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -38,6 +38,11 @@ interface TerminalInstance {
   config: TerminalConfig;
   xterm: Terminal | null;
   restoredOutput?: string;
+  // Serialized xterm buffer stashed when the view unmounts (e.g. switching
+  // tab <-> grid/split), replayed on remount so scrollback survives the
+  // teardown that xterm's single-DOM-node model forces. Distinct from
+  // restoredOutput, which is persisted session history shown with banners.
+  carryOverBuffer?: string;
   model?: string;
   effort?: string;
   isWorktree: boolean;
@@ -95,7 +100,8 @@ interface TerminalState {
   updateNickname: (id: string, nickname: string) => Promise<void>;
   writeToTerminal: (id: string, data: string) => Promise<void>;
   resizeTerminal: (id: string, cols: number, rows: number) => Promise<void>;
-  setXterm: (id: string, xterm: Terminal) => void;
+  setXterm: (id: string, xterm: Terminal | null) => void;
+  stashTerminalBuffer: (id: string, data: string) => void;
   handleTerminalOutput: (id: string, data: Uint8Array) => void;
   updateTerminalStatus: (id: string, status: TerminalConfig['status']) => void;
   setLoopMode: (id: string, info: LoopInfo | null) => void;
@@ -373,6 +379,22 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   setXterm: (id, xterm) => {
+    // Clearing the ref (xterm === null) on unmount/dispose. Without this the
+    // store keeps pointing at a disposed Terminal, and handleTerminalOutput
+    // would keep calling write() on it (a disposed instance is still truthy)
+    // whenever the PTY streams while the view is unmounted (e.g. grid/split).
+    if (!xterm) {
+      set((state) => {
+        const newTerminals = new Map(state.terminals);
+        const inst = newTerminals.get(id);
+        if (inst) {
+          inst.xterm = null;
+        }
+        return { terminals: newTerminals };
+      });
+      return;
+    }
+
     const { terminals } = get();
     const instance = terminals.get(id);
 
@@ -382,6 +404,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       xterm.write('\x1b[90m─── Previous session output ───\x1b[0m\r\n\r\n');
       xterm.write(lines.replace(/\n/g, '\r\n'));
       xterm.write('\r\n\r\n\x1b[90m─── Session restored ───\x1b[0m\r\n\r\n');
+    } else if (instance?.carryOverBuffer) {
+      // Replay a buffer stashed on a view switch, verbatim and banner-free -
+      // this is the same live session, just re-rendered into a new xterm.
+      xterm.write(instance.carryOverBuffer);
     }
 
     set((state) => {
@@ -390,6 +416,21 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       if (inst) {
         inst.xterm = xterm;
         delete inst.restoredOutput; // Free memory
+        delete inst.carryOverBuffer; // Replayed - drop the snapshot
+      }
+      return { terminals: newTerminals };
+    });
+  },
+
+  stashTerminalBuffer: (id, data) => {
+    set((state) => {
+      const inst = state.terminals.get(id);
+      // No-op if the terminal is gone (permanently closed) - nothing to carry.
+      if (!inst) return state;
+      const newTerminals = new Map(state.terminals);
+      const next = newTerminals.get(id);
+      if (next) {
+        next.carryOverBuffer = data;
       }
       return { terminals: newTerminals };
     });
@@ -399,7 +440,14 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     const state = get();
     const instance = state.terminals.get(id);
     if (instance?.xterm) {
-      instance.xterm.write(data);
+      // Guard against a dispose/output race: if the view unmounted between the
+      // store read and this write, xterm.write() on a disposed instance throws.
+      // Swallow it rather than surface an UnhandledRejection in the event loop.
+      try {
+        instance.xterm.write(data);
+      } catch {
+        /* terminal disposed - drop this chunk */
+      }
     }
     // Active-work indicator: record the timestamp in a plain Map (no Zustand
     // set() - that would defeat the streaming-rate optimization below).


### PR DESCRIPTION
## Summary

Three coherent chunks land together on this branch.

---

### 1. Live preview panel (Base44/Lovable/Dyad-style) — 19 commits (`050a316`..`43caec7`)

- Right-docked, drag-to-resize (320–1400 px, persisted) iframe panel that auto-detects a terminal's dev-server URL from stdout + `package.json` (Vite, Next.js, Astro, Nuxt, SvelteKit, Remix, Angular, CRA, Expo).
- Per-terminal state in a new Zustand slice with partial persistence (`allowList`, `keepAliveAcrossTabs`, `panelWidthPx`).
- URL bar with allow-list validation. Localhost always allowed; user-added hostname globs (e.g. `*.ngrok.io`) opt in tunnel hosts. Anything else is blocked with an inline explanation.
- Profiles gain a `preview.enabled` checkbox + optional URL override. Terminals launched from a GUI profile auto-open the panel; ad-hoc terminals get a subtle inline hint on first detection.
- **Rust:** `PreviewProfile` on `ConfigProfile` (backwards-compatible via `#[serde(default)]`) and a nullable `preview_json` column on the `profiles` table.
- Toggle via right-side `ToolStripe` icon or `Ctrl+Alt+P`.
- Full spec: `docs/superpowers/specs/2026-07-23-preview-panel-design.md`. Plan: `docs/superpowers/plans/2026-07-23-preview-panel.md`. M3 items (device frames, back/forward, network-status pill, pop-out `WebviewWindow`) are outlined but deferred to a follow-up plan.

### 2. Reload-vector guards — 4 commits (`a6ee4e7`..`a0be190`)

Terminals are ephemeral (frontend state only), so an accidental page reload throws them all away. Three vectors, all closed:

- `useKeyboardShortcuts.ts` — global F5 / Ctrl+R interceptor. Routes to preview reload when the panel is open; no-op otherwise.
- `usePreventWebviewReload.ts` — global `contextmenu` swallow (exempting inputs / xterm / Monaco / contenteditable) plus `beforeunload` cancel while any terminal is open. Cross-platform fallback.
- `main.rs` — `ICoreWebView2Settings.AreDefaultContextMenusEnabled(false)` via `with_webview` on Windows. Kills the native WebView2 menu (Back/Refresh/Save-as/Inspect) at the shell level. This is the only reliable fix for right-clicks inside the preview iframe, which parent JS cannot intercept across the iframe boundary. macOS/`WKWebView` parity deferred.
- Also in this chunk: script-runner child → parent URL routing (`a6ee4e7`), self-preview guard so the iframe can't recursively load ClaudeTerminal itself in dev mode (`f47029c`), and `type=\"button\"` on all preview toolbar controls.

### 3. Security / lifecycle audit fixes (original branch scope) — 3 commits (`2eabb1c`, `49a2282`, `0d35160`)

#### 🔒 Security (`2eabb1c`)
- **Windows git command injection** — git was invoked as `cmd /C git …`, so cmd metacharacters (`& | ( ) ^ !`) in a branch name / file path / remote coming from a hostile repo could break out into command execution (Rust only quotes args with whitespace, and its cmd.exe caret-escaping only applies to `.bat`/`.cmd` targets). Added a `git_command` helper that spawns `git.exe` **directly** on Windows and repointed all 35 call sites; Unix keeps the escaped login-shell path.
- **Destructive FS ops bypassing the trust boundary** — `rename_path`, `trash_path`, `move_into_dir`, `copy_into_dir` only did an empty/null-byte check. They now gate on `validate_path_is_trusted` (source, plus destination dir for move/copy), matching the sibling FS commands.
- **`list_memory_files` arbitrary-dir read** — a caller-supplied `project_path` was scanned directly; it's now confined to `~/.claude` via `validate_claude_path`.

#### ♻️ Lifecycle (`2eabb1c`)
- **Orphaned processes / leaked reader threads** — the spawned child was dropped and never killed; on Windows a ConPTY read can block indefinitely after the PTY drops, leaking the reader thread and orphaning the process. The `Child` is now stored on `Terminal` and `kill()`-ed in `close`/`close_all` (non-blocking, so no mutex deadlock).
- **Writes to a disposed xterm** — switching tab↔grid/split disposed each xterm but left the store pointing at it. The store ref is now cleared on unmount (before dispose) and the write is try/catch-guarded.
- **Scrollback loss on view switch** — added `@xterm/addon-serialize`; buffer snapshotted on unmount into `carryOverBuffer` and replayed banner-free on remount.

#### 🖥️ UI correctness (`49a2282`)
- **`ClaudeConfigModal` clobbering settings** — a read failure used to fall back to `{}`; a subsequent Save then overwrote a real (unreadable) `settings.json`. A read error now shows an error panel + Retry and mounts no editor.
- **Session Timeline \"Resume\" ignored the clicked row** — it ran `--continue` in the app's cwd. `session_history` now stores `working_directory` (at insert) and `claude_session_id` (stamped when detected). Resume uses `--resume <id>` in the real cwd when known, else `--continue` in that cwd.
- **Cross-platform worktree paths** — `NewTerminalModal` / `WorktreeModal` hardcoded `\\`, producing broken paths on macOS/Linux. The separator is now derived from the repo path.

#### 📌 Audit follow-ups (`0d35160`)
Medium-severity FE/BE hygiene items from the same audit pass.

---

## Merge

Merged `origin/master` (v1.28.0 UI-polish primitives + v1.28.1 telemetry fixes) so the branch is up-to-date. Only conflict was `changelog.json` — resolved by keeping both release histories and renumbering the new preview entry to **1.29.0**.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — **273 tests pass** across 30 files (35 new preview tests: allow-list, detector, framework, store)
- [x] `cd src-tauri && cargo test` — **135 tests pass** (3 new: `PreviewProfile` round-trip, `ConfigProfile` back-compat deserialize, DB round-trip with/without preview)
- [x] `npx vite build` clean
- [x] Manual: dev app launches, session restore works, preview panel opens via `Ctrl+Alt+P` and right-side toggle
- [x] Manual: URL detected from Astro dev server (Astro landed on 4322 → panel populated)
- [x] Manual: allow-list rejects `example.com`; adding pattern in Settings unblocks it
- [x] Manual: self-preview guard shows placeholder instead of recursively iframing the app
- [x] Manual: drag-resize on the left edge, width persists across restart
- [x] Manual: F5 no longer nukes terminals — with panel open reloads the iframe, with panel closed does nothing
- [x] Manual: right-click → Refresh no longer appears in the WebView2 native menu (menu disabled entirely on Windows)
- [ ] macOS parity for the WebView2 context-menu disable — `WKWebView` needs a separate implementation. JS `contextmenu`/`beforeunload` fallback still applies there.
- [ ] Windows behavior of the direct git-spawn and `kill()` unblocking the ConPTY reader (needs manual repro from the original security work).

## Deferred (M3 — separate future PR)

Device frames (desktop/tablet/mobile CSS wrappers), back/forward navigation, dev-server network-status pill, pop-out to detached `WebviewWindow`. Full breakdown in the spec + plan; invoke `writing-plans` again against the same spec when scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)