### PR TITLE
feat(ui): Phase 2 — IntelliJ New UI polish (token consolidation & adoption)

### DIFF
--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -109,7 +109,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
           <div className="w-12 h-12 mx-auto mb-4 rounded-lg bg-bg-surface flex items-center justify-center">
             <Terminal size={24} className="text-text-secondary" />
           </div>
-          <h1 className="text-xl font-semibold text-text-primary mb-1">Welcome to ClaudeTerminal</h1>
+          <h1 className="text-[length:var(--text-h1)] font-semibold text-text-primary mb-1">Welcome to ClaudeTerminal</h1>
           <p className="text-text-secondary text-[13px]">Let's make sure everything is set up correctly</p>
         </div>
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -81,7 +81,7 @@ export function StatusBar() {
           <ProgressStripe />
         </div>
       )}
-      <div className="h-[22px] flex items-center justify-between pl-2 pr-1 bg-elevation-1 border-t border-[var(--ij-divider)] text-[11px] select-none">
+      <div className="h-[var(--h-status)] flex items-center justify-between pl-2 pr-1 bg-elevation-1 border-t border-[var(--ij-divider)] text-[11px] select-none">
       {/* Left side */}
       <div className="flex items-center gap-0.5">
         {/* Terminal count */}

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -171,7 +171,7 @@ export function TerminalTabs() {
     return (
       <div className="h-full flex flex-col">
         {/* Split Toolbar */}
-        <div className="h-9 bg-elevation-1 border-b border-[var(--ij-divider)] flex items-center justify-between px-3">
+        <div className="h-[var(--h-tab)] bg-elevation-1 border-b border-[var(--ij-divider)] flex items-center justify-between px-3">
           <div className="flex items-center gap-2">
             <SplitSquareHorizontal size={13} className="text-accent-primary" strokeWidth={1.75} />
             <span className="text-text-primary text-[12px] font-medium">Split View</span>
@@ -220,7 +220,7 @@ export function TerminalTabs() {
   return (
     <div className="h-full flex flex-col">
       {/* Tab Bar - IntelliJ editor tabs */}
-      <div className="h-9 bg-elevation-1 border-b border-[var(--ij-divider)] flex items-center justify-between px-0.5">
+      <div className="h-[var(--h-tab)] bg-elevation-1 border-b border-[var(--ij-divider)] flex items-center justify-between px-0.5">
         <div className="relative flex items-center flex-1 min-w-0">
           {canScrollLeft && (
             <button
@@ -281,7 +281,7 @@ export function TerminalTabs() {
                       });
                     }
                   }}
-                  className={`group relative flex items-center gap-2 px-3 h-9 text-[12px] cursor-pointer select-none transition-all duration-150 ${
+                  className={`group relative flex items-center gap-2 px-3 h-[var(--h-tab)] text-[12px] cursor-pointer select-none transition-all duration-150 ${
                     splitDropTargetId === terminal.id
                       ? 'bg-accent-primary/12 text-accent-primary'
                       : isActiveTab
@@ -433,7 +433,7 @@ export function TerminalTabs() {
                         }
                         closeFileTab(tab.path);
                       }}
-                      className={`group relative flex items-center gap-1.5 px-3 h-9 text-[12px] transition-colors flex-shrink-0 ${
+                      className={`group relative flex items-center gap-1.5 px-3 h-[var(--h-tab)] text-[12px] transition-colors flex-shrink-0 ${
                         isActive
                           ? 'bg-elevation-0 text-text-primary'
                           : 'hover:bg-white/[0.045] text-text-secondary'

--- a/src/index.css
+++ b/src/index.css
@@ -199,8 +199,8 @@
   /* Accent-derived shadow-glow tokens (Phase 2). Consumed by Tailwind's
      shadow-glow-sm / shadow-glow-md utilities. applyAccentColor() rewrites
      these from the user's chosen hex so focused surfaces glow in the current
-     accent instead of always-blue. --accent-glow (0.18) above is a distinct
-     token with different consumers — do not consolidate. */
+     accent instead of always-blue. --accent-glow (0.18), set elsewhere in
+     accentTheme.ts, is a distinct token — do not consolidate. */
   --accent-glow-sm: rgba(53, 116, 240, 0.14);
   --accent-glow-md: rgba(53, 116, 240, 0.22);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -195,6 +195,14 @@
      this default keeps focus-visible visible on first paint before that runs. */
   --focus-ring-width: 2px;
   --border-focus: rgba(53, 116, 240, 0.55);
+
+  /* Accent-derived shadow-glow tokens (Phase 2). Consumed by Tailwind's
+     shadow-glow-sm / shadow-glow-md utilities. applyAccentColor() rewrites
+     these from the user's chosen hex so focused surfaces glow in the current
+     accent instead of always-blue. --accent-glow (0.18) above is a distinct
+     token with different consumers — do not consolidate. */
+  --accent-glow-sm: rgba(53, 116, 240, 0.14);
+  --accent-glow-md: rgba(53, 116, 240, 0.22);
 }
 
 /* Standardized keyboard-focus ring (IntelliJ-style ~2px rectangle).

--- a/src/lib/accentTheme.test.ts
+++ b/src/lib/accentTheme.test.ts
@@ -25,6 +25,21 @@ describe('accentTheme', () => {
     expect(document.documentElement.style.getPropertyValue('--ij-stripe')).toBe('#abc');
   });
 
+  it('applyAccentColor derives shadow-glow-sm/md vars from the chosen accent', () => {
+    // Default IntelliJ blue.
+    applyAccentColor('#3574F0');
+    let style = document.documentElement.style;
+    expect(style.getPropertyValue('--accent-glow-sm')).toBe('rgba(53, 116, 240, 0.14)');
+    expect(style.getPropertyValue('--accent-glow-md')).toBe('rgba(53, 116, 240, 0.22)');
+
+    // A distinct accent — verify the vars actually track the input, not a
+    // hardcoded blue.
+    applyAccentColor('#22A322');
+    style = document.documentElement.style;
+    expect(style.getPropertyValue('--accent-glow-sm')).toBe('rgba(34, 163, 34, 0.14)');
+    expect(style.getPropertyValue('--accent-glow-md')).toBe('rgba(34, 163, 34, 0.22)');
+  });
+
   it('applyThemeMode toggles the data-theme attribute and elevation tokens', () => {
     applyThemeMode('light');
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');

--- a/src/lib/accentTheme.ts
+++ b/src/lib/accentTheme.ts
@@ -18,6 +18,10 @@ export function applyAccentColor(hex: string): void {
   root.style.setProperty('--ij-stripe', hex);
   root.style.setProperty('--ij-tab-underline', hex);
   root.style.setProperty('--border-focus', `rgba(${r}, ${g}, ${b}, 0.55)`);
+  // Shadow-glow tokens consumed by Tailwind's shadow-glow-sm / shadow-glow-md.
+  // Distinct from --accent-glow (0.18) — different consumers, different alphas.
+  root.style.setProperty('--accent-glow-sm', `rgba(${r}, ${g}, ${b}, 0.14)`);
+  root.style.setProperty('--accent-glow-md', `rgba(${r}, ${g}, ${b}, 0.22)`);
 }
 
 export function applyThemeMode(mode: ThemeMode): void {

--- a/src/lib/gridEmptyCells.test.ts
+++ b/src/lib/gridEmptyCells.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { computeEmptyCellCount } from './gridEmptyCells';
+import { MAX_GRID_TERMINALS, computeEmptyCellCount } from './gridEmptyCells';
+
+describe('MAX_GRID_TERMINALS', () => {
+  it('is pinned at 8', () => {
+    // Pinning this value guards against accidental drift. If the grid cap
+    // legitimately changes, update this test intentionally alongside the
+    // matching literals in the other test cases below.
+    expect(MAX_GRID_TERMINALS).toBe(8);
+  });
+});
 
 describe('computeEmptyCellCount', () => {
   it('returns 4 empty cells for a 2x2 layout with 0 filled', () => {

--- a/src/lib/gridEmptyCells.ts
+++ b/src/lib/gridEmptyCells.ts
@@ -1,3 +1,6 @@
+/** Hard cap on how many terminals can be placed in grid mode. */
+export const MAX_GRID_TERMINALS = 8;
+
 /**
  * Compute how many empty "add terminal" cells to render in the grid.
  *
@@ -14,6 +17,6 @@ export function computeEmptyCellCount(params: {
   maxTotal?: number;
 }): number {
   const total = params.layoutCols * params.layoutRows;
-  const cap = params.maxTotal ?? 8;
+  const cap = params.maxTotal ?? MAX_GRID_TERMINALS;
   return Math.max(0, Math.min(total - params.filledCount, cap - params.filledCount));
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
 import type { TerminalThemeName } from '../lib/terminalThemes';
+import { MAX_GRID_TERMINALS } from '../lib/gridEmptyCells';
 
 export type TerminalCursorStyle = 'bar' | 'block' | 'underline';
 export type TerminalScrollbarMode = 'auto-hide' | 'always' | 'hidden';
@@ -901,7 +902,7 @@ export const useAppStore = create<AppState>()(
       setGridMode: (enabled) => set({ gridMode: enabled }),
       addToGrid: (terminalId) => set((state) => {
         if (state.gridTerminalIds.includes(terminalId)) return state;
-        if (state.gridTerminalIds.length >= 8) return state;
+        if (state.gridTerminalIds.length >= MAX_GRID_TERMINALS) return state;
         const newIds = [...state.gridTerminalIds, terminalId];
         return {
           gridTerminalIds: newIds,
@@ -919,8 +920,8 @@ export const useAppStore = create<AppState>()(
         };
       }),
       setGridTerminals: (terminalIds) => set({
-        gridTerminalIds: terminalIds.slice(0, 8),
-        gridLayout: getOptimalLayout(Math.min(terminalIds.length, 8)),
+        gridTerminalIds: terminalIds.slice(0, MAX_GRID_TERMINALS),
+        gridLayout: getOptimalLayout(Math.min(terminalIds.length, MAX_GRID_TERMINALS)),
       }),
       setGridLayout: (layout) => set({ gridLayout: layout }),
       setGridFocusedIndex: (index) => set({ gridFocusedIndex: index }),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,8 +43,10 @@ export default {
         mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
       },
       boxShadow: {
-        'glow-sm': '0 0 8px rgba(53, 116, 240, 0.14)',
-        'glow-md': '0 0 16px rgba(53, 116, 240, 0.22)',
+        // Accent-aware — derived vars are (re)set by applyAccentColor() so the
+        // glow follows the user's chosen accent instead of hardcoded blue.
+        'glow-sm': '0 0 8px var(--accent-glow-sm)',
+        'glow-md': '0 0 16px var(--accent-glow-md)',
         'elevation-2': '0 1px 2px rgba(0, 0, 0, 0.35)',
         'elevation-3': '0 4px 12px rgba(0, 0, 0, 0.45)',
         'elevation-4': '0 8px 28px rgba(0, 0, 0, 0.55)',


### PR DESCRIPTION
## Summary

Follow-up to [PR #42](https://github.com/talayash/claude-terminal/pull/42) (v1.30.0). Closes the three deferred concerns from Phase 1's final code review + adopts the remaining tokens defined-but-unconsumed in Phase 1.

- **Magic-8 consolidated** — `MAX_GRID_TERMINALS` exported from `src/lib/gridEmptyCells.ts`, imported in appStore.ts; the constant is now the single source of truth for the grid-mode cap
- **`shadow-glow` accent-aware** — CSS vars `--accent-glow-sm` / `--accent-glow-md` derive from the user's chosen accent in `applyAccentColor()`; focused grid cells glow in the correct color instead of always-blue
- **Token adoption completed for the four primary bars** — `--h-tab` in TerminalTabs (4 sites, 36 → 32px), `--h-status` in StatusBar (22 → 24px), `--text-h1` in SetupWizard welcome heading (20 → 18px)

## Verification

- **Tests:** 301 passing / 33 files (was 299 on master; +2 new — MAX_GRID_TERMINALS value pin + shadow-glow accent derivation)
- **Build:** clean, no new warnings
- **TypeScript:** clean
- **New dependencies:** none

## Commits

1. `23c913d` refactor(grid) — extract MAX_GRID_TERMINALS constant to eliminate magic-8
2. `58151c2` feat(theme) — accent-aware shadow-glow tokens
3. `e0a6e74` feat(tabs) — adopt --h-tab token in TerminalTabs
4. `3cb3763` feat(tokens) — adopt --h-status in StatusBar, --text-h1 in SetupWizard
5. `9c05fa8` chore(tokens) — fix comment (reviewer M4 nit)

## Development discipline

Executed via subagent-driven development (same pattern as PR #42). Each task got its own implementer subagent with a focused brief; spec compliance verified for Task A separately; per-task code-quality reviews batched into a single final-branch review to keep momentum on trivial (< 50-LOC) tasks. Final reviewer surfaced 4 minor observations (M1–M4); only M4 (a one-word comment fix) was addressed inline as commit 5. M1–M3 are non-blocking dead-code observations queued for Phase 3.

## Visible changes for testers

- Tab strip 4px shorter (36 → 32px)
- Status bar 2px taller (22 → 24px)
- Setup wizard welcome heading 2px smaller (20 → 18px)
- Focused grid cell glow color matches user's accent (was always-blue)

## Test plan

- [ ] `npm run tauri dev` — visually confirm tab strip feels tighter (32px), status bar has more breathing room (24px)
- [ ] Set a non-default accent (Settings → Appearance → Accent Color) → toggle grid view → focused cell should glow in the chosen color, not blue
- [ ] Run setup wizard (delete `~/.claudeterminal` config or trigger via dev URL) → welcome heading should be 18px, still clearly hierarchical against 13px body
- [ ] `npm run test:run` → 301 passing

## Follow-up (deferred for Phase 3)

- **FU1** — `--accent-glow` (0.18) is dead code: set on every accent change, no `src/` consumer. Wire up to a real UI surface OR remove
- **FU2** — `--text-h2` (16px) has no natural consumer yet. Audit modals (`ProfileModal`, `SettingsModal`, `ClaudeConfigModal`, `NewTerminalModal`, `WhatsNewModal`) for section headers currently sized 14–15px `font-medium`; adopt or delete the token
- **FU3** — `shadow-glow-sm` derived but unread (Task B added derivation symmetrically with md). Keep for symmetry unless FU1 audit removes both
- **FU4** — Phase 4 tab work: pinned tab semantics, "Show Hidden Tabs" overflow chevron with count badge, user-selectable tab height (Small/Medium/Large)
- **FU5** — `shadow-elevation-*` still hardcoded black rgba; needs light-mode theme-awareness pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)