### PR TITLE
feat(tabs): pinned tabs — Phase 4a of IntelliJ New UI pass

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { getWindowMode } from './lib/windowMode';
 import { DragPreview } from './components/DragPreview';
 import { WebviewWindow, getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { installTransferReceiver, requestTransfer, restoreDetachedWindow } from './lib/tabTransfer';
+import { filterLivePins } from './lib/pinnedTabs';
 import { keyOf, upsertEntry, removeEntry, getDetachedEntries, currentGeometry } from './lib/windowLayout';
 import { planRestoreModes } from './lib/restorePlan';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -221,6 +222,29 @@ function App() {
   // openFiles / lspEnabled changes and wires diagnostics events to Monaco.
   useEffect(() => {
     initLsp();
+  }, []);
+
+  // Ghost-pin GC. Session restore is user-triggered (banner click) and
+  // restored terminals get fresh UUIDs from Uuid::new_v4() in Rust, so 100%
+  // of persisted pinned ids are ghosts after app restart. The mount pass
+  // below catches:
+  //   - the "user dismisses the restore banner" case (no terminals ever
+  //     get the old ids)
+  //   - the detached-window adoption case
+  //   - the "session save was empty" case
+  // The restore-completion pass at the end of `handleRestore` catches the
+  // "user restored terminals" case, where new terminals have been added
+  // with fresh ids and every persisted pin is now a ghost.
+  // Ghost pins are silently ignored by the tab-order helpers, so this is
+  // purely a persistence-hygiene fix — the pinnedTabIds array would
+  // otherwise grow unbounded across sessions.
+  useEffect(() => {
+    const { pinnedTabIds, unpinTab } = useAppStore.getState();
+    const live = useTerminalStore.getState().terminals;
+    const survivors = new Set(filterLivePins(pinnedTabIds, live.keys()));
+    for (const id of pinnedTabIds) {
+      if (!survivors.has(id)) unpinTab(id);
+    }
   }, []);
 
   // Telemetry heartbeat - fire on startup then every 5 minutes
@@ -670,6 +694,18 @@ function App() {
       }
     } catch (err) {
       console.error('Failed to restore detached windows:', err);
+    }
+
+    // Ghost-pin GC after restore. Restored terminals got fresh UUIDs above,
+    // so every id in pinnedTabIds from the previous session is now a ghost.
+    // Drop them so the persisted list doesn't grow unbounded across sessions.
+    // (Mirrors the mount-time GC — this pass catches the case where restore
+    // actually created terminals with new ids that never match the old pins.)
+    const { pinnedTabIds, unpinTab } = useAppStore.getState();
+    const live = useTerminalStore.getState().terminals;
+    const survivors = new Set(filterLivePins(pinnedTabIds, live.keys()));
+    for (const id of pinnedTabIds) {
+      if (!survivors.has(id)) unpinTab(id);
     }
 
     toast.success('Session Restored', `${pendingRestoreConfigs.length} terminal${pendingRestoreConfigs.length !== 1 ? 's' : ''} restored.`);

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon, Pin } from 'lucide-react';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon, Pin, PinOff } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -21,9 +21,16 @@ import { useTabDrag } from '../hooks/useTabDrag';
 import { getWindowMode } from '../lib/windowMode';
 import { getLastOutputAt } from '../lib/terminalActivity';
 import { orderTabsPinnedFirst } from '../lib/pinnedTabOrder';
+import { idsToCloseForOthers, idsToCloseForAllButPinned } from '../lib/closeTabActions';
 import { StateDot } from './StateDot';
 import { Tooltip } from './ui/Tooltip';
 import type { SessionState } from '../lib/terminalState';
+
+interface TabContextMenuState {
+  x: number;
+  y: number;
+  terminalId: string;
+}
 
 function fileBasename(p: string): string {
   const trimmed = p.replace(/[\\/]+$/, '');
@@ -43,6 +50,8 @@ export function TerminalTabs() {
   const { terminals, activeTerminalId, closeTerminal, unreadTerminalIds, gitInfoCache, scriptChildren, closeScript } = useTerminalStore();
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree, showTabActivity } = useAppStore();
   const pinnedTabIds = useAppStore((s) => s.pinnedTabIds);
+  const toggleTabPin = useAppStore((s) => s.toggleTabPin);
+  const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
   const now = useNowTick();
   const terminalStates = useTerminalStore((s) => s.terminalStates);
   const justFinishedAt = useTerminalStore((s) => s.justFinishedAt);
@@ -115,6 +124,50 @@ export function TerminalTabs() {
       setSplitMode(true);
     }
   };
