### PR TITLE
feat(tabs): Show Hidden Tabs overflow chevron — Phase 4b

### DIFF
--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon, Pin, PinOff } from 'lucide-react';
+import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, ChevronDown, Copy, File as FileIcon, Pin, PinOff } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
 import { useTerminalStore } from '../store/terminalStore';
 import { useAppStore } from '../store/appStore';
@@ -47,8 +47,15 @@ function formatCost(usd: number): string {
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
+// Width reserved for the "Show Hidden Tabs" chevron in the tab-strip overflow
+// calculation. Approx: ChevronDown 13px + 4px gap + badge (min 15px, growing
+// with digit count) + 2*8px horizontal padding + 1px left border = ~49px.
+// Rounded up to 50 so `computeTabOverflow` doesn't shove the last tab under
+// the chevron by a hair.
+const CHEVRON_WIDTH = 50;
+
 export function TerminalTabs() {
-  const { terminals, activeTerminalId, closeTerminal, unreadTerminalIds, gitInfoCache, scriptChildren, closeScript } = useTerminalStore();
+  const { terminals, activeTerminalId, closeTerminal, unreadTerminalIds, gitInfoCache, scriptChildren, closeScript, setActiveTerminal } = useTerminalStore();
   const { openNewTerminalModal, gridMode, toggleGridMode, addToGrid, gridTerminalIds, splitMode, splitTerminalIds, splitOrientation, splitRatio, setSplitOrientation, setSplitRatio, clearSplit, setSplitTerminals, setSplitMode, openFiles, activeFilePath, setActiveFilePath, closeFileTab, showFileTree, showTabActivity } = useAppStore();
   const pinnedTabIds = useAppStore((s) => s.pinnedTabIds);
   const toggleTabPin = useAppStore((s) => s.toggleTabPin);
@@ -196,14 +203,40 @@ export function TerminalTabs() {
   const [canScrollRight, setCanScrollRight] = useState(false);
 
   // Phase 4b Task B: tab-strip overflow measurement.
-  // `hiddenTabIds` holds the ids the strip can't fit, so they can be exposed via
-  // the "Show Hidden Tabs" chevron dropdown (Task C wires the UI; this task
-  // just populates the set so overflow tabs silently drop from the render).
-  // The chevron/reserved constants are best-guess placeholders — Task C will
-  // tune `chevronWidth` when the real button lands.
+  // `hiddenTabIds` holds the ids the strip can't fit, so Task C's chevron
+  // dropdown can surface them. `chevronWidth` is now the measured
+  // `CHEVRON_WIDTH` constant defined at the top of this module.
   const stripRef = useRef<HTMLUListElement | null>(null);
   const [hiddenTabIds, setHiddenTabIds] = useState<string[]>([]);
   const hiddenSet = useMemo(() => new Set(hiddenTabIds), [hiddenTabIds]);
+
+  // Phase 4b Task C: hidden-tabs chevron dropdown state.
+  const [hiddenMenuOpen, setHiddenMenuOpen] = useState(false);
+  const chevronRef = useRef<HTMLButtonElement | null>(null);
+
+  // Close the "Show Hidden Tabs" dropdown on outside click / Escape. Mirrors
+  // the pattern used by the tab-context-menu dismiss above; the chevron
+  // button itself is excluded so its own onClick (which toggles the menu)
+  // still fires cleanly.
+  useEffect(() => {
+    if (!hiddenMenuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (chevronRef.current?.contains(target)) return;
+      const menu = document.querySelector('[data-hidden-tabs-menu]');
+      if (menu?.contains(target)) return;
+      setHiddenMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setHiddenMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [hiddenMenuOpen]);
 
   useLayoutEffect(() => {
     const strip = stripRef.current;
@@ -227,10 +260,9 @@ export function TerminalTabs() {
         activeId: activeTerminalId,
         tabWidths,
         containerWidth,
-        // Placeholder — Task C will replace with the measured chevron width.
-        chevronWidth: 40,
-        // Placeholder — approx. two 28px controls (+, grid toggle) + gaps +
-        // divider slack. Adjust when the real controls are stabilized.
+        chevronWidth: CHEVRON_WIDTH,
+        // Approx. two 28px controls (+, grid toggle) + gaps + divider slack.
+        // Adjust when the real controls are stabilized.
         reservedRight: 96,
       });
 
@@ -547,6 +579,31 @@ export function TerminalTabs() {
             </AnimatePresence>
           </ul>
 
+          {/* Phase 4b Task C: "Show Hidden Tabs" chevron. Rendered only when
+              the strip overflowed (Task B's `hiddenTabIds`). Clicking opens a
+              floating dropdown below the button with the hidden tabs; picking
+              one calls `setActiveTerminal`, which triggers Task A's
+              computeTabOverflow to swap it into the visible list on the next
+              layout pass. */}
+          {hiddenTabIds.length > 0 && (
+            <button
+              ref={chevronRef}
+              onClick={(e) => {
+                e.stopPropagation();
+                setHiddenMenuOpen((v) => !v);
+              }}
+              className="no-drag h-[var(--h-tab)] px-2 flex items-center gap-1 text-text-secondary hover:bg-white/[0.06] hover:text-text-primary transition-colors border-l border-[var(--ij-divider-soft)] flex-shrink-0"
+              title="Show hidden tabs"
+              aria-label={`Show ${hiddenTabIds.length} hidden tab${hiddenTabIds.length === 1 ? '' : 's'}`}
+              aria-expanded={hiddenMenuOpen}
+            >
+              <ChevronDown size={13} strokeWidth={2} />
+              <span className="text-[10px] font-semibold px-[5px] h-[15px] min-w-[15px] flex items-center justify-center rounded-full bg-accent-primary text-white">
+                {hiddenTabIds.length}
+              </span>
+            </button>
+          )}
+
           {/* File tabs - rendered inline next to terminal tabs, VS Code style */}
           {openFiles.length > 0 && (
             <>
@@ -759,6 +816,50 @@ export function TerminalTabs() {
             </div>
         )}
       </div>
+
+      {hiddenMenuOpen && chevronRef.current && (() => {
+        const rect = chevronRef.current.getBoundingClientRect();
+        const menuWidth = 240;
+        // Anchor to the chevron's right edge so the menu extends leftward
+        // (mirrors Chrome/Edge's overflow tab menu). Clamp against viewport
+        // edges so the menu never renders off-screen on a narrow window.
+        const left = Math.max(4, rect.right - menuWidth);
+        const top = rect.bottom + 4;
+        const clampedTop = Math.min(top, window.innerHeight - 200 - 4);
+        const clampedLeft = Math.min(Math.max(4, left), window.innerWidth - menuWidth - 4);
+        return (
+          <div
+            data-hidden-tabs-menu
+            className="fixed z-[80] bg-bg-elevated ring-1 ring-white/[0.08] rounded-md shadow-elevation-4 py-1 min-w-[240px] max-h-[320px] overflow-y-auto"
+            style={{ left: clampedLeft, top: clampedTop }}
+            onClick={(e) => e.stopPropagation()}
+            role="menu"
+          >
+            <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider font-semibold text-text-tertiary border-b border-[var(--ij-divider-soft)]">
+              Hidden Tabs ({hiddenTabIds.length})
+            </div>
+            {hiddenTabIds.map((id) => {
+              const t = terminalList.find((x) => x.id === id);
+              if (!t) return null;
+              const isPinned = pinnedTabIds.includes(id);
+              return (
+                <button
+                  key={id}
+                  role="menuitem"
+                  onClick={() => {
+                    setActiveTerminal(id);
+                    setHiddenMenuOpen(false);
+                  }}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-text-primary hover:bg-white/[0.06] text-left"
+                >
+                  {isPinned && <Pin size={10} className="text-accent-primary flex-shrink-0" />}
+                  <span className="truncate">{t.nickname || t.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        );
+      })()}
 
       {contextMenu && (() => {
         const ctxId = contextMenu.terminalId;

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { useMemo, useState, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Plus, Grid3X3, SplitSquareHorizontal, RotateCw, GitBranch, ChevronLeft, ChevronRight, Copy, File as FileIcon, Pin, PinOff } from 'lucide-react';
 import appIconUrl from '../assets/app-icon.png';
@@ -21,6 +21,7 @@ import { useTabDrag } from '../hooks/useTabDrag';
 import { getWindowMode } from '../lib/windowMode';
 import { getLastOutputAt } from '../lib/terminalActivity';
 import { orderTabsPinnedFirst } from '../lib/pinnedTabOrder';
+import { estimateTabWidth, computeTabOverflow } from '../lib/tabOverflow';
 import { idsToCloseForOthers, idsToCloseForAllButPinned } from '../lib/closeTabActions';
 import { StateDot } from './StateDot';
 import { Tooltip } from './ui/Tooltip';
@@ -190,9 +191,65 @@ export function TerminalTabs() {
   };
 
   // Tab scroll overflow detection
-  const tabsContainerRef = useRef<HTMLUListElement>(null);
+  const tabsContainerRef = useRef<HTMLUListElement | null>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+
+  // Phase 4b Task B: tab-strip overflow measurement.
+  // `hiddenTabIds` holds the ids the strip can't fit, so they can be exposed via
+  // the "Show Hidden Tabs" chevron dropdown (Task C wires the UI; this task
+  // just populates the set so overflow tabs silently drop from the render).
+  // The chevron/reserved constants are best-guess placeholders — Task C will
+  // tune `chevronWidth` when the real button lands.
+  const stripRef = useRef<HTMLUListElement | null>(null);
+  const [hiddenTabIds, setHiddenTabIds] = useState<string[]>([]);
+  const hiddenSet = useMemo(() => new Set(hiddenTabIds), [hiddenTabIds]);
+
+  useLayoutEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+
+    const measure = () => {
+      const el = stripRef.current;
+      if (!el) return;
+      const containerWidth = el.clientWidth;
+
+      const tabIds = terminalList.map((t) => t.id);
+      const tabWidths = terminalList.map((t) =>
+        estimateTabWidth(t.nickname || t.label, {
+          isPinned: pinnedTabIds.includes(t.id),
+          hasStatusDot: t.status === 'Running' || t.status === 'Idle',
+        })
+      );
+
+      const result = computeTabOverflow({
+        tabIds,
+        activeId: activeTerminalId,
+        tabWidths,
+        containerWidth,
+        // Placeholder — Task C will replace with the measured chevron width.
+        chevronWidth: 40,
+        // Placeholder — approx. two 28px controls (+, grid toggle) + gaps +
+        // divider slack. Adjust when the real controls are stabilized.
+        reservedRight: 96,
+      });
+
+      setHiddenTabIds((prev) => {
+        if (
+          prev.length === result.hidden.length &&
+          prev.every((id, i) => id === result.hidden[i])
+        ) {
+          return prev;
+        }
+        return result.hidden;
+      });
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(strip);
+    return () => ro.disconnect();
+  }, [terminalList, pinnedTabIds, activeTerminalId]);
 
   const checkScroll = useCallback(() => {
     const el = tabsContainerRef.current;
@@ -300,12 +357,19 @@ export function TerminalTabs() {
             </button>
           )}
           <ul
-            ref={tabsContainerRef}
+            ref={(node) => {
+              tabsContainerRef.current = node;
+              stripRef.current = node;
+            }}
             data-tab-strip
             className="flex items-center overflow-x-auto scrollbar-none list-none m-0 p-0"
           >
             <AnimatePresence initial={false}>
             {renderList.map((terminal, index) => {
+              // Phase 4b Task B: overflow-hidden tabs drop from the render but
+              // stay in the enumeration so `index` still matches the drag/drop
+              // model. Task C will surface them via a chevron dropdown.
+              if (hiddenSet.has(terminal.id)) return null;
               const instance = terminals.get(terminal.id);
               const model = instance?.model;
               const isWorktree = instance?.isWorktree;

--- a/src/lib/tabOverflow.test.ts
+++ b/src/lib/tabOverflow.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { computeTabOverflow, estimateTabWidth } from './tabOverflow';
+
+describe('estimateTabWidth', () => {
+  it('returns a value within the [80, 200] clamp for a normal label', () => {
+    const w = estimateTabWidth('abc');
+    expect(w).toBeGreaterThanOrEqual(80);
+    expect(w).toBeLessThanOrEqual(200);
+  });
+
+  it('clamps empty label to the minimum 80px', () => {
+    expect(estimateTabWidth('', {})).toBe(80);
+  });
+
+  it('clamps very long labels to the maximum 200px', () => {
+    expect(estimateTabWidth('a'.repeat(50))).toBe(200);
+  });
+
+  it('adds width when the tab is pinned', () => {
+    // Use a label long enough to be above the 80px floor so the pin actually
+    // moves the estimate — otherwise both are clamped to 80.
+    const long = 'x'.repeat(10);
+    expect(estimateTabWidth(long, { isPinned: true })).toBeGreaterThan(
+      estimateTabWidth(long),
+    );
+  });
+
+  it('adds width when the status dot is shown', () => {
+    const long = 'x'.repeat(10);
+    expect(estimateTabWidth(long, { hasStatusDot: true })).toBeGreaterThan(
+      estimateTabWidth(long),
+    );
+  });
+
+  it('handles non-finite / weird inputs defensively (returns clamped minimum)', () => {
+    // Cast to any so we can pass hostile inputs without TS complaining.
+    // The function should silently floor them to 0, not return NaN.
+    expect(estimateTabWidth(null as unknown as string)).toBe(80);
+    expect(estimateTabWidth(undefined as unknown as string)).toBe(80);
+  });
+});
+
+describe('computeTabOverflow', () => {
+  it('returns empty arrays for empty tabIds', () => {
+    expect(
+      computeTabOverflow({
+        tabIds: [],
+        activeId: null,
+        tabWidths: [],
+        containerWidth: 500,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: [], hidden: [] });
+  });
+
+  it('marks everything visible when all tabs fit in the container', () => {
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c'],
+        activeId: 'a',
+        tabWidths: [100, 100, 100],
+        containerWidth: 500,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['a', 'b', 'c'], hidden: [] });
+  });
+
+  it('treats exact-fit as fully visible (no chevron)', () => {
+    // 3 tabs at 100 = 300px, container is exactly 300px — everything fits.
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c'],
+        activeId: 'a',
+        tabWidths: [100, 100, 100],
+        containerWidth: 300,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['a', 'b', 'c'], hidden: [] });
+  });
+
+  it('splits into visible prefix + hidden tail when active is already in the prefix', () => {
+    // 5 tabs at 100 = 500; container 300, reserve chevron 32 → budget 268 → 2 fit.
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c', 'd', 'e'],
+        activeId: 'a',
+        tabWidths: [100, 100, 100, 100, 100],
+        containerWidth: 300,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['a', 'b'], hidden: ['c', 'd', 'e'] });
+  });
+
+  it('swaps the last visible slot for the active tab when it would otherwise hide', () => {
+    // 2 fit in the budget; active='d' is in the hidden set → swap into slot 2.
+    // Hidden reconstructs from original tabIds order minus the visible set.
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c', 'd', 'e'],
+        activeId: 'd',
+        tabWidths: [100, 100, 100, 100, 100],
+        containerWidth: 300,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['a', 'd'], hidden: ['b', 'c', 'e'] });
+  });
+
+  it('shows just the active tab when budget is too small for even one tab', () => {
+    // containerWidth 20 < chevronWidth 32 → budget is negative → nothing fits,
+    // but active is preserved so the user can still see where they are.
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c'],
+        activeId: 'b',
+        tabWidths: [100, 100, 100],
+        containerWidth: 20,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['b'], hidden: ['a', 'c'] });
+  });
+
+  it('hides everything when budget is non-positive and no activeId is set', () => {
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c'],
+        activeId: null,
+        tabWidths: [100, 100, 100],
+        containerWidth: 20,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: [], hidden: ['a', 'b', 'c'] });
+  });
+
+  it('treats missing widths as the 200px conservative fallback', () => {
+    // Only 1 width provided for 3 tabs → indices 1,2 default to 200.
+    // Total = 100 + 200 + 200 = 500. Container 300, chevron 32 → budget 268.
+    // Only 'a' (100) fits (adding 200 would exceed 268).
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c'],
+        activeId: 'a',
+        tabWidths: [100],
+        containerWidth: 300,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['a'], hidden: ['b', 'c'] });
+  });
+
+  it('subtracts reservedRight from the available budget', () => {
+    // Container 400, reservedRight 100 → 300 available. Chevron 32 → 268 budget.
+    // Same result as the container-300 case above: 2 tabs at 100 each fit.
+    expect(
+      computeTabOverflow({
+        tabIds: ['a', 'b', 'c', 'd'],
+        activeId: 'a',
+        tabWidths: [100, 100, 100, 100],
+        containerWidth: 400,
+        chevronWidth: 32,
+        reservedRight: 100,
+      }),
+    ).toEqual({ visible: ['a', 'b'], hidden: ['c', 'd'] });
+  });
+
+  it('preserves the pinned-first ordering the caller provides (active swap included)', () => {
+    // tabIds already ordered pinned-first (['pin1', 'pin2', ...]). Active is 'b',
+    // which lives in the unpinned tail — verify the swap picks it up while
+    // pins stay in front.
+    // Widths: 5 * 100 = 500. Container 300, chevron 32 → budget 268 → 2 fit.
+    // Prefix ['pin1', 'pin2'] fits; active 'b' is hidden → swap into slot 2.
+    expect(
+      computeTabOverflow({
+        tabIds: ['pin1', 'pin2', 'a', 'b', 'c'],
+        activeId: 'b',
+        tabWidths: [100, 100, 100, 100, 100],
+        containerWidth: 300,
+        chevronWidth: 32,
+      }),
+    ).toEqual({ visible: ['pin1', 'b'], hidden: ['pin2', 'a', 'c'] });
+  });
+});

--- a/src/lib/tabOverflow.ts
+++ b/src/lib/tabOverflow.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure helpers for the tab-strip "Show Hidden Tabs" overflow chevron.
+ *
+ * The tab strip has a bounded width; when many tabs are open they overflow
+ * off-screen. This module computes — without any DOM measurement — which
+ * tabs fit and which need to move into a chevron dropdown, keeping the
+ * active tab visible when possible.
+ *
+ * Kept pure (no React, no DOM refs) so it can be unit-tested and reasoned
+ * about independently. `TerminalTabs.tsx` (Phase 4b Task B) wires this to a
+ * ResizeObserver that tracks the real container width.
+ */
+
+export interface TabWidthHints {
+  isPinned?: boolean;
+  hasStatusDot?: boolean;
+}
+
+/**
+ * Estimate a tab's rendered width in px from its label + adornments.
+ *
+ * Deterministic (no DOM measurement) so overflow computation stays pure.
+ * Approximates the actual layout in `TerminalTabs.tsx`:
+ *   px-3 padding (12+12=24) + optional pin (10+8) + optional status dot
+ *   (6+8) + label glyph width (~7px per char, monospace-ish) + close
+ *   button (16). Clamped to [80, 200] to match the browser's flex-shrink
+ *   behavior on real tabs — a lone glyph never renders narrower than 80px
+ *   and a long label collapses to 200px before ellipsis.
+ *
+ * Defensive: non-finite / negative label lengths are floored to 0, so a
+ * malformed input still returns the clamped minimum instead of NaN.
+ */
+export function estimateTabWidth(label: string, opts: TabWidthHints = {}): number {
+  const base = 24 /* padding */ + 16 /* close button */;
+  const pin = opts.isPinned ? 18 : 0;
+  const dot = opts.hasStatusDot ? 14 : 0;
+  const rawLen = typeof label === 'string' ? label.length : 0;
+  const safeLen = Number.isFinite(rawLen) && rawLen > 0 ? rawLen : 0;
+  const glyphs = safeLen * 7;
+  return Math.max(80, Math.min(200, base + pin + dot + glyphs));
+}
+
+export interface OverflowParams {
+  tabIds: readonly string[];
+  activeId: string | null;
+  /** Parallel to tabIds — width of each tab in px. Length should match tabIds. */
+  tabWidths: readonly number[];
+  containerWidth: number;
+  chevronWidth: number;
+  /** Extra reserved space at the right (for `+` button, grid toggle, etc). */
+  reservedRight?: number;
+}
+
+export interface OverflowResult {
+  visible: string[];
+  hidden: string[];
+}
+
+/**
+ * Decide which tabs fit in the strip and which move into the "Show Hidden
+ * Tabs" dropdown, keeping the active tab visible when possible.
+ *
+ * Algorithm:
+ *   1. If all tabs fit in `(containerWidth - reservedRight)`, everything is
+ *      visible; no chevron needed.
+ *   2. Otherwise reserve `chevronWidth`. Take the longest prefix of `tabIds`
+ *      whose cumulative width fits in the available space.
+ *   3. If `activeId` is in the hidden set, swap it into the last visible
+ *      slot so the active tab always renders.
+ *
+ * Edge cases:
+ *   - Empty `tabIds` → both arrays empty.
+ *   - `containerWidth` too small for even one tab (budget ≤ 0) → active tab
+ *     shown alone if present, otherwise everything hidden.
+ *   - `tabWidths` shorter than `tabIds` → missing entries treated as the
+ *     max clamp (200) so the tab is conservatively counted. Silent — the
+ *     helper stays pure and side-effect-free.
+ */
+export function computeTabOverflow(params: OverflowParams): OverflowResult {
+  const { tabIds, activeId, tabWidths, containerWidth, chevronWidth } = params;
+  const reservedRight = params.reservedRight ?? 0;
+
+  if (tabIds.length === 0) return { visible: [], hidden: [] };
+
+  const widthAt = (i: number): number => tabWidths[i] ?? 200;
+  const totalWidth = tabIds.reduce((sum, _id, i) => sum + widthAt(i), 0);
+  const availableForTabs = containerWidth - reservedRight;
+
+  // Everything fits — no chevron needed.
+  if (totalWidth <= availableForTabs) {
+    return { visible: [...tabIds], hidden: [] };
+  }
+
+  // Overflow: reserve chevron width.
+  const budget = availableForTabs - chevronWidth;
+
+  // Budget too small for anything — show active if present, else hide all.
+  if (budget <= 0) {
+    if (activeId && tabIds.includes(activeId)) {
+      return {
+        visible: [activeId],
+        hidden: tabIds.filter((id) => id !== activeId),
+      };
+    }
+    return { visible: [], hidden: [...tabIds] };
+  }
+
+  // Find longest prefix whose cumulative width fits in the budget.
+  let acc = 0;
+  let fitCount = 0;
+  for (let i = 0; i < tabIds.length; i++) {
+    const next = acc + widthAt(i);
+    if (next > budget) break;
+    acc = next;
+    fitCount++;
+  }
+
+  const visible = tabIds.slice(0, fitCount);
+  const hidden = tabIds.slice(fitCount);
+
+  // Keep active tab visible: swap it into the last visible slot.
+  if (activeId && hidden.includes(activeId) && visible.length > 0) {
+    const newVisible = [...visible.slice(0, -1), activeId];
+    const visibleSet = new Set(newVisible);
+    return {
+      visible: newVisible,
+      hidden: tabIds.filter((id) => !visibleSet.has(id)),
+    };
+  }
+
+  return { visible, hidden };
+}


### PR DESCRIPTION
## Summary

Second half of Phase 4 tab polish, stacked on [PR #44](https://github.com/talayash/claude-terminal/pull/44) (pinned tabs). When tabs overflow the strip, they now surface via a **chevron button with count badge** at the right end; clicking opens a dropdown of hidden tabs, click one to activate.

- **Pure overflow algorithm** — `src/lib/tabOverflow.ts` with two exports: `estimateTabWidth(label, opts)` (deterministic px heuristic, clamped [80, 200]) and `computeTabOverflow({...})` (takes container width + reserved right + chevron width, returns `{ visible, hidden }` split)
- **Active tab always visible** — if the active terminal would be hidden, algorithm swaps it into the last visible slot so users don't lose their working tab off-screen
- **ResizeObserver wiring** — `useLayoutEffect` on the tab strip `<ul>` re-measures on window resize / tab list change / active-terminal change; shallow-equality guard prevents render thrash during rapid resize
- **Chevron + dropdown UI** — appears only when `hiddenTabIds.length > 0`, count pill in accent color, dropdown positioned below-and-left with viewport clamping, outside-click + Escape dismiss (same pattern as Phase 4a's right-click menu); pinned tabs in dropdown show their Pin glyph

## Base branch

This PR is stacked on **`ui/intellij-new-ui-phase-4a-pinned-tabs`** (PR #44). Only the 3 commits below are new in this PR. Once #44 merges to master, GitHub will auto-retarget this to master.

## Commits

1. `8c3e601` feat(lib) — computeTabOverflow + estimateTabWidth pure helpers + 16 unit tests
2. `7ce4eb3` feat(tabs) — ResizeObserver wiring into TerminalTabs, hidden tabs return null from render loop
3. `490bbcc` feat(tabs) — chevron button + dropdown UI with accent-color count badge

## Interaction with Phase 4a

Pinned-first ordering naturally works with overflow: because pinned tabs are already at the front of `terminalList` (from Phase 4a's `orderTabsPinnedFirst`), taking a prefix from the front keeps them visible when overflow happens. Verified via test case in `tabOverflow.test.ts` (pinned-first order preservation).

Edge case handled: if active is a pinned tab that falls outside the visible prefix (5 pinned + budget of only 2), the algorithm demotes an earlier pinned tab to the dropdown so active-pinned wins. Documented in reviewer trace.

## Verification

- **Tests:** 325 → 341 passing (+16 for tabOverflow.test.ts). Full suite green across 37 files.
- **Build:** clean, no new warnings
- **TypeScript:** clean
- **New dependencies:** none

## Test plan

- [ ] `npm run tauri dev` on a wide window → open 15+ terminals — verify chevron appears at right end with count badge in accent color
- [ ] Click chevron — dropdown opens listing hidden terminals in scroll-preserved order
- [ ] Click a hidden terminal in dropdown — dropdown closes, tab appears in the visible strip (Task A's active-swap kicks in)
- [ ] Resize window narrower — hidden count grows, chevron badge updates
- [ ] Escape / click outside — dropdown dismisses
- [ ] With Phase 4a pinned tabs: pin 3 terminals, open 20 unpinned → verify pinned stay visible, unpinned move to chevron
- [ ] `npm run test:run` → 341 passing

## Known cosmetic limitation (transient)

Chevron uses `h-[var(--h-tab)]` (32px per Phase 1 token) while the surrounding tab strip is still `h-9` (36px) — chevron renders 2px inset above/below within the 36px bar. **Auto-resolves when PR #43 (Phase 2 tab-height token adoption) lands and this rebases.** Both will then be 32px.

## Follow-up tasks

- **Right-click actions in hidden-tabs dropdown** — currently users can activate a hidden tab but can't pin/close/close-others without first activating it. Small addition once the pattern proves useful
- **Measure real chevron + right-controls widths** — replace `CHEVRON_WIDTH = 50` and `reservedRight = 96` magic constants with a second ref that measures actual DOM widths
- **Focus management + arrow-key nav** — on dropdown open, move focus to first item; Escape returns focus to chevron. Consistency uplift for the whole context-menu family
- **Pinned tabs at top of hidden-tabs dropdown** — when pin state overflows, surface pinned entries above unpinned in the dropdown for visual priority
- **Density-aware width estimation** — when density tokens introduce compact/comfortable/spacious padding, `estimateTabWidth` will need to read the current density to stay accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)