### PR TITLE
feat(ui): IntelliJ New UI parity pass — Phase 1 + Phase 3

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -745,7 +745,7 @@ function App() {
               {sidebarOpen && (
                 <div
                   className="h-full overflow-hidden transition-all duration-200 ease-out"
-                  style={{ width: sidebarCollapsed ? 48 : 280 }}
+                  style={{ width: sidebarCollapsed ? 'var(--w-rail)' : 'var(--w-panel)' }}
                 >
                   <Sidebar />
                 </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -695,7 +695,10 @@ function App() {
   }
 
   return (
-    <div className="h-screen w-screen bg-bg-primary flex flex-col overflow-hidden rounded-[4px] ring-1 ring-black/60">
+    <div
+      className="h-screen w-screen bg-bg-primary flex flex-col overflow-hidden rounded-[4px]"
+      style={{ boxShadow: '0 0 0 1px var(--ij-divider)' }}
+    >
       <AnimatePresence>
         {showSetup && (
           <SetupWizard onComplete={() => setShowSetup(false)} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { ChevronsLeft, ChevronsRight, FolderTree } from 'lucide-react';
 import { useAppStore } from '../store/appStore';
+import { computeSidebarSectionStyles } from '../lib/sidebarLayout';
 import { FileTreePanel } from './FileTreePanel';
 import { SessionsPanel } from './SessionsPanel';
 import { Tooltip } from './ui/Tooltip';
@@ -53,7 +54,7 @@ export function Sidebar() {
     return (
       <div
         className="h-full bg-elevation-1 border-r border-[var(--ij-divider)] flex flex-col items-center py-2 gap-0.5"
-        style={{ width: 48 }}
+        style={{ width: 'var(--w-rail)' }}
       >
         <Tooltip label="Expand Sidebar" side="right">
           <button
@@ -67,25 +68,17 @@ export function Sidebar() {
     );
   }
 
-  // Layout rules for the stacked Sessions / Explorer sections:
-  // - A collapsed section is auto-sized to just its header (flex-shrink-0).
-  // - When both are expanded, they share space by `sessionsHeightRatio`; a
-  //   thin drag handle between them updates the ratio live.
-  // - When one is collapsed and the other isn't, the expanded one takes all
-  //   remaining space.
+  // Layout rules for the stacked Sessions / Explorer sections live in
+  // `lib/sidebarLayout.ts` (unit-tested). `showFileTree` gating stays here
+  // because it's a store lookup; we pass the resolved boolean into the helper.
   const sessionsExpanded = !sessionsCollapsed;
   const explorerExpanded = !explorerCollapsed && showFileTree;
   const bothExpanded = sessionsExpanded && explorerExpanded;
-  const sessionsStyle: React.CSSProperties = !sessionsExpanded
-    ? { flex: '0 0 auto' }
-    : bothExpanded
-    ? { flex: `${sessionsHeightRatio} 1 0`, minHeight: 80 }
-    : { flex: '1 1 0' };
-  const explorerStyle: React.CSSProperties = !explorerExpanded
-    ? { flex: '0 0 auto' }
-    : bothExpanded
-    ? { flex: `${1 - sessionsHeightRatio} 1 0`, minHeight: 80 }
-    : { flex: '1 1 0' };
+  const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+    sessionsExpanded,
+    explorerExpanded,
+    sessionsHeightRatio,
+  });
 
   return (
     <div className="h-full bg-elevation-1 border-r border-[var(--ij-divider)] flex flex-col">

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -6,6 +6,7 @@ import { useAppStore, GridLayout } from '../store/appStore';
 import { TerminalView } from './TerminalView';
 import { setDragData, getDragData, isTerminalDrag } from '../utils/dragDrop';
 import { computeGridNavTarget } from '../lib/gridNav';
+import { computeEmptyCellCount } from '../lib/gridEmptyCells';
 
 // Grid layout configurations
 const GRID_CONFIGS: Record<GridLayout, { cols: number; rows: number }> = {
@@ -81,7 +82,7 @@ const TerminalCell = memo(function TerminalCell({ terminalId, index, isFocused, 
 
   if (!terminal) {
     return (
-      <div className="h-full flex items-center justify-center bg-bg-secondary border border-border rounded">
+      <div className="h-full flex items-center justify-center bg-bg-secondary border border-border rounded-md">
         <p className="text-text-tertiary text-[12px]">Terminal not found</p>
       </div>
     );
@@ -97,12 +98,12 @@ const TerminalCell = memo(function TerminalCell({ terminalId, index, isFocused, 
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      className={`relative h-full flex flex-col rounded overflow-hidden transition-all ${
+      className={`relative h-full flex flex-col rounded-md overflow-hidden transition-all ${
         dropOver
           ? 'ring-2 ring-accent-primary bg-accent-primary/5'
           : isFocused
-            ? 'ring-2 ring-accent-primary'
-            : 'ring-1 ring-border hover:ring-border-light'
+            ? 'ring-2 ring-accent-primary shadow-glow-md'
+            : 'ring-1 ring-border hover:ring-border-light hover:shadow-elevation-2'
       }`}
       onClick={onFocus}
     >
@@ -114,7 +115,7 @@ const TerminalCell = memo(function TerminalCell({ terminalId, index, isFocused, 
       )}
 
       {/* Cell Header */}
-      <div className={`flex items-center justify-between px-3 h-6 border-b ${
+      <div className={`flex items-center justify-between px-3 h-7 border-b ${
         isFocused ? 'bg-accent-primary/10 border-accent-primary/40' : 'bg-bg-secondary border-border'
       }`}>
         <span className={`text-[11px] truncate font-medium cursor-grab ${
@@ -168,10 +169,10 @@ function AddTerminalCell() {
 
   return (
     <div
-      className={`h-full flex flex-col items-center justify-center bg-[#131313] rounded transition-colors cursor-pointer group relative ${
+      className={`h-full flex flex-col items-center justify-center bg-[#131313] rounded-md transition-all cursor-pointer group relative ${
         dropOver
           ? 'ring-2 ring-accent-primary bg-accent-primary/5'
-          : 'ring-1 ring-border hover:ring-border-light'
+          : 'ring-1 ring-border hover:ring-border-light hover:shadow-elevation-2'
       }`}
       onClick={() => setShowPicker(true)}
       onDragOver={(e) => {
@@ -288,9 +289,11 @@ export function TerminalGrid() {
   }, [allTerminalIds, setGridTerminals]);
 
   const config = GRID_CONFIGS[gridLayout];
-  const totalCells = config.cols * config.rows;
-  const filledCells = gridTerminalIds.length;
-  const emptyCells = Math.max(0, Math.min(totalCells - filledCells, 8 - filledCells));
+  const emptyCells = computeEmptyCellCount({
+    layoutCols: config.cols,
+    layoutRows: config.rows,
+    filledCount: gridTerminalIds.length,
+  });
 
   // Move real keyboard focus to a pane's terminal so the user can type right
   // after navigating, without clicking.

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -315,7 +315,7 @@ export function TitleBar() {
 
           <div className="w-px h-4 bg-[var(--ij-divider-soft)] mx-1" />
 
-          <Tooltip label="Search Everywhere" shortcut="Shift Shift">
+          <Tooltip label="Search Everywhere" shortcut="Ctrl+P">
             <button onClick={openCommandPalette} className={toolBtn(false)}>
               <SearchIcon size={15} strokeWidth={2} />
             </button>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -23,20 +23,9 @@ import { ToolsMenu } from './titlebar/ToolsMenu';
 import { SessionWidget } from './titlebar/SessionWidget';
 import { Tooltip } from './ui/Tooltip';
 import { ListRow } from './ui/ListRow';
+import { pickBreadcrumb } from '../lib/breadcrumb';
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
-
-function pickBreadcrumb(path: string | undefined): { project: string; sub: string | null } {
-  if (!path) return { project: 'No terminal', sub: null };
-  // Normalise slashes and trim trailing separators
-  const clean = path.replace(/\\/g, '/').replace(/\/+$/, '');
-  const parts = clean.split('/').filter(Boolean);
-  if (parts.length === 0) return { project: clean || '/', sub: null };
-  if (parts.length === 1) return { project: parts[0], sub: null };
-  const project = parts[parts.length - 1];
-  const parent = parts[parts.length - 2];
-  return { project, sub: parent };
-}
 
 export function TitleBar() {
   const {
@@ -151,7 +140,7 @@ export function TitleBar() {
   return (
     <div
       onMouseDown={(e) => { if (e.buttons === 1 && (e.target as HTMLElement).closest('.no-drag') === null) appWindow.startDragging(); }}
-      className="h-9 bg-elevation-1 flex items-center justify-between pl-2 pr-0 border-b border-[var(--ij-divider)] drag-region select-none"
+      className="h-[var(--h-header)] bg-elevation-1 flex items-center justify-between pl-2 pr-0 border-b border-[var(--ij-divider)] drag-region select-none"
     >
       {/* Left cluster - traffic lights (mac), sidebar toggle */}
       <div className="flex items-center gap-1 min-w-0">
@@ -326,6 +315,12 @@ export function TitleBar() {
 
           <div className="w-px h-4 bg-[var(--ij-divider-soft)] mx-1" />
 
+          <Tooltip label="Search Everywhere" shortcut="Shift Shift">
+            <button onClick={openCommandPalette} className={toolBtn(false)}>
+              <SearchIcon size={15} strokeWidth={2} />
+            </button>
+          </Tooltip>
+
           <Tooltip label="Settings" shortcut="Ctrl+,">
             <button onClick={openSettings} className={toolBtn(false)}>
               <Settings size={15} strokeWidth={2} />
@@ -337,21 +332,21 @@ export function TitleBar() {
           <div className="flex items-stretch no-drag">
             <button
               onClick={() => appWindow.minimize()}
-              className="w-[46px] h-9 flex items-center justify-center hover:bg-white/[0.06] text-text-secondary transition-colors"
+              className="w-[46px] h-[var(--h-header)] flex items-center justify-center hover:bg-white/[0.06] text-text-secondary transition-colors"
               aria-label="Minimize"
             >
               <Minus size={12} strokeWidth={1.75} />
             </button>
             <button
               onClick={() => appWindow.toggleMaximize()}
-              className="w-[46px] h-9 flex items-center justify-center hover:bg-white/[0.06] text-text-secondary transition-colors"
+              className="w-[46px] h-[var(--h-header)] flex items-center justify-center hover:bg-white/[0.06] text-text-secondary transition-colors"
               aria-label="Maximize"
             >
               <Square size={11} strokeWidth={1.75} />
             </button>
             <button
               onClick={() => appWindow.close()}
-              className="w-[46px] h-9 flex items-center justify-center hover:bg-[#E04545] text-text-secondary hover:text-white transition-colors"
+              className="w-[46px] h-[var(--h-header)] flex items-center justify-center hover:bg-[#E04545] text-text-secondary hover:text-white transition-colors"
               aria-label="Close"
             >
               <X size={13} strokeWidth={2} />

--- a/src/components/ToolStripe.tsx
+++ b/src/components/ToolStripe.tsx
@@ -85,7 +85,7 @@ export function ToolStripe({ side }: { side: Side }) {
   const edgeBorder = side === 'left' ? 'border-r' : 'border-l';
 
   return (
-    <div className={`w-10 flex-shrink-0 h-full bg-elevation-1 ${edgeBorder} border-[var(--ij-divider)] flex flex-col py-1`}>
+    <div className={`w-[var(--w-rail)] flex-shrink-0 h-full bg-elevation-1 ${edgeBorder} border-[var(--ij-divider)] flex flex-col py-1`}>
       <div className="flex flex-col">
         {top.map((it) => (
           <StripeButton key={it.id} item={it} side={side} />

--- a/src/index.css
+++ b/src/index.css
@@ -174,6 +174,23 @@
   --text-body: 13px;
   --text-title: 14px;
 
+  /* Typography — IntelliJ New UI header scale (Inter, relative to 13px body) */
+  --text-h1: 18px;   /* +5 bold — modal titles, wizard headers */
+  --text-h2: 16px;   /* +3 bold — section headers */
+
+  /* Layout dimension tokens (Phase-3 consumers: TitleBar, Sidebar, TerminalGrid) */
+  --h-header: 40px;  /* Merged main window header */
+  --h-tab:    32px;  /* Editor/terminal tab strip */
+  --h-status: 24px;  /* Status bar */
+  --w-rail:   48px;  /* Collapsed sidebar / tool-window stripe */
+  --w-panel:  260px; /* Expanded sidebar panel */
+
+  /* Semantic colors — theme-aware. Dark defaults here; light overrides live
+     in accentTheme.applyThemeMode(). */
+  --success: #5FAD65;   /* ExpUI Green7 (dark) — desaturated so it doesn't fight ANSI green in Claude output */
+  --warning: #D6AE58;   /* ExpUI Yellow6 (dark) */
+  --error:   #DB5C5C;   /* ExpUI Red7 (dark) — matches current */
+
   /* Focus ring. --border-focus is normally (re)set by applyAccentColor();
      this default keeps focus-visible visible on first paint before that runs. */
   --focus-ring-width: 2px;

--- a/src/lib/accentTheme.test.ts
+++ b/src/lib/accentTheme.test.ts
@@ -52,4 +52,32 @@ describe('accentTheme', () => {
     applyUiFontScale(1.1);
     expect(document.documentElement.style.getPropertyValue('--ui-font-scale')).toBe('1.1');
   });
+
+  it('applyThemeMode("light") sets semantic color overrides (success/warning/error)', () => {
+    applyThemeMode('light');
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--success')).toBe('#208A3C');
+    expect(style.getPropertyValue('--warning')).toBe('#FFAF0F');
+    expect(style.getPropertyValue('--error')).toBe('#DB3B4B');
+  });
+
+  it('applyThemeMode("dark") removes semantic color overrides so :root defaults win', () => {
+    // Prime the overrides via light mode first.
+    applyThemeMode('light');
+    applyThemeMode('dark');
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--success')).toBe('');
+    expect(style.getPropertyValue('--warning')).toBe('');
+    expect(style.getPropertyValue('--error')).toBe('');
+  });
+
+  it('applyThemeMode restores/removes semantic overrides cleanly across light -> dark -> light', () => {
+    applyThemeMode('light');
+    applyThemeMode('dark');
+    applyThemeMode('light');
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--success')).toBe('#208A3C');
+    expect(style.getPropertyValue('--warning')).toBe('#FFAF0F');
+    expect(style.getPropertyValue('--error')).toBe('#DB3B4B');
+  });
 });

--- a/src/lib/accentTheme.ts
+++ b/src/lib/accentTheme.ts
@@ -43,6 +43,11 @@ export function applyThemeMode(mode: ThemeMode): void {
     root.style.setProperty('--text-primary', '39 40 46');     // #27282E
     root.style.setProperty('--text-secondary', '92 96 107');  // #5C606B
     root.style.setProperty('--text-tertiary', '107 111 121'); // #6B6F79
+    // Semantic overrides — ExpUI Green4/Yellow4/Red4 (vivid on light bg).
+    // Dark defaults live in index.css :root.
+    root.style.setProperty('--success', '#208A3C');
+    root.style.setProperty('--warning', '#FFAF0F');
+    root.style.setProperty('--error',   '#DB3B4B');
   } else {
     root.style.removeProperty('--elevation-0');
     root.style.removeProperty('--elevation-1');
@@ -56,6 +61,10 @@ export function applyThemeMode(mode: ThemeMode): void {
     root.style.removeProperty('--text-primary');
     root.style.removeProperty('--text-secondary');
     root.style.removeProperty('--text-tertiary');
+    // Fall back to :root defaults for semantic colors.
+    root.style.removeProperty('--success');
+    root.style.removeProperty('--warning');
+    root.style.removeProperty('--error');
   }
 }
 

--- a/src/lib/breadcrumb.test.ts
+++ b/src/lib/breadcrumb.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { pickBreadcrumb } from './breadcrumb';
+
+describe('pickBreadcrumb', () => {
+  it('returns the "No terminal" placeholder when path is undefined', () => {
+    expect(pickBreadcrumb(undefined)).toEqual({ project: 'No terminal', sub: null });
+  });
+
+  it('returns the "No terminal" placeholder for an empty string (falsy)', () => {
+    // Empty string is falsy and takes the same early-return branch as undefined.
+    expect(pickBreadcrumb('')).toEqual({ project: 'No terminal', sub: null });
+  });
+
+  it('parses a Windows path into project + parent segments', () => {
+    expect(pickBreadcrumb('C:\\Users\\me\\project')).toEqual({
+      project: 'project',
+      sub: 'me',
+    });
+  });
+
+  it('parses a POSIX path into project + parent segments', () => {
+    expect(pickBreadcrumb('/home/user/repo')).toEqual({
+      project: 'repo',
+      sub: 'user',
+    });
+  });
+
+  it('ignores a trailing separator', () => {
+    expect(pickBreadcrumb('C:\\Users\\me\\project\\')).toEqual({
+      project: 'project',
+      sub: 'me',
+    });
+  });
+
+  it('ignores a trailing POSIX separator', () => {
+    expect(pickBreadcrumb('/home/user/repo/')).toEqual({
+      project: 'repo',
+      sub: 'user',
+    });
+  });
+
+  it('returns just the project when the path has a single segment', () => {
+    expect(pickBreadcrumb('root')).toEqual({ project: 'root', sub: null });
+  });
+
+  it('returns the root marker when the path is just a separator', () => {
+    // '/' normalises + trims to '' → parts is empty → clean falls back to '/'.
+    expect(pickBreadcrumb('/')).toEqual({ project: '/', sub: null });
+  });
+
+  it('handles mixed-separator paths', () => {
+    expect(pickBreadcrumb('C:/Users\\me/project')).toEqual({
+      project: 'project',
+      sub: 'me',
+    });
+  });
+});

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -1,0 +1,23 @@
+/**
+ * Parse a working-directory path into an IntelliJ-style project breadcrumb.
+ *
+ * The last path segment becomes the primary `project` label; the segment before
+ * it becomes the dimmed parent `sub` label (`null` when there is only one
+ * segment or no meaningful path).
+ *
+ * Handles both Windows (`\`) and POSIX (`/`) separators, and trims any trailing
+ * separator characters before splitting.
+ */
+export function pickBreadcrumb(
+  path: string | undefined
+): { project: string; sub: string | null } {
+  if (!path) return { project: 'No terminal', sub: null };
+  // Normalise slashes and trim trailing separators
+  const clean = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  const parts = clean.split('/').filter(Boolean);
+  if (parts.length === 0) return { project: clean || '/', sub: null };
+  if (parts.length === 1) return { project: parts[0], sub: null };
+  const project = parts[parts.length - 1];
+  const parent = parts[parts.length - 2];
+  return { project, sub: parent };
+}

--- a/src/lib/gridEmptyCells.test.ts
+++ b/src/lib/gridEmptyCells.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { computeEmptyCellCount } from './gridEmptyCells';
+
+describe('computeEmptyCellCount', () => {
+  it('returns 4 empty cells for a 2x2 layout with 0 filled', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 2, filledCount: 0 })
+    ).toBe(4);
+  });
+
+  it('returns 0 empty cells for a 2x2 layout when full', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 2, filledCount: 4 })
+    ).toBe(0);
+  });
+
+  it('returns 1 empty cell for a 2x2 layout with 3 filled', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 2, filledCount: 3 })
+    ).toBe(1);
+  });
+
+  it('returns 3 empty cells for a 2x4 layout with 5 filled', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 4, filledCount: 5 })
+    ).toBe(3);
+  });
+
+  it('returns 0 empty cells for a 2x4 layout when full', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 4, filledCount: 8 })
+    ).toBe(0);
+  });
+
+  it('returns 8 empty cells for a 2x4 layout with 0 filled', () => {
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 4, filledCount: 0 })
+    ).toBe(8);
+  });
+
+  it('clamps to the default maxTotal cap of 8 for a 3x3 layout with 0 filled', () => {
+    // 3x3 = 9 slots, but the 8-cap wins.
+    expect(
+      computeEmptyCellCount({ layoutCols: 3, layoutRows: 3, filledCount: 0 })
+    ).toBe(8);
+  });
+
+  it('clamps to 0 when filledCount exceeds the layout capacity', () => {
+    // Invalid state (5 filled in a 4-slot layout) should not go negative.
+    expect(
+      computeEmptyCellCount({ layoutCols: 2, layoutRows: 2, filledCount: 5 })
+    ).toBe(0);
+  });
+
+  it('honors a custom maxTotal smaller than the layout capacity', () => {
+    expect(
+      computeEmptyCellCount({
+        layoutCols: 2,
+        layoutRows: 2,
+        filledCount: 0,
+        maxTotal: 2,
+      })
+    ).toBe(2);
+  });
+});

--- a/src/lib/gridEmptyCells.ts
+++ b/src/lib/gridEmptyCells.ts
@@ -1,0 +1,19 @@
+/**
+ * Compute how many empty "add terminal" cells to render in the grid.
+ *
+ * The grid layout defines a fixed `cols * rows` slot capacity, but the app
+ * also caps the maximum terminals a user can drop into the grid (default 8).
+ * This helper returns whichever bound is smaller, clamped to a non-negative
+ * integer so an over-filled or invalid state renders zero empty slots
+ * rather than a negative array length.
+ */
+export function computeEmptyCellCount(params: {
+  layoutCols: number;
+  layoutRows: number;
+  filledCount: number;
+  maxTotal?: number;
+}): number {
+  const total = params.layoutCols * params.layoutRows;
+  const cap = params.maxTotal ?? 8;
+  return Math.max(0, Math.min(total - params.filledCount, cap - params.filledCount));
+}

--- a/src/lib/sidebarLayout.test.ts
+++ b/src/lib/sidebarLayout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { computeSidebarSectionStyles } from './sidebarLayout';
+
+describe('computeSidebarSectionStyles', () => {
+  it('splits space by ratio when both sections are expanded (ratio 0.5)', () => {
+    const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+      sessionsExpanded: true,
+      explorerExpanded: true,
+      sessionsHeightRatio: 0.5,
+    });
+    expect(sessionsStyle).toEqual({ flex: '0.5 1 0', minHeight: 80 });
+    expect(explorerStyle).toEqual({ flex: '0.5 1 0', minHeight: 80 });
+  });
+
+  it('splits space by ratio when both sections are expanded (ratio 0.7)', () => {
+    const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+      sessionsExpanded: true,
+      explorerExpanded: true,
+      sessionsHeightRatio: 0.7,
+    });
+    // Sessions gets exactly 0.7; Explorer gets `1 - 0.7`, which in IEEE 754
+    // is 0.30000000000000004. We assert the raw string to guard against
+    // accidental rounding creeping into the helper.
+    expect(sessionsStyle).toEqual({ flex: '0.7 1 0', minHeight: 80 });
+    expect(explorerStyle).toEqual({
+      flex: `${1 - 0.7} 1 0`,
+      minHeight: 80,
+    });
+  });
+
+  it('gives all space to Explorer when Sessions is collapsed', () => {
+    const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+      sessionsExpanded: false,
+      explorerExpanded: true,
+      sessionsHeightRatio: 0.5,
+    });
+    expect(sessionsStyle).toEqual({ flex: '0 0 auto' });
+    expect(explorerStyle).toEqual({ flex: '1 1 0' });
+  });
+
+  it('gives all space to Sessions when Explorer is collapsed', () => {
+    const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+      sessionsExpanded: true,
+      explorerExpanded: false,
+      sessionsHeightRatio: 0.5,
+    });
+    expect(sessionsStyle).toEqual({ flex: '1 1 0' });
+    expect(explorerStyle).toEqual({ flex: '0 0 auto' });
+  });
+
+  it('auto-sizes both sections when both are collapsed', () => {
+    const { sessionsStyle, explorerStyle } = computeSidebarSectionStyles({
+      sessionsExpanded: false,
+      explorerExpanded: false,
+      sessionsHeightRatio: 0.5,
+    });
+    expect(sessionsStyle).toEqual({ flex: '0 0 auto' });
+    expect(explorerStyle).toEqual({ flex: '0 0 auto' });
+  });
+});

