### PR TITLE
feat(palette): Search Everywhere upgrade — Phase 5

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -6,6 +6,8 @@ import { useTerminalStore } from '../store/terminalStore';
 import { toast } from '../store/toastStore';
 import { copyText } from '../lib/clipboard';
 import { reportInvokeFailure } from '../lib/errorReporter';
+import { fuzzyMatch, frecencyScore } from '../lib/paletteMatching';
+import type { PaletteItem } from '../lib/paletteSources';
 import {
   Terminal,
   Settings,
@@ -37,23 +39,6 @@ interface Snippet {
   created_at: string;
 }
 
-interface PaletteItem {
-  id: string;
-  // Stable key for frecency tracking. Empty string = not tracked (terminals,
-  // whose ids are ephemeral and must not leak into persisted usage).
-  frecencyKey: string;
-  label: string;
-  description: string;
-  category: string;
-  icon?: LucideIcon;
-  shortcut?: string;
-  // Tailwind bg-* class for a presence dot (terminal status). Color is
-  // supplementary - the status is also spelled out in the description so we
-  // never convey it by color alone.
-  statusColor?: string;
-  action: () => void;
-}
-
 // Terminal status → presence-dot color.
 const STATUS_DOT: Record<string, string> = {
   Running: 'bg-success',
@@ -61,46 +46,6 @@ const STATUS_DOT: Record<string, string> = {
   Error: 'bg-error',
   Stopped: 'bg-text-tertiary',
 };
-
-// Frecency = frequency + recency. A small recency bump keeps recently-used
-// items near the top without letting a one-off click outrank a daily habit.
-function frecencyScore(u?: { count: number; lastUsedTs: number }): number {
-  if (!u) return 0;
-  const age = Date.now() - u.lastUsedTs;
-  const HOUR = 3_600_000;
-  const DAY = 24 * HOUR;
-  const recency = age < HOUR ? 8 : age < DAY ? 4 : age < 7 * DAY ? 2 : 1;
-  return u.count + recency;
-}
-
-function fuzzyMatch(text: string, query: string): { matches: boolean; score: number } {
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-
-  // Exact substring match (highest score)
-  const subIdx = lower.indexOf(q);
-  if (subIdx !== -1) {
-    // Prefer matches at the start
-    return { matches: true, score: 100 - subIdx };
-  }
-
-  // Character-by-character fuzzy match
-  let qi = 0;
-  let score = 0;
-  let lastMatchIdx = -1;
-  for (let i = 0; i < lower.length && qi < q.length; i++) {
-    if (lower[i] === q[qi]) {
-      qi++;
-      // Bonus for consecutive matches
-      score += lastMatchIdx === i - 1 ? 3 : 1;
-      lastMatchIdx = i;
-    }
-  }
-  if (qi === q.length) {
-    return { matches: true, score };
-  }
-  return { matches: false, score: 0 };
-}
 
 export function CommandPalette() {
   const { closeCommandPalette } = useAppStore();

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -7,12 +7,13 @@ import { toast } from '../store/toastStore';
 import { copyText } from '../lib/clipboard';
 import { reportInvokeFailure } from '../lib/errorReporter';
 import { fuzzyMatch, frecencyScore } from '../lib/paletteMatching';
-import type { PaletteItem } from '../lib/paletteSources';
+import { PALETTE_SOURCES, type PaletteItem } from '../lib/paletteSources';
 import {
   Terminal,
   Settings,
   PanelLeft,
   LayoutGrid,
+  LayoutList,
   Lightbulb,
   FolderOpen,
   User,
@@ -47,6 +48,37 @@ const STATUS_DOT: Record<string, string> = {
   Stopped: 'bg-text-tertiary',
 };
 
+// Filter chip in the source strip. Rendered inline in CommandPalette;
+// pulled out so both the "All" chip and the per-source chips can share
+// styling.
+function ChipButton({
+  label,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: LucideIcon;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`inline-flex items-center gap-1.5 h-6 px-2 rounded-full text-[11px] transition-colors whitespace-nowrap ${
+        active
+          ? 'bg-accent-primary text-white'
+          : 'bg-elevation-2 text-text-secondary hover:bg-elevation-3 hover:text-text-primary'
+      }`}
+    >
+      <Icon size={11} strokeWidth={2} />
+      {label}
+    </button>
+  );
+}
+
 export function CommandPalette() {
   const { closeCommandPalette } = useAppStore();
   const paletteUsage = useAppStore((s) => s.paletteUsage);
@@ -56,11 +88,17 @@ export function CommandPalette() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [hints, setHints] = useState<HintCategory[]>([]);
   const [snippets, setSnippets] = useState<Snippet[]>([]);
+  // Chip-strip filter. 'all' means no chip filter is active; a source id
+  // (e.g. 'terminals') restricts results to that source. Typed prefix chars
+  // still take precedence — see `wantSource` below.
+  const [activeSourceId, setActiveSourceId] = useState<string>('all');
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
+    // Reset chip filter each time the palette is (re)opened.
+    setActiveSourceId('all');
     invoke<HintCategory[]>('get_hints').then(setHints).catch(() => {});
     invoke<Snippet[]>('get_snippets').then(setSnippets).catch(() => {});
   }, []);
@@ -81,8 +119,23 @@ export function CommandPalette() {
   const items = useMemo<PaletteItem[]>(() => {
     const result: PaletteItem[] = [];
 
+    // Should the given source contribute items right now?
+    // - Typed prefix wins (backward compat with muscle memory).
+    // - '>' historically surfaced BOTH Commands and Hints together, so we
+    //   preserve that pairing even though the chip strip treats them as two
+    //   separate sources.
+    // - Otherwise, if a chip is active, filter to that source.
+    // - Else show every source.
+    const wantSource = (sourceId: string) => {
+      if (prefixMode !== 'all') {
+        return prefixMode === sourceId || (prefixMode === 'commands' && sourceId === 'hints');
+      }
+      if (activeSourceId !== 'all') return activeSourceId === sourceId;
+      return true;
+    };
+
     // Terminals
-    if (prefixMode === 'all' || prefixMode === 'terminals') {
+    if (wantSource('terminals')) {
       terminals.forEach((instance) => {
         const config = instance.config;
         result.push({
@@ -99,7 +152,7 @@ export function CommandPalette() {
     }
 
     // Actions
-    if (prefixMode === 'all' || prefixMode === 'commands') {
+    if (wantSource('commands')) {
       const actions: { label: string; description: string; icon: LucideIcon; shortcut?: string; action: () => void }[] = [
         { label: 'New Terminal', description: 'Create a new terminal instance', icon: Plus, shortcut: 'Ctrl+Shift+N', action: () => { useAppStore.getState().openNewTerminalModal(); closeCommandPalette(); } },
         { label: 'Toggle Sidebar', description: 'Show or hide the sidebar', icon: PanelLeft, shortcut: 'Ctrl+B', action: () => { useAppStore.getState().toggleSidebar(); closeCommandPalette(); } },
@@ -118,7 +171,7 @@ export function CommandPalette() {
     }
 
     // Hints
-    if (prefixMode === 'all' || prefixMode === 'commands') {
+    if (wantSource('hints')) {
       hints.forEach((cat) => {
         cat.hints.forEach((hint, i) => {
           result.push({
@@ -141,7 +194,7 @@ export function CommandPalette() {
     }
 
     // Snippets
-    if (prefixMode === 'all' || prefixMode === 'snippets') {
+    if (wantSource('snippets')) {
       snippets.forEach((snippet) => {
         result.push({
           id: `snippet-${snippet.id}`,
@@ -164,7 +217,7 @@ export function CommandPalette() {
     }
 
     return result;
-  }, [terminals, hints, snippets, activeTerminalId, closeCommandPalette, setActiveTerminal, writeToTerminal, prefixMode]);
+  }, [terminals, hints, snippets, activeTerminalId, closeCommandPalette, setActiveTerminal, writeToTerminal, prefixMode, activeSourceId]);
 
   const filtered = useMemo(() => {
     if (!effectiveQuery) return items;
@@ -227,6 +280,19 @@ export function CommandPalette() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Ctrl+Tab cycles the chip filter forward; Ctrl+Shift+Tab cycles back.
+    // Order matches the chip strip: All → Terminals → Commands → Hints → Snippets → All.
+    // Plain Tab is left alone so the input keeps its default behavior.
+    if (e.key === 'Tab' && e.ctrlKey) {
+      e.preventDefault();
+      const ids = ['all', ...PALETTE_SOURCES.map((s) => s.id)];
+      const currentIdx = Math.max(0, ids.indexOf(activeSourceId));
+      const nextIdx = e.shiftKey
+        ? (currentIdx - 1 + ids.length) % ids.length
+        : (currentIdx + 1) % ids.length;
+      setActiveSourceId(ids[nextIdx]);
+      return;
+    }
     if (e.key === 'Escape') {
       closeCommandPalette();
     } else if (e.key === 'ArrowDown') {
@@ -291,6 +357,42 @@ export function CommandPalette() {
             </div>
           </div>
 
+          {/* Source filter chips */}
+          <div className="px-3 pt-2 pb-2 flex items-center gap-1 border-b border-border overflow-x-auto scrollbar-none">
+            <ChipButton
+              label="All"
+              icon={LayoutList}
+              active={activeSourceId === 'all' && prefixMode === 'all'}
+              onClick={() => {
+                // Clicking "All" clears the chip filter and also strips any
+                // typed prefix char so users don't get "stuck" in a mode
+                // they can't see.
+                setActiveSourceId('all');
+                if (prefixMode !== 'all') setQuery(query.slice(1).trimStart());
+              }}
+            />
+            {PALETTE_SOURCES.map((src) => {
+              // Highlight the chip when either (a) it's the active chip and
+              // no typed prefix is fighting it, or (b) the typed prefix
+              // matches this source — so muscle-memory users still see
+              // which source their prefix maps to.
+              const active =
+                (activeSourceId === src.id && prefixMode === 'all') ||
+                prefixMode === src.id;
+              return (
+                <ChipButton
+                  key={src.id}
+                  label={src.label}
+                  icon={src.icon}
+                  active={active}
+                  onClick={() =>
+                    setActiveSourceId(activeSourceId === src.id ? 'all' : src.id)
+                  }
+                />
+              );
+            })}
+          </div>
+
           {/* Results */}
           <div ref={listRef} className="max-h-[50vh] overflow-y-auto p-1.5">
             {grouped.map((group) => (
@@ -352,6 +454,7 @@ export function CommandPalette() {
           <div className="px-3 py-2 border-t border-border flex items-center gap-4 text-[10px] text-text-tertiary">
             <span><kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">↑↓</kbd> navigate</span>
             <span><kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">↵</kbd> select</span>
+            <span><kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">Ctrl+Tab</kbd> cycle sources</span>
             <span><kbd className="px-1 py-0.5 bg-elevation-2 rounded border border-border font-mono">esc</kbd> close</span>
           </div>
         </div>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -8,6 +8,7 @@ import { copyText } from '../lib/clipboard';
 import { reportInvokeFailure } from '../lib/errorReporter';
 import { fuzzyMatch, frecencyScore } from '../lib/paletteMatching';
 import { PALETTE_SOURCES, type PaletteItem } from '../lib/paletteSources';
+import { HighlightedText } from './palette/HighlightedText';
 import {
   Terminal,
   Settings,
@@ -219,8 +220,18 @@ export function CommandPalette() {
     return result;
   }, [terminals, hints, snippets, activeTerminalId, closeCommandPalette, setActiveTerminal, writeToTerminal, prefixMode, activeSourceId]);
 
-  const filtered = useMemo(() => {
-    if (!effectiveQuery) return items;
+  // Task C: each surviving result also carries the match positions for
+  // label + description so the renderer can highlight the matched chars.
+  interface FilteredItem {
+    item: PaletteItem;
+    labelPositions: number[];
+    descPositions: number[];
+  }
+
+  const filtered = useMemo<FilteredItem[]>(() => {
+    if (!effectiveQuery) {
+      return items.map(item => ({ item, labelPositions: [], descPositions: [] }));
+    }
     return items
       .map(item => {
         const labelMatch = fuzzyMatch(item.label, effectiveQuery);
@@ -229,12 +240,29 @@ export function CommandPalette() {
         // Nudge frequently/recently used matches up without overriding a strong
         // textual match (fuzzy scores dominate; the boost only breaks ties).
         const boost = item.frecencyKey ? frecencyScore(paletteUsage[item.frecencyKey]) * 1.5 : 0;
-        return { item, matches: labelMatch.matches || descMatch.matches, score: bestScore + boost };
+        return {
+          item,
+          matches: labelMatch.matches || descMatch.matches,
+          score: bestScore + boost,
+          labelPositions: labelMatch.matches ? labelMatch.positions : [],
+          descPositions: descMatch.matches ? descMatch.positions : [],
+        };
       })
       .filter(r => r.matches)
       .sort((a, b) => b.score - a.score)
-      .map(r => r.item);
+      .map(({ item, labelPositions, descPositions }) => ({ item, labelPositions, descPositions }));
   }, [items, effectiveQuery, paletteUsage]);
+
+  // Task C: keep grouped/flatItems as PaletteItem[] (they're used all over the
+  // render pass) and stash positions in a side-map keyed by item id. When the
+  // query is empty every list is [], so highlighting is a no-op automatically.
+  const positionsMap = useMemo(() => {
+    const m = new Map<string, { label: number[]; desc: number[] }>();
+    for (const f of filtered) {
+      m.set(f.item.id, { label: f.labelPositions, desc: f.descPositions });
+    }
+    return m;
+  }, [filtered]);
 
   // Recent group (empty query only): tracked items ordered by last use.
   const recentItems = useMemo(() => {
@@ -254,7 +282,7 @@ export function CommandPalette() {
     if (recentItems.length) groups.push({ category: 'Recent', items: recentItems });
     const recentKeys = new Set(recentItems.map(i => i.frecencyKey));
     const catMap = new Map<string, PaletteItem[]>();
-    for (const item of filtered) {
+    for (const { item } of filtered) {
       if (!effectiveQuery && item.frecencyKey && recentKeys.has(item.frecencyKey)) continue;
       const arr = catMap.get(item.category) || [];
       arr.push(item);
@@ -429,8 +457,18 @@ export function CommandPalette() {
                         </div>
                       )}
                       <div className="flex-1 min-w-0">
-                        <p className="text-[12px] font-medium truncate">{item.label}</p>
-                        <p className="text-text-tertiary text-[11px] truncate">{item.description}</p>
+                        <p className="text-[12px] font-medium truncate">
+                          <HighlightedText
+                            text={item.label}
+                            positions={positionsMap.get(item.id)?.label ?? []}
+                          />
+                        </p>
+                        <p className="text-text-tertiary text-[11px] truncate">
+                          <HighlightedText
+                            text={item.description}
+                            positions={positionsMap.get(item.id)?.desc ?? []}
+                          />
+                        </p>
                       </div>
                       {item.shortcut && (
                         <kbd className="shrink-0 text-[10px] text-text-tertiary bg-elevation-2 px-1.5 py-0.5 rounded border border-border font-mono">

--- a/src/components/palette/HighlightedText.tsx
+++ b/src/components/palette/HighlightedText.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react';
+
+interface HighlightedTextProps {
+  text: string;
+  positions: number[];
+  className?: string;
+  matchClassName?: string;
+}
+
+/**
+ * Render `text` with characters at `positions` wrapped in a highlighted span.
+ * Positions must be sorted ascending. Consecutive positions collapse into
+ * a single span for cleaner DOM.
+ */
+export const HighlightedText = memo(function HighlightedText({
+  text,
+  positions,
+  className,
+  matchClassName = 'text-accent-primary font-semibold',
+}: HighlightedTextProps) {
+  if (positions.length === 0) {
+    return <span className={className}>{text}</span>;
+  }
+  const parts: React.ReactNode[] = [];
+  const posSet = new Set(positions);
+  let i = 0;
+  while (i < text.length) {
+    if (posSet.has(i)) {
+      // Collect consecutive match run
+      let j = i;
+      while (j < text.length && posSet.has(j)) j++;
+      parts.push(
+        <span key={`m-${i}`} className={matchClassName}>{text.slice(i, j)}</span>
+      );
+      i = j;
+    } else {
+      // Collect run of non-matches
+      let j = i;
+      while (j < text.length && !posSet.has(j)) j++;
+      parts.push(<span key={`t-${i}`}>{text.slice(i, j)}</span>);
+      i = j;
+    }
+  }
+  return <span className={className}>{parts}</span>;
+});

--- a/src/lib/paletteMatching.test.ts
+++ b/src/lib/paletteMatching.test.ts
@@ -7,6 +7,7 @@ describe('fuzzyMatch', () => {
     expect(fuzzyMatch('Toggle Sidebar', 'toggle')).toEqual({
       matches: true,
       score: 100,
+      positions: [0, 1, 2, 3, 4, 5],
     });
   });
 
@@ -16,8 +17,16 @@ describe('fuzzyMatch', () => {
     const start = fuzzyMatch('toggle sidebar', 'toggle');
     const middle = fuzzyMatch('Sidebar toggle', 'toggle');
     expect(start.score).toBeGreaterThan(middle.score);
-    expect(start).toEqual({ matches: true, score: 100 });
-    expect(middle).toEqual({ matches: true, score: 100 - 'Sidebar '.length });
+    expect(start).toEqual({
+      matches: true,
+      score: 100,
+      positions: [0, 1, 2, 3, 4, 5],
+    });
+    expect(middle).toEqual({
+      matches: true,
+      score: 100 - 'Sidebar '.length,
+      positions: [8, 9, 10, 11, 12, 13],
+    });
   });
 
   it('falls back to character-by-character fuzzy matching when no substring hit', () => {
@@ -28,16 +37,25 @@ describe('fuzzyMatch', () => {
     expect(result.score).toBeGreaterThan(0);
     // Substring scores are triple-digit; fuzzy stays in single/low double.
     expect(result.score).toBeLessThan(100);
+    expect(result.positions).toEqual([0, 2, 4]);
   });
 
   it('returns matches:false when the query characters are not all present in order', () => {
-    expect(fuzzyMatch('Toggle Sidebar', 'zzz')).toEqual({ matches: false, score: 0 });
+    expect(fuzzyMatch('Toggle Sidebar', 'zzz')).toEqual({
+      matches: false,
+      score: 0,
+      positions: [],
+    });
   });
 
   it('treats an empty query as a match with score 0', () => {
     // Added for Phase 5 — lets callers pipe unfiltered input through the same
     // scoring path instead of guarding externally.
-    expect(fuzzyMatch('anything', '')).toEqual({ matches: true, score: 0 });
+    expect(fuzzyMatch('anything', '')).toEqual({
+      matches: true,
+      score: 0,
+      positions: [],
+    });
   });
 
   it('is case-insensitive for both text and query', () => {
@@ -53,6 +71,32 @@ describe('fuzzyMatch', () => {
     expect(consecutive.matches).toBe(true);
     expect(scattered.matches).toBe(true);
     expect(consecutive.score).toBeGreaterThan(scattered.score);
+  });
+
+  it('returns a contiguous positions run for a substring match at the start', () => {
+    // Task C addition: highlighting needs the exact indices, not just a boolean.
+    expect(fuzzyMatch('hello', 'hel').positions).toEqual([0, 1, 2]);
+  });
+
+  it('returns a contiguous positions run for a substring match in the middle', () => {
+    expect(fuzzyMatch('hello', 'llo').positions).toEqual([2, 3, 4]);
+  });
+
+  it('returns scattered positions for a character-by-character fuzzy match', () => {
+    // 'sch' in 'search' → s@0, c@4, h@5 (no substring, so falls through to
+    // per-char scanning; 'c' is the first 'c' after 's', 'h' is the first 'h'
+    // after that 'c').
+    const result = fuzzyMatch('search', 'sch');
+    expect(result.matches).toBe(true);
+    expect(result.positions).toEqual([0, 4, 5]);
+  });
+
+  it('returns empty positions when the query does not match', () => {
+    expect(fuzzyMatch('hello', 'xyz').positions).toEqual([]);
+  });
+
+  it('returns empty positions when the query is empty', () => {
+    expect(fuzzyMatch('hello', '').positions).toEqual([]);
   });
 });
 

--- a/src/lib/paletteMatching.test.ts
+++ b/src/lib/paletteMatching.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { frecencyScore, fuzzyMatch } from './paletteMatching';
+
+describe('fuzzyMatch', () => {
+  it('scores an exact substring at the start near 100', () => {
+    // Substring at index 0 → 100 - 0 = 100.
+    expect(fuzzyMatch('Toggle Sidebar', 'toggle')).toEqual({
+      matches: true,
+      score: 100,
+    });
+  });
+
+  it('scores an exact substring in the middle lower than the same substring at the start', () => {
+    // Same needle in both haystacks, positioned differently. The 100 - startIdx
+    // rule means the earlier match wins by exactly the offset difference.
+    const start = fuzzyMatch('toggle sidebar', 'toggle');
+    const middle = fuzzyMatch('Sidebar toggle', 'toggle');
+    expect(start.score).toBeGreaterThan(middle.score);
+    expect(start).toEqual({ matches: true, score: 100 });
+    expect(middle).toEqual({ matches: true, score: 100 - 'Sidebar '.length });
+  });
+
+  it('falls back to character-by-character fuzzy matching when no substring hit', () => {
+    // 'tgl' has no substring in 'Toggle Sidebar' but the chars appear in order.
+    // T(1) o... g(consecutive? no → 1) ... l(consecutive? no → 1) = 3.
+    const result = fuzzyMatch('Toggle Sidebar', 'tgl');
+    expect(result.matches).toBe(true);
+    expect(result.score).toBeGreaterThan(0);
+    // Substring scores are triple-digit; fuzzy stays in single/low double.
+    expect(result.score).toBeLessThan(100);
+  });
+
+  it('returns matches:false when the query characters are not all present in order', () => {
+    expect(fuzzyMatch('Toggle Sidebar', 'zzz')).toEqual({ matches: false, score: 0 });
+  });
+
+  it('treats an empty query as a match with score 0', () => {
+    // Added for Phase 5 — lets callers pipe unfiltered input through the same
+    // scoring path instead of guarding externally.
+    expect(fuzzyMatch('anything', '')).toEqual({ matches: true, score: 0 });
+  });
+
+  it('is case-insensitive for both text and query', () => {
+    expect(fuzzyMatch('TOGGLE SIDEBAR', 'toggle').matches).toBe(true);
+    expect(fuzzyMatch('toggle sidebar', 'TOGGLE').matches).toBe(true);
+  });
+
+  it('rewards consecutive fuzzy matches over scattered ones', () => {
+    // 'abc' consecutive: a(1)+b(3)+c(3) = 7.
+    // 'abc' scattered by unrelated letters: a(1)+b(1)+c(1) = 3.
+    const consecutive = fuzzyMatch('xabcy', 'abc');
+    const scattered = fuzzyMatch('axbxc', 'abc');
+    expect(consecutive.matches).toBe(true);
+    expect(scattered.matches).toBe(true);
+    expect(consecutive.score).toBeGreaterThan(scattered.score);
+  });
+});
+
+describe('frecencyScore', () => {
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 when usage is undefined', () => {
+    expect(frecencyScore(undefined)).toBe(0);
+  });
+
+  it('adds an 8-point recency bump for usage within the last hour', () => {
+    // 10 minutes ago.
+    expect(frecencyScore({ count: 3, lastUsedTs: NOW - 10 * 60 * 1000 })).toBe(3 + 8);
+  });
+
+  it('adds a 4-point recency bump for usage within the last day', () => {
+    // 5 hours ago.
+    expect(frecencyScore({ count: 2, lastUsedTs: NOW - 5 * 3_600_000 })).toBe(2 + 4);
+  });
+
+  it('adds a 2-point recency bump for usage within the last week', () => {
+    // 3 days ago.
+    expect(frecencyScore({ count: 5, lastUsedTs: NOW - 3 * 24 * 3_600_000 })).toBe(5 + 2);
+  });
+
+  it('adds a 1-point recency bump for usage older than a week', () => {
+    // 30 days ago.
+    expect(frecencyScore({ count: 10, lastUsedTs: NOW - 30 * 24 * 3_600_000 })).toBe(10 + 1);
+  });
+});

--- a/src/lib/paletteMatching.ts
+++ b/src/lib/paletteMatching.ts
@@ -1,0 +1,72 @@
+// Palette matching helpers extracted from CommandPalette.tsx so they can be
+// unit-tested in isolation and reused by any palette source in Phase 5.
+//
+// Semantics are preserved verbatim from the original inline implementations;
+// the only intentional addition is empty-query handling in fuzzyMatch, which
+// the CommandPalette caller previously guarded externally.
+
+export interface PaletteUsage {
+  count: number;
+  lastUsedTs: number;
+}
+
+export interface FuzzyMatchResult {
+  matches: boolean;
+  score: number;
+}
+
+/**
+ * Fuzzy match text against query. Exact-substring matches score highest
+ * (100 - startIdx, so front matches beat middle matches). Character-by-
+ * character fuzzy match falls back if no substring hit — consecutive
+ * matches get a 3-point bonus, non-consecutive 1 point.
+ * Empty query returns { matches: true, score: 0 }.
+ */
+export function fuzzyMatch(text: string, query: string): FuzzyMatchResult {
+  // Empty query: everything matches with a neutral score, so callers can
+  // safely feed unfiltered input through the same pipeline.
+  if (query.length === 0) {
+    return { matches: true, score: 0 };
+  }
+
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+
+  // Exact substring match (highest score)
+  const subIdx = lower.indexOf(q);
+  if (subIdx !== -1) {
+    // Prefer matches at the start
+    return { matches: true, score: 100 - subIdx };
+  }
+
+  // Character-by-character fuzzy match
+  let qi = 0;
+  let score = 0;
+  let lastMatchIdx = -1;
+  for (let i = 0; i < lower.length && qi < q.length; i++) {
+    if (lower[i] === q[qi]) {
+      qi++;
+      // Bonus for consecutive matches
+      score += lastMatchIdx === i - 1 ? 3 : 1;
+      lastMatchIdx = i;
+    }
+  }
+  if (qi === q.length) {
+    return { matches: true, score };
+  }
+  return { matches: false, score: 0 };
+}
+
+/**
+ * Frecency = frequency + recency. Small recency bump keeps recently-used
+ * items near the top without letting a one-off click outrank a daily habit.
+ * Returns 0 for undefined usage.
+ */
+export function frecencyScore(usage?: PaletteUsage): number {
+  if (!usage) return 0;
+  const age = Date.now() - usage.lastUsedTs;
+  const HOUR = 3_600_000;
+  const DAY = 24 * HOUR;
+  const recency = age < HOUR ? 8 : age < DAY ? 4 : age < 7 * DAY ? 2 : 1;
+  return usage.count + recency;
+}

--- a/src/lib/paletteMatching.ts
+++ b/src/lib/paletteMatching.ts
@@ -13,6 +13,10 @@ export interface PaletteUsage {
 export interface FuzzyMatchResult {
   matches: boolean;
   score: number;
+  /** Indices in `text` (lowercased for comparison) where each character of
+   * `query` matched. Empty when no match. For substring matches, positions
+   * is a contiguous run [start, start+1, ..., start+query.length-1]. */
+  positions: number[];
 }
 
 /**
@@ -20,13 +24,13 @@ export interface FuzzyMatchResult {
  * (100 - startIdx, so front matches beat middle matches). Character-by-
  * character fuzzy match falls back if no substring hit — consecutive
  * matches get a 3-point bonus, non-consecutive 1 point.
- * Empty query returns { matches: true, score: 0 }.
+ * Empty query returns { matches: true, score: 0, positions: [] }.
  */
 export function fuzzyMatch(text: string, query: string): FuzzyMatchResult {
   // Empty query: everything matches with a neutral score, so callers can
   // safely feed unfiltered input through the same pipeline.
   if (query.length === 0) {
-    return { matches: true, score: 0 };
+    return { matches: true, score: 0, positions: [] };
   }
 
   const lower = text.toLowerCase();
@@ -36,25 +40,29 @@ export function fuzzyMatch(text: string, query: string): FuzzyMatchResult {
   const subIdx = lower.indexOf(q);
   if (subIdx !== -1) {
     // Prefer matches at the start
-    return { matches: true, score: 100 - subIdx };
+    const positions: number[] = [];
+    for (let i = 0; i < q.length; i++) positions.push(subIdx + i);
+    return { matches: true, score: 100 - subIdx, positions };
   }
 
   // Character-by-character fuzzy match
   let qi = 0;
   let score = 0;
   let lastMatchIdx = -1;
+  const positions: number[] = [];
   for (let i = 0; i < lower.length && qi < q.length; i++) {
     if (lower[i] === q[qi]) {
       qi++;
       // Bonus for consecutive matches
       score += lastMatchIdx === i - 1 ? 3 : 1;
       lastMatchIdx = i;
+      positions.push(i);
     }
   }
   if (qi === q.length) {
-    return { matches: true, score };
+    return { matches: true, score, positions };
   }
-  return { matches: false, score: 0 };
+  return { matches: false, score: 0, positions: [] };
 }
 
 /**

--- a/src/lib/paletteSources.test.ts
+++ b/src/lib/paletteSources.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { PALETTE_SOURCES } from './paletteSources';
+
+describe('PALETTE_SOURCES', () => {
+  it('is an array (may be empty until Task B populates it)', () => {
+    expect(Array.isArray(PALETTE_SOURCES)).toBe(true);
+  });
+
+  it('each source has required fields when populated', () => {
+    for (const src of PALETTE_SOURCES) {
+      expect(typeof src.id).toBe('string');
+      expect(typeof src.label).toBe('string');
+      expect(typeof src.category).toBe('string');
+      expect(typeof src.icon).toBe('function'); // LucideIcon is a Component function
+    }
+  });
+});

--- a/src/lib/paletteSources.test.ts
+++ b/src/lib/paletteSources.test.ts
@@ -2,16 +2,32 @@ import { describe, it, expect } from 'vitest';
 import { PALETTE_SOURCES } from './paletteSources';
 
 describe('PALETTE_SOURCES', () => {
-  it('is an array (may be empty until Task B populates it)', () => {
-    expect(Array.isArray(PALETTE_SOURCES)).toBe(true);
+  it('contains the four expected sources in order', () => {
+    expect(PALETTE_SOURCES.map((s) => s.id)).toEqual([
+      'terminals',
+      'commands',
+      'hints',
+      'snippets',
+    ]);
   });
 
-  it('each source has required fields when populated', () => {
+  it('each source has required fields', () => {
+    expect(PALETTE_SOURCES.length).toBe(4);
     for (const src of PALETTE_SOURCES) {
       expect(typeof src.id).toBe('string');
       expect(typeof src.label).toBe('string');
       expect(typeof src.category).toBe('string');
-      expect(typeof src.icon).toBe('function'); // LucideIcon is a Component function
+      // LucideIcon is a React.forwardRef component — object in current lucide-react,
+      // function in older builds. Both are renderable.
+      expect(['function', 'object']).toContain(typeof src.icon);
+      expect(src.icon).toBeTruthy();
     }
+  });
+
+  it('prefix chars are unique across sources that declare one', () => {
+    const prefixes = PALETTE_SOURCES.map((s) => s.prefix).filter(
+      (p): p is string => typeof p === 'string',
+    );
+    expect(new Set(prefixes).size).toBe(prefixes.length);
   });
 });

--- a/src/lib/paletteSources.ts
+++ b/src/lib/paletteSources.ts
@@ -1,0 +1,46 @@
+// Palette source registry — types + fixed-order array for the command
+// palette's Search Everywhere upgrade (Phase 5). This file only defines the
+// shape; Task B populates PALETTE_SOURCES and rewrites CommandPalette to
+// consume it.
+
+import type { LucideIcon } from 'lucide-react';
+
+/** A single result item in the command palette. */
+export interface PaletteItem {
+  id: string;
+  /** Stable key for frecency tracking. Empty string = not tracked. */
+  frecencyKey: string;
+  label: string;
+  description: string;
+  category: string;
+  icon?: LucideIcon;
+  shortcut?: string;
+  /** Tailwind bg-* class for a presence dot. Supplementary; status is also
+   *  spelled out in the description so we never convey state by color alone. */
+  statusColor?: string;
+  action: () => void;
+}
+
+/**
+ * A palette source contributes items to the command palette. Sources are
+ * enumerated in a fixed order and can be filtered via the source-chip
+ * strip or the prefix characters.
+ */
+export interface PaletteSource {
+  /** Stable id used in filter state. */
+  id: string;
+  /** Human-readable label shown in the chip strip. */
+  label: string;
+  /** Icon for the chip. */
+  icon: LucideIcon;
+  /** Optional single-char prefix that filters to just this source (e.g. '>', '@', '#'). */
+  prefix?: string;
+  /** Category name items from this source use (must match PaletteItem.category). */
+  category: string;
+}
+
+/**
+ * Static registry of sources in the order they appear in the chip strip.
+ * When a source is added, Task B (filter chips) auto-picks it up.
+ */
+export const PALETTE_SOURCES: PaletteSource[] = [];

--- a/src/lib/paletteSources.ts
+++ b/src/lib/paletteSources.ts
@@ -1,9 +1,8 @@
 // Palette source registry — types + fixed-order array for the command
-// palette's Search Everywhere upgrade (Phase 5). This file only defines the
-// shape; Task B populates PALETTE_SOURCES and rewrites CommandPalette to
-// consume it.
+// palette's Search Everywhere upgrade (Phase 5). The chip strip in
+// CommandPalette iterates PALETTE_SOURCES to render one chip per source.
 
-import type { LucideIcon } from 'lucide-react';
+import { Terminal, Command, Lightbulb, Scissors, type LucideIcon } from 'lucide-react';
 
 /** A single result item in the command palette. */
 export interface PaletteItem {
@@ -41,6 +40,14 @@ export interface PaletteSource {
 
 /**
  * Static registry of sources in the order they appear in the chip strip.
- * When a source is added, Task B (filter chips) auto-picks it up.
+ * The chip strip renders "All" first, followed by these sources in order.
+ * `prefix` mirrors the typed-prefix modes the palette accepts for
+ * backward compatibility (users who learned '>', '@', '#' still get the
+ * matching chip highlighted).
  */
-export const PALETTE_SOURCES: PaletteSource[] = [];
+export const PALETTE_SOURCES: PaletteSource[] = [
+  { id: 'terminals', label: 'Terminals', icon: Terminal, prefix: '@', category: 'Terminals' },
+  { id: 'commands',  label: 'Commands',  icon: Command,  prefix: '>', category: 'Commands' },
+  { id: 'hints',     label: 'Hints',     icon: Lightbulb,             category: 'Hints' },
+  { id: 'snippets',  label: 'Snippets',  icon: Scissors, prefix: '#', category: 'Snippets' },
+];


### PR DESCRIPTION
## Summary

Elevates the existing CommandPalette to match IntelliJ's "Search Everywhere" UX. Previously the palette had **invisible** prefix modes (`>` `@` `#`) users could only discover from placeholder text. This PR makes source filtering **visible, clickable, and keyboard-navigable**.

- **Visible source chips** — clickable filter chips at the top of the palette (All / Terminals / Commands / Hints / Snippets), active chip in accent color
- **Ctrl+Tab cycling** — Ctrl+Tab forward, Ctrl+Shift+Tab backward through chips; the global Ctrl+Tab (terminal cycling) is correctly bailed by the existing `isFocusInNonTerminalEditable` guard so no collision
- **Match highlighting** — matched characters in each result (label + description) render in accent color so users see WHY a fuzzy match ranked highly. Substring matches produce a contiguous run; char-by-char fuzzy matches produce scattered highlights
- **Backward compatible** — typed prefixes (`>`, `@`, `#`) still work identically, and highlight the matching chip so users transitioning from prefix habit see the chip they were implicitly using

## Verification

- **Tests:** 299 → 319 passing / 35 files (+20 new)
  - fuzzyMatch: 12 tests (7 base + 3 position + 2 empty-query edge)
  - frecencyScore: 5 tests
  - source registry shape: 3 tests
- **Build:** clean, no new warnings
- **TypeScript:** clean
- **New dependencies:** none

## Commits

1. `4979811` feat(lib) — extract palette matching helpers + source registry types
2. `cf6f7e1` feat(palette) — visible source-filter chips + Ctrl+Tab cycling
3. `7ef7025` feat(palette) — highlight matched characters in search results

## Interaction with existing features

- **Frecency ranking untouched** — `paletteUsage` state and boost math preserved
- **Recent group untouched** — empty query still surfaces 5 most-recently-used items at the top
- **Typed prefixes preserved** — `>` still shows Commands + Hints (both sources) for muscle-memory continuity
- **Clicking "All" chip** — strips any typed prefix from the input (nice touch, prevents users from getting stuck in an invisible mode)

## Reviewer's algorithm trace (verified positions)

- `fuzzyMatch('Toggle Sidebar', 'tgl')` → positions `[0, 2, 4]` (t@0, g@2, first l@4)
- `fuzzyMatch('search', 'sch')` → positions `[0, 4, 5]` (s@0, c@4, h@5)
- `fuzzyMatch('hello', 'ell')` → positions `[1, 2, 3]` (contiguous substring)

## Test plan

- [ ] `npm run tauri dev` → Ctrl+P opens palette → verify visible chip strip: All | Terminals | Commands | Hints | Snippets
- [ ] Type `set` → "Open Settings" renders with **Set** in accent color
- [ ] Click **Terminals** chip → only terminals show; chip highlighted; results filtered
- [ ] Ctrl+Tab → chip cycles Terminals → Commands → Hints → Snippets → All
- [ ] Ctrl+Shift+Tab → cycles backward
- [ ] Type `@` → Terminals chip highlights via typed-prefix path
- [ ] Backspace prefix → chip un-highlights
- [ ] Escape → palette closes; reopens with All active (per-mount reset)
- [ ] `npm run test:run` → 319 passing

## Follow-up polish (not blocking merge)

- **Prefix + chip-click harmonization** — currently clicking a source chip while a typed prefix is active is a visual no-op (prefix wins). Decide whether to strip the prefix (like "All" does) for consistency
- **Chip strip a11y** — add `role="group" aria-label="Filter by source"` on the chip container
- **Overflow affordance** — chips use `scrollbar-none`; if future sources push past ~10 chips, add fade-mask or `scrollbar-thin` so overflow is visible
- **Stable EMPTY_POSITIONS constant** — hoist a module constant to help `HighlightedText`'s memo when positions are absent
- **Placeholder text update** — still advertises only prefix chars; could mention Ctrl+Tab (footer already does)
- **Future sources** — Git branches (contextual on active terminal's repo), Settings deep-links, File search (needs FS walk backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)