+
+  // Wrap `closeTerminal` in the same toast-on-failure / telemetry pattern the
+  // rest of the tab strip already uses (see the × button, middle-click close).
+  // Used by the context menu's Close / Close Others / Close All But Pinned.
+  const closeTerminalWithReport = useCallback((id: string) => {
+    closeTerminal(id).catch((err) => {
+      toast.error('Close failed', 'Could not close the terminal.');
+      reportInvokeFailure('close_terminal', err);
+    });
+  }, [closeTerminal]);
+
+  const openTabContextMenu = useCallback((e: React.MouseEvent, terminalId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Clamp against the viewport so the menu doesn't overflow when the
+    // right-click lands near the right or bottom edge. Numbers mirror the
+    // SessionsPanel pattern — a slight over-estimate is fine, the CSS
+    // min-width keeps the menu readable.
+    const margin = 4;
+    const menuWidth = 220;
+    const menuHeight = 200;
+    const x = Math.min(e.clientX, window.innerWidth - menuWidth - margin);
+    const y = Math.min(e.clientY, window.innerHeight - menuHeight - margin);
+    setContextMenu({ x: Math.max(margin, x), y: Math.max(margin, y), terminalId });
+  }, []);
+
+  // Close the tab context menu on outside click / Escape.
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && target.closest('[data-context-menu="terminal-tabs"]')) return;
+      setContextMenu(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null);
+    };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [contextMenu]);
 
   const { createTerminal } = useTerminalStore();
   const handleDuplicate = (terminalId: string) => {
@@ -297,6 +350,7 @@ export function TerminalTabs() {
                       });
                     }
                   }}
+                  onContextMenu={(e) => openTabContextMenu(e, terminal.id)}
                   className={`group relative flex items-center gap-2 px-3 h-9 text-[12px] cursor-pointer select-none transition-all duration-150 ${
                     splitDropTargetId === terminal.id
                       ? 'bg-accent-primary/12 text-accent-primary'
@@ -642,7 +696,85 @@ export function TerminalTabs() {
         )}
       </div>
 
+      {contextMenu && (() => {
+        const ctxId = contextMenu.terminalId;
+        const isPinned = pinnedTabIds.includes(ctxId);
+        // Terminal-store insertion order is the source of truth for "all
+        // terminals" — we deliberately don't reuse `terminalList` here (which
+        // has the pinned-first re-order applied), because bulk-close acts on
+        // the store, not on the rendered ordering. Filter out script-child /
+        // shell terminals for the same reason `terminalList` does: those are
+        // rendered elsewhere and shouldn't be touched by the tab-strip menu.
+        const allTabIds = Array.from(terminals.values())
+          .filter((t) => !t.scriptParentId && !t.isShellTerminal)
+          .map((t) => t.config.id);
+        return (
+          <div
+            role="menu"
+            data-context-menu="terminal-tabs"
+            className="fixed z-[80] min-w-[220px] bg-bg-elevated ring-1 ring-white/[0.08] rounded-md py-1 select-none"
+            style={{ left: contextMenu.x, top: contextMenu.y }}
+          >
+            <TabMenuItem
+              icon={isPinned ? <PinOff size={13} strokeWidth={1.75} /> : <Pin size={13} strokeWidth={1.75} />}
+              label={isPinned ? 'Unpin' : 'Pin'}
+              onClick={() => { setContextMenu(null); toggleTabPin(ctxId); }}
+            />
+            <div className="my-1 border-t border-white/[0.06]" />
+            <TabMenuItem
+              icon={<X size={13} strokeWidth={1.75} />}
+              label="Close"
+              onClick={() => { setContextMenu(null); closeTerminalWithReport(ctxId); }}
+            />
+            <TabMenuItem
+              icon={<X size={13} strokeWidth={1.75} />}
+              label="Close Others"
+              disabled={allTabIds.length <= 1}
+              onClick={() => {
+                setContextMenu(null);
+                idsToCloseForOthers(allTabIds, ctxId).forEach(closeTerminalWithReport);
+              }}
+            />
+            <TabMenuItem
+              icon={<X size={13} strokeWidth={1.75} />}
+              label="Close All But Pinned"
+              disabled={idsToCloseForAllButPinned(allTabIds, pinnedTabIds).length === 0}
+              onClick={() => {
+                setContextMenu(null);
+                idsToCloseForAllButPinned(allTabIds, pinnedTabIds).forEach(closeTerminalWithReport);
+              }}
+            />
+          </div>
+        );
+      })()}
+
       <BottomTerminalPane />
     </div>
+  );
+}
+
+interface TabMenuItemProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function TabMenuItem({ icon, label, onClick, disabled }: TabMenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-left text-[12px] transition-colors ${
+        disabled
+          ? 'text-text-tertiary/50 cursor-not-allowed'
+          : 'text-text-primary hover:bg-white/[0.06]'
+      }`}
+    >
+      <span className={disabled ? 'opacity-50' : 'text-text-tertiary'}>{icon}</span>
+      <span className="flex-1">{label}</span>
+    </button>
   );
 }

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon } from 'lucide-react';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon, Pin } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -20,6 +20,7 @@ import { useNowTick } from '../hooks/useNowTick';
 import { useTabDrag } from '../hooks/useTabDrag';
 import { getWindowMode } from '../lib/windowMode';
 import { getLastOutputAt } from '../lib/terminalActivity';