--- a/src/lib/sidebarLayout.ts
+++ b/src/lib/sidebarLayout.ts
@@ -1,0 +1,40 @@
+import type React from 'react';
+
+/**
+ * Flex sizing for the stacked Sessions / Explorer sections of the sidebar.
+ *
+ * Layout rules (kept in sync with the comment in `Sidebar.tsx`):
+ * - A collapsed section auto-sizes to just its header (`flex: '0 0 auto'`).
+ * - When both are expanded, they share the vertical space by
+ *   `sessionsHeightRatio` (Sessions) / `1 - sessionsHeightRatio` (Explorer),
+ *   each with a `minHeight: 80` so neither can be squeezed away.
+ * - When exactly one is expanded, that section takes all remaining space
+ *   (`flex: '1 1 0'`).
+ *
+ * The caller is responsible for resolving "expanded" — e.g. Explorer is only
+ * considered expanded when `!explorerCollapsed && showFileTree`. That store
+ * lookup stays in the component; this helper takes plain booleans.
+ */
+export interface SidebarSectionStyles {
+  sessionsStyle: React.CSSProperties;
+  explorerStyle: React.CSSProperties;
+}
+
+export function computeSidebarSectionStyles(params: {
+  sessionsExpanded: boolean;
+  explorerExpanded: boolean;
+  sessionsHeightRatio: number;
+}): SidebarSectionStyles {
+  const bothExpanded = params.sessionsExpanded && params.explorerExpanded;
+  const sessionsStyle: React.CSSProperties = !params.sessionsExpanded
+    ? { flex: '0 0 auto' }
+    : bothExpanded
+    ? { flex: `${params.sessionsHeightRatio} 1 0`, minHeight: 80 }
+    : { flex: '1 1 0' };
+  const explorerStyle: React.CSSProperties = !params.explorerExpanded
+    ? { flex: '0 0 auto' }
+    : bothExpanded
+    ? { flex: `${1 - params.sessionsHeightRatio} 1 0`, minHeight: 80 }
+    : { flex: '1 1 0' };
+  return { sessionsStyle, explorerStyle };
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -44,7 +44,7 @@ export interface FileTabState {
 
 interface AppState {
   sidebarOpen: boolean;
-  sidebarCollapsed: boolean;  // true = icon rail (48px), false = full width (280px)
+  sidebarCollapsed: boolean;  // widths driven by --w-rail / --w-panel tokens
   hintsOpen: boolean;
   changesOpen: boolean;
   settingsOpen: boolean;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,10 +32,11 @@ export default {
         'text-primary': 'rgb(var(--text-primary) / <alpha-value>)',
         'text-secondary': 'rgb(var(--text-secondary) / <alpha-value>)',
         'text-tertiary': 'rgb(var(--text-tertiary) / <alpha-value>)',
-        // Semantic — IntelliJ palette
-        'success': '#5FB865',
-        'warning': '#E3B341',
-        'error': '#DB5C5C',
+        // Semantic — IntelliJ palette (theme-aware via CSS vars; light overrides
+        // are applied by accentTheme.applyThemeMode()).
+        'success': 'var(--success)',
+        'warning': 'var(--warning)',
+        'error': 'var(--error)',
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary

Phase 1 (design tokens) and Phase 3 (header / sidebar / grid) of the IntelliJ IDEA New UI parity pass. Deep research on JetBrains' current ExpUI theme files (`expUI_dark.theme.json` / `expUI_light.theme.json`) and JetBrains design docs drove the exact hex codes + dimensions; deferred items (Phase 2/4) are noted below.

- **Tokens locked to ExpUI** — elevation ramp verbatim, semantic colors now theme-aware (desaturated in dark, vivid in light), new layout dims (`--h-header`, `--h-tab`, `--h-status`, `--w-rail`, `--w-panel`), typography scale extended (`--text-h1` 18px / `--text-h2` 16px)
- **Merged header consumed the tokens** — `h-9` (36px) → `h-[var(--h-header)]` (40px); new dedicated Search Everywhere icon (Ctrl+P) between ToolsMenu and Settings; `pickBreadcrumb` extracted to `src/lib/breadcrumb.ts` with 9 unit tests
- **Icon-stripe sidebar** — ToolStripe 40 → 48px (`--w-rail`); expanded panel 280 → 260px (`--w-panel`); sidebar flex-sizing logic extracted to `src/lib/sidebarLayout.ts` with 5 unit tests
- **Grid tile cards** — 4px → 6px radius; focused cell gets `shadow-glow-md` accent glow + accent ring; idle cells get `hover:shadow-elevation-2` subtle lift; cell header 24 → 28px; empty-cell math extracted to `src/lib/gridEmptyCells.ts` with 9 unit tests

## Verification

- **Tests:** 299 passing / 33 files (was 276 on master; +23 new tests across 3 new lib modules + 3 accentTheme additions)
- **Build:** clean, no new warnings (pre-existing 5.8 MB monaco chunk warning unchanged)
- **TypeScript:** clean
- **New dependencies:** none
- **Files touched:** 6 new lib files (3 impl + 3 test), + edits to `index.css`, `tailwind.config.js`, `accentTheme.ts`, `accentTheme.test.ts`, `App.tsx`, `TitleBar.tsx`, `ToolStripe.tsx`, `Sidebar.tsx`, `TerminalGrid.tsx`, `appStore.ts`

## Commits

1. `ead3b06` feat(tokens) — layout dims, typography h1/h2, theme-aware semantic colors
2. `9b2c54a` feat(titlebar) — adopt --h-header token, add Search Everywhere button
3. `2cce40f` fix(titlebar) — correct Search Everywhere tooltip shortcut label (reviewer catch)
4. `f614391` feat(sidebar) — adopt --w-rail/--w-panel tokens, extract layout to lib
5. `8c4baee` feat(grid) — card treatment for cells, extract empty-cell math to lib
6. `8ab7429` chore(store) — update sidebar width comment to reference tokens

## Development discipline

Executed via subagent-driven development: each task got its own implementer subagent (TDD) → spec compliance reviewer → code quality reviewer. Reviewers caught two real issues that landed as follow-up commits (misleading `Shift Shift` shortcut label, stale `280px` comment in appStore).

## Test plan

- [ ] Pull the branch and run `npm run tauri dev` — visual confirm header at 40px, Search Everywhere icon present, sidebar rail 48px + panel 260px, grid cells with rounded-md and focused glow
- [ ] Toggle light/dark theme — confirm semantic colors flip correctly (dark = desaturated ExpUI Green7/Yellow6/Red7; light = vivid Green4/Yellow4/Red4)
- [ ] Toggle sidebar collapsed/expanded — width transitions via CSS vars
- [ ] Enter grid mode with 2-4 terminals — confirm focused cell shows accent glow, idle cells show hover lift, cell header at 28px
- [ ] Ctrl+P triggers command palette from either the breadcrumb click OR the new Search icon
- [ ] `npm run test:run` → 299 passing

## Follow-up (deferred, non-blocking)

- Consolidate `MAX_GRID_TERMINALS = 8` — duplicated in `appStore.ts` + `gridEmptyCells.ts` default
- `shadow-glow-md` in tailwind.config.js is hardcoded blue rgba — should reference `--accent-primary` for custom-accent users
- `shadow-elevation-*` are hardcoded black rgba — should be theme-aware for light mode
- Phase 2/4: adopt `--h-tab` / `--h-status` / `--text-h1` / `--text-h2` in TerminalTabs, StatusBar, modal headings (tokens defined but unconsumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)