+import { orderTabsPinnedFirst } from '../lib/pinnedTabOrder';
 import { StateDot } from './StateDot';
 import { Tooltip } from './ui/Tooltip';
 import type { SessionState } from '../lib/terminalState';
@@ -41,6 +42,7 @@ const isMac = navigator.platform.toUpperCase().includes('MAC');
 export function TerminalTabs() {
   const { terminals, activeTerminalId, closeTerminal, unreadTerminalIds, gitInfoCache, scriptChildren, closeScript } = useTerminalStore();
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree, showTabActivity } = useAppStore();
+  const pinnedTabIds = useAppStore((s) => s.pinnedTabIds);
   const now = useNowTick();
   const terminalStates = useTerminalStore((s) => s.terminalStates);
   const justFinishedAt = useTerminalStore((s) => s.justFinishedAt);
@@ -56,12 +58,26 @@ export function TerminalTabs() {
   // Script-child terminals are rendered below their parent and bottom-pane
   // shells are rendered in BottomTerminalPane - neither belongs in the main
   // tab bar.
+  //
+  // Pinned tabs are re-ordered to the front of the strip via
+  // `orderTabsPinnedFirst` while the terminal store's insertion order stays
+  // untouched — pinning is a render-only concern. Drag-reorder still writes to
+  // the store via `reorderTerminals`, and the pinned-first partition is
+  // re-applied on next render, so dragging can't move a tab across the
+  // pinned/unpinned boundary visually.
   const terminalList = useMemo(
-    () =>
-      Array.from(terminals.values())
+    () => {
+      const configs = Array.from(terminals.values())
         .filter((t) => !t.scriptParentId && !t.isShellTerminal)
-        .map((t) => t.config),
-    [terminals]
+        .map((t) => t.config);
+      if (pinnedTabIds.length === 0) return configs;
+      const byId = new Map(configs.map((c) => [c.id, c] as const));
+      const orderedIds = orderTabsPinnedFirst(configs.map((c) => c.id), pinnedTabIds);
+      return orderedIds
+        .map((id) => byId.get(id))
+        .filter((c): c is NonNullable<typeof c> => c != null);
+    },
+    [terminals, pinnedTabIds]
   );
 
   // Slide-aside preview order: while dragging, the dragged tab(s) are pulled out
@@ -341,6 +357,9 @@ export function TerminalTabs() {
                     <Tooltip label={`Loop: ${loopInfo.interval}`}>
                       <span className="w-2 h-2 rounded-full bg-purple-400 animate-pulse flex-shrink-0" />
                     </Tooltip>
+                  )}
+                  {pinnedTabIds.includes(terminal.id) && (
+                    <Pin size={10} className="text-accent-primary flex-shrink-0" />
                   )}
                   <span className="max-w-[120px] truncate">{terminal.nickname || terminal.label}</span>
                   {gitInfoCache.get(terminal.id)?.current_branch && (

--- a/src/lib/closeTabActions.test.ts
+++ b/src/lib/closeTabActions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { idsToCloseForOthers, idsToCloseForAllButPinned } from './closeTabActions';
+
+describe('idsToCloseForOthers', () => {
+  it('returns every id except the kept one, preserving order', () => {
+    expect(idsToCloseForOthers(['a', 'b', 'c', 'd'], 'b')).toEqual(['a', 'c', 'd']);
+  });
+
+  it('returns empty array when the kept id is the only tab', () => {
+    expect(idsToCloseForOthers(['only'], 'only')).toEqual([]);
+  });
+
+  it('returns empty array for empty tabIds', () => {
+    expect(idsToCloseForOthers([], 'anything')).toEqual([]);
+  });
+
+  it('returns all ids unchanged when keepId is not in the list (defensive)', () => {
+    // If the right-clicked tab has already been closed by the time the user
+    // clicks the menu item, "close all except that one" collapses to
+    // "close everything left".
+    expect(idsToCloseForOthers(['a', 'b', 'c'], 'gone')).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('idsToCloseForAllButPinned', () => {
+  it('returns only ids not in pinnedIds, preserving order', () => {
+    expect(idsToCloseForAllButPinned(['a', 'b', 'c', 'd'], ['b', 'd'])).toEqual(['a', 'c']);
+  });
+
+  it('returns every id when nothing is pinned', () => {
+    expect(idsToCloseForAllButPinned(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty array when every id is pinned', () => {
+    expect(idsToCloseForAllButPinned(['a', 'b', 'c'], ['a', 'b', 'c'])).toEqual([]);
+  });
+
+  it('returns empty array for empty tabIds', () => {
+    expect(idsToCloseForAllButPinned([], ['a'])).toEqual([]);
+    expect(idsToCloseForAllButPinned([], [])).toEqual([]);
+  });
+
+  it('silently ignores pinned ids that are not in tabIds (stale pin state)', () => {
+    // A pinned id may reference a terminal that no longer exists — the
+    // helper shouldn't crash or produce ghost entries.
+    expect(idsToCloseForAllButPinned(['a', 'b'], ['a', 'ghost'])).toEqual(['b']);
+  });
+});

--- a/src/lib/closeTabActions.ts
+++ b/src/lib/closeTabActions.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure selectors for the "Close Others" / "Close All But Pinned" bulk-close
+ * context menu actions on the terminal tab strip.
+ *
+ * Kept out of the component so the filtering logic is trivially
+ * unit-testable — the component just maps the result through the store's
+ * existing `closeTerminal(id)` mechanism.
+ *
+ * Neither helper closes anything itself; they return the id list the caller
+ * should iterate and pass to `closeTerminal`. This keeps them free of any
+ * Zustand / IPC coupling.
+ */
+
+/**
+ * Ids to close when the user picks "Close Others" on the tab whose id is
+ * `keepId`. Returns every id in `tabIds` except `keepId`, preserving the
+ * caller's order. If `keepId` isn't in `tabIds` (stale menu, defensive),
+ * every id is returned — mirrors the user's intent ("close all except this
+ * one") since the "this one" is already gone.
+ */
+export function idsToCloseForOthers(
+  tabIds: readonly string[],
+  keepId: string,
+): string[] {
+  return tabIds.filter((id) => id !== keepId);
+}
+
+/**
+ * Ids to close when the user picks "Close All But Pinned". Returns every id
+ * in `tabIds` that is NOT in `pinnedIds`. Preserves `tabIds` order.
+ */
+export function idsToCloseForAllButPinned(
+  tabIds: readonly string[],
+  pinnedIds: readonly string[],
+): string[] {
+  const pinned = new Set(pinnedIds);
+  return tabIds.filter((id) => !pinned.has(id));
+}

--- a/src/lib/pinnedTabOrder.test.ts
+++ b/src/lib/pinnedTabOrder.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { orderTabsPinnedFirst } from './pinnedTabOrder';
+
+describe('orderTabsPinnedFirst', () => {
+  it('returns tabIds unchanged when no tabs are pinned', () => {
+    expect(orderTabsPinnedFirst(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns tabIds unchanged when all tabs are pinned (all in pinned block, same order)', () => {
+    expect(orderTabsPinnedFirst(['a', 'b', 'c'], ['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('partitions mixed pinned + unpinned, preserving intra-group insertion order', () => {
+    // Pinned: a, c, e. Unpinned: b, d. Insertion order preserved within each group.
+    expect(orderTabsPinnedFirst(['a', 'b', 'c', 'd', 'e'], ['a', 'c', 'e'])).toEqual([
+      'a',
+      'c',
+      'e',
+      'b',
+      'd',
+    ]);
+  });
+
+  it('ignores pinnedIds order — final order follows tabIds insertion order', () => {
+    // pinnedIds says c-then-a, but result is a-then-c because 'a' comes first in tabIds.
+    expect(orderTabsPinnedFirst(['a', 'b', 'c', 'd', 'e'], ['c', 'a'])).toEqual([
+      'a',
+      'c',
+      'b',
+      'd',
+      'e',
+    ]);
+  });
+
+  it('silently ignores pinned ids that are not in tabIds (no error, no ghost entry)', () => {
+    expect(orderTabsPinnedFirst(['a', 'b'], ['a', 'ghost', 'zzz'])).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array for empty tabIds', () => {
+    expect(orderTabsPinnedFirst([], ['a', 'b'])).toEqual([]);
+    expect(orderTabsPinnedFirst([], [])).toEqual([]);
+  });
+
+  it('returns tabIds unchanged when pinnedIds is empty', () => {
+    expect(orderTabsPinnedFirst(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is defensive against duplicate pin ids — treats [a, a] the same as [a]', () => {
+    // Even if pinnedIds contains duplicates, each tab id only appears once
+    // in the result (based on its single occurrence in tabIds).
+    expect(orderTabsPinnedFirst(['a', 'b', 'c'], ['a', 'a'])).toEqual(['a', 'b', 'c']);
+    expect(orderTabsPinnedFirst(['a', 'b', 'c'], ['b', 'b'])).toEqual(['b', 'a', 'c']);
+  });
+});

--- a/src/lib/pinnedTabOrder.ts
+++ b/src/lib/pinnedTabOrder.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helper for rendering a tab strip with pinned tabs first.
+ *
+ * Kept separate from `pinnedTabs.ts` (which is add/remove/toggle) because
+ * ordering is a distinct concern — the tab-strip needs a stable "pinned
+ * block, then everything else" view without touching the underlying
+ * insertion-order source of truth.
+ */
+
+/**
+ * Reorder a list of tab ids so pinned tabs come first, preserving each
+ * group's original insertion order. Ids not in `pinnedIds` retain their
+ * original relative order after the pinned block.
+ *
+ * The order of `pinnedIds` is intentionally ignored — only `tabIds`
+ * insertion order drives the final sequence. This matches how users
+ * perceive tab pinning: pinning doesn't rearrange, it just partitions.
+ *
+ * Silently ignores ids in `pinnedIds` that aren't in `tabIds` (defensive
+ * against stale pin state after tab close) and duplicate pin ids.
+ *
+ * Example:
+ *   tabIds     = ['a', 'b', 'c', 'd', 'e']
+ *   pinnedIds  = ['c', 'a']  // (pin order doesn't matter — insertion order wins)
+ *   result     = ['a', 'c', 'b', 'd', 'e']
+ */
+export function orderTabsPinnedFirst(
+  tabIds: readonly string[],
+  pinnedIds: readonly string[],
+): string[] {
+  const pinSet = new Set(pinnedIds);
+  const pinned: string[] = [];
+  const unpinned: string[] = [];
+  for (const id of tabIds) {
+    (pinSet.has(id) ? pinned : unpinned).push(id);
+  }
+  return [...pinned, ...unpinned];
+}

--- a/src/lib/pinnedTabs.test.ts
+++ b/src/lib/pinnedTabs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { addPin, removePin, togglePin } from './pinnedTabs';
+import { addPin, filterLivePins, removePin, togglePin } from './pinnedTabs';
 
 describe('pinnedTabs helpers', () => {
   it('addPin adds id if not present, no-op if already pinned', () => {
@@ -32,5 +32,37 @@ describe('pinnedTabs helpers', () => {
     // Pinned → unpinned.
     expect(togglePin(['a', 'b'], 'a')).toEqual(['b']);
     expect(togglePin(['a'], 'a')).toEqual([]);
+  });
+
+  describe('filterLivePins', () => {
+    it('returns unchanged list when all pins are live', () => {
+      expect(filterLivePins(['a', 'b', 'c'], ['a', 'b', 'c', 'd'])).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns [] when all pins are ghosts (restart case)', () => {
+      // After app restart every persisted pinned id is a ghost because
+      // restored terminals get fresh UUIDs from Uuid::new_v4() in Rust.
+      expect(filterLivePins(['old-1', 'old-2'], ['new-1', 'new-2'])).toEqual([]);
+    });
+
+    it('keeps only live ids and preserves original order', () => {
+      expect(filterLivePins(['a', 'ghost', 'b', 'gone', 'c'], ['c', 'a', 'b']))
+        .toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns [] when pins are empty', () => {
+      expect(filterLivePins([], ['a', 'b'])).toEqual([]);
+    });
+
+    it('returns [] when live set is empty', () => {
+      expect(filterLivePins(['a', 'b'], [])).toEqual([]);
+    });
+
+    it('accepts a Map keys iterator (terminals.keys())', () => {
+      // The startup GC feeds it useTerminalStore.getState().terminals.keys(),
+      // so verify the Iterable<string> signature actually works with a Map.
+      const terminals = new Map<string, unknown>([['a', {}], ['c', {}]]);
+      expect(filterLivePins(['a', 'ghost', 'c'], terminals.keys())).toEqual(['a', 'c']);
+    });
   });
 });

--- a/src/lib/pinnedTabs.test.ts
+++ b/src/lib/pinnedTabs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { addPin, removePin, togglePin } from './pinnedTabs';
+
+describe('pinnedTabs helpers', () => {
+  it('addPin adds id if not present, no-op if already pinned', () => {
+    // Adds when absent.
+    expect(addPin([], 'a')).toEqual(['a']);
+    expect(addPin(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+
+    // No-op when already pinned — same array reference so shallow-equal
+    // selectors can short-circuit.
+    const pinned = ['a', 'b'];
+    expect(addPin(pinned, 'a')).toBe(pinned);
+  });
+
+  it('unpinTab (removePin) removes id if present, no-op if absent', () => {
+    // Removes when present.
+    expect(removePin(['a', 'b', 'c'], 'b')).toEqual(['a', 'c']);
+    expect(removePin(['a'], 'a')).toEqual([]);
+
+    // No-op when absent — content unchanged (filter still returns a fresh
+    // array, but callers compare by value here).
+    expect(removePin(['a', 'b'], 'missing')).toEqual(['a', 'b']);
+    expect(removePin([], 'anything')).toEqual([]);
+  });
+
+  it('togglePin flips: unpinned → pinned, pinned → unpinned', () => {
+    // Unpinned → pinned.
+    expect(togglePin([], 'a')).toEqual(['a']);
+    expect(togglePin(['a'], 'b')).toEqual(['a', 'b']);
+
+    // Pinned → unpinned.
+    expect(togglePin(['a', 'b'], 'a')).toEqual(['b']);
+    expect(togglePin(['a'], 'a')).toEqual([]);
+  });
+});

--- a/src/lib/pinnedTabs.ts
+++ b/src/lib/pinnedTabs.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure helpers for managing the pinned-tabs id list.
+ *
+ * Kept out of the store so the toggling logic is trivially unit-testable
+ * without hydrating Zustand. Callers (see `appStore.ts`) feed the current
+ * `pinnedTabIds` array in and set the result back — no in-place mutation,
+ * so React/Zustand change detection is preserved.
+ */
+
+/** Add `id` to the list if not already present. Returns the same array
+ *  reference on no-op so shallow equality checks in selectors can short-circuit. */
+export function addPin(pinnedIds: string[], id: string): string[] {
+  return pinnedIds.includes(id) ? pinnedIds : [...pinnedIds, id];
+}
+
+/** Remove `id` from the list. Filter always returns a new array, but callers
+ *  should treat a no-op remove (id absent) as harmless. */
+export function removePin(pinnedIds: string[], id: string): string[] {
+  return pinnedIds.filter((x) => x !== id);
+}
+
+/** Flip pinned state: pinned → unpinned, unpinned → pinned. */
+export function togglePin(pinnedIds: string[], id: string): string[] {
+  return pinnedIds.includes(id) ? removePin(pinnedIds, id) : addPin(pinnedIds, id);
+}

--- a/src/lib/pinnedTabs.ts
+++ b/src/lib/pinnedTabs.ts
@@ -23,3 +23,15 @@ export function removePin(pinnedIds: string[], id: string): string[] {
 export function togglePin(pinnedIds: string[], id: string): string[] {
   return pinnedIds.includes(id) ? removePin(pinnedIds, id) : addPin(pinnedIds, id);
 }
+
+/**
+ * Drop any pinned ids that don't map to a currently-live terminal. Used by
+ * the startup GC in App.tsx after session restore, since restored terminals
+ * get fresh UUIDs (`Uuid::new_v4()` in Rust) and 100% of persisted pinned
+ * ids are ghosts after app restart. Order is preserved so the surviving
+ * pins keep their relative positions.
+ */
+export function filterLivePins(pinnedIds: string[], liveIds: Iterable<string>): string[] {
+  const live = new Set(liveIds);
+  return pinnedIds.filter((id) => live.has(id));
+}

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -405,6 +405,8 @@ describe('appStore - persist partialize', () => {
     // Claude (NEW v1.22.0)
     'claudeDefaultModel',
     'claudeBinaryPathOverride',
+    // Pinned tabs (Phase 4a)
+    'pinnedTabIds',
   ].sort();
 
   it('persists exactly the allow-listed keys, and no transient ones', () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
 import type { TerminalThemeName } from '../lib/terminalThemes';
+import { addPin, removePin, togglePin } from '../lib/pinnedTabs';
 
 export type TerminalCursorStyle = 'bar' | 'block' | 'underline';
 export type TerminalScrollbarMode = 'auto-hide' | 'always' | 'hidden';
@@ -171,6 +172,15 @@ interface AppState {
   gridTerminalIds: string[];
   gridLayout: GridLayout;
   gridFocusedIndex: number | null;
+
+  // Pinned tabs — persist by id so relaunched sessions stay pinned across app restarts.
+  // Terminals themselves are ephemeral; pins are just intent-preserving metadata.
+  // Bulk close actions (Close Others, Close All But Pinned) live in the tab
+  // context-menu logic, not the store — see Task D.
+  pinnedTabIds: string[];
+  pinTab: (id: string) => void;
+  unpinTab: (id: string) => void;
+  toggleTabPin: (id: string) => void;
 
   // Command Palette (F1)
   commandPaletteOpen: boolean;
@@ -559,6 +569,10 @@ export const useAppStore = create<AppState>()(
       gridLayout: '1x1',
       gridFocusedIndex: null,
 
+      // Pinned tabs — id list only; terminals themselves remain ephemeral in
+      // terminalStore. See src/lib/pinnedTabs.ts for the pure helpers.
+      pinnedTabIds: [],
+
       // Command Palette (F1)
       commandPaletteOpen: false,
       paletteUsage: {},
@@ -944,6 +958,12 @@ export const useAppStore = create<AppState>()(
         return { gridTerminalIds: newIds };
       }),
 
+      // Pinned-tab actions. Delegate to the pure helpers in src/lib/pinnedTabs.ts
+      // so the toggling logic is unit-tested independently of Zustand hydration.
+      pinTab: (id) => set((s) => ({ pinnedTabIds: addPin(s.pinnedTabIds, id) })),
+      unpinTab: (id) => set((s) => ({ pinnedTabIds: removePin(s.pinnedTabIds, id) })),
+      toggleTabPin: (id) => set((s) => ({ pinnedTabIds: togglePin(s.pinnedTabIds, id) })),
+
       // Command Palette actions (F1)
       recordPaletteUse: (key) =>
         set((s) => {
@@ -1144,6 +1164,10 @@ export const useAppStore = create<AppState>()(
         // Claude (NEW v1.22.0)
         claudeDefaultModel: state.claudeDefaultModel,
         claudeBinaryPathOverride: state.claudeBinaryPathOverride,
+
+        // Pinned tabs (Phase 4a) — id list survives restarts so users don't
+        // have to re-pin sessions after a crash / restore-session flow.
+        pinnedTabIds: state.pinnedTabIds,
       }),
     }
   )

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1165,8 +1165,13 @@ export const useAppStore = create<AppState>()(
         claudeDefaultModel: state.claudeDefaultModel,
         claudeBinaryPathOverride: state.claudeBinaryPathOverride,
 
-        // Pinned tabs (Phase 4a) — id list survives restarts so users don't
-        // have to re-pin sessions after a crash / restore-session flow.
+        // Pinned tabs (Phase 4a). Persist pinned-tab intent WITHIN a session
+        // so refreshes / new detached windows preserve the pin state.
+        // Restored terminals get fresh UUIDs (Uuid::new_v4() in Rust), so
+        // pins do NOT survive app restart — see the startup GC in App.tsx
+        // that drops ghost ids after session restore populates the store.
+        // A stable-key persistence pass (using working_directory +
+        // claude_session_id) is queued as a follow-up.
         pinnedTabIds: state.pinnedTabIds,
       }),
     }

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -320,6 +320,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         await invoke('purge_pastes', { terminalId: id }).catch(() => {});
       }
       usePasteStore.getState().clearForTerminal(id);
+      // Ghost-pin GC: if this terminal was pinned, drop the id from the
+      // persisted pinnedTabIds so it doesn't leak forever. Without this,
+      // right-click → Pin → Close leaves the id in localStorage across
+      // sessions and pinnedTabIds grows unbounded. The startup GC in
+      // App.tsx catches the restart case; this covers the live case.
+      useAppStore.getState().unpinTab(id);
+      if (childId) useAppStore.getState().unpinTab(childId);
     } catch {
       // ignore - cleanup is best-effort
     }


### PR DESCRIPTION
## Summary

First real UX feature of the New UI refresh series (Phases 1 & 2 were tokens + polish). Users can now **pin long-running terminal sessions** so they stay at the front of the tab strip and survive bulk-close actions like "Close Others."

- **Store + persistence** — `pinnedTabIds: string[]` in `appStore`, in-session persist via existing `partialize` allow-list (no schema version bump; additive)
- **Ordering** — `orderTabsPinnedFirst(tabIds, pinnedIds)` in `src/lib/pinnedTabOrder.ts` — pure helper that partitions tabs into `[pinned..., unpinned...]`, preserving intra-group insertion order (pin order intentionally ignored — pinning is a set-membership concept, not a sort key)
- **Rendering** — pin glyph (Lucide `Pin`) inline before label on pinned tabs, tinted with `--accent-primary`
- **Right-click menu** — Pin/Unpin, Close, Close Others, Close All But Pinned (matches SessionsPanel's context-menu pattern: fixed positioning, viewport clamping, outside-click + Escape dismiss)
- **Middle-click close** — was already wired via `onAuxClick` (nice discovery during Task C)
- **Ghost-pin GC** — auto-unpin on `closeTerminal`; one-shot GC on mount + at end of `handleRestore` to drop stale ids after session restore (terminals get fresh UUIDs on restore, so cross-restart pin survival needs a stable-key follow-up)

## Verification

- **Tests:** 325 passing / 36 files (was 299 on master; **+26 new** — pinnedTabs 3, orderTabsPinnedFirst 8, closeTabActions 9, filterLivePins 6)
- **Build:** clean, no new warnings
- **TypeScript:** clean
- **New dependencies:** none

## Commits

1. `2fc93d7` feat(store) — pinnedTabIds state + persist allow-list + add/remove/toggle helpers
2. `856fbdb` feat(lib) — orderTabsPinnedFirst pure helper + 8 tests
3. `6c5cfa8` feat(tabs) — render pinned first with pin glyph + middle-click (verified pre-existing)
4. `336cd01` feat(tabs) — right-click context menu with pin & close-variant actions
5. `0e44c72` fix(tabs) — unpin on close + startup GC (blocker fixes from final review)

## Development discipline

Executed via subagent-driven development (same pattern as PRs #42, #43). Final holistic reviewer caught two real bugs that a per-task review would have missed:
- **Blocker 1** — commit message claimed pins "survive restarts" but they don't (fresh UUIDs on restore). Now corrected with honest partialize comment + startup GC.
- **Blocker 2** — closing a pinned terminal leaked its id into persisted state forever. Now `terminalStore.closeTerminal` unwinds `pinnedTabIds` alongside other per-terminal maps.

Both fixed in commit 5. See PR #42 and PR #43 for prior phases.

## Test plan

- [ ] `npm run tauri dev` — open several terminals, right-click one → Pin. Verify:
  - Pin glyph appears inline before the label, tinted in your accent color
  - Pinned tab moves to the front of the strip
- [ ] Right-click a pinned tab → Unpin — glyph disappears, tab returns to insertion order
- [ ] Right-click any tab → Close Others — every OTHER tab closes (regardless of pin state)
- [ ] Right-click any tab → Close All But Pinned — only pinned tabs remain
- [ ] Middle-click any tab — closes cleanly with toast on failure
- [ ] Close a pinned terminal via the × button — verify (via devtools) that its id is dropped from `pinnedTabIds` in localStorage
- [ ] Restart the app with session restore — pinned tab visuals may not survive (see follow-ups below), but no ghost ids accumulate and no crashes
- [ ] `npm run test:run` → 325 passing

## Follow-up (queued for future PRs)

- **Cross-restart pin survival** — persist by stable key (`working_directory` + `claude_session_id`) instead of ephemeral UUID. Bumps persist version to 3 with a `migrate()`. Would replace the "GC ghosts on restore" approach with "rebuild live-id list from key map."
- **Cross-partition drag** — dragging a tab across the pinned/unpinned boundary has slightly surprising behavior today (visual re-partition after drag). Decide on JetBrains-style rigid partition (block cross-partition drags) or "drag across auto-pins/unpins."
- **Store-level pin persist round-trip test** — `appStore.test.ts` checks the allow-list keys but never asserts a full round-trip. Trivial addition.
- **Move Up / Move Down menu items** — deferred until cross-partition drag policy is resolved
- **`shadow-elevation-*` light-mode theme-awareness** — inherited follow-up from Phase 1's final review; still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)