### PR TITLE
fix(terminal): buffer pre-attach PTY output so new tabs don't open blank (#48)

### DIFF
--- a/src/store/terminalStore.test.ts
+++ b/src/store/terminalStore.test.ts
@@ -8,7 +8,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 import type { TerminalConfig } from './terminalStore';
-import { useTerminalStore } from './terminalStore';
+import { useTerminalStore, __resetPendingOutputBuffersForTest } from './terminalStore';
 
 function makeConfig(id: string, overrides: Partial<TerminalConfig> = {}): TerminalConfig {
   return {
@@ -46,6 +46,10 @@ function seed(ids: string[], activeId: string | null = null) {
     bottomTerminalIds: [],
     activeBottomTerminalId: null,
   });
+  // Every handleTerminalOutput() call in the earlier cases queues bytes into
+  // the module-scoped pre-attach buffer. Clear it so setXterm-based tests
+  // don't inherit chunks from unrelated prior cases.
+  __resetPendingOutputBuffersForTest();
 }
 
 describe('terminalStore - unread set', () => {
@@ -231,6 +235,95 @@ describe('terminalStore - writeToTerminal chunking', () => {
     );
     expect(dataLengths.reduce((n, len) => n + len, 0)).toBe(big.length);
     expect(dataLengths.every((len) => len <= 60 * 1024)).toBe(true);
+  });
+});
+
+describe('terminalStore - pre-attach output buffer (issue #48)', () => {
+  beforeEach(() => {
+    seed([]);
+  });
+
+  it('buffers output when xterm is not yet attached, then replays on setXterm', () => {
+    seed(['a'], 'a');
+    // Simulate the spawn→attach race: the backend has started streaming
+    // (Claude Code's ANSI-heavy welcome banner) but TerminalView has not yet
+    // mounted, so xterm is still null.
+    const first = new Uint8Array([0x1b, 0x5b, 0x3f, 0x32, 0x35, 0x6c]); // ESC[?25l
+    const second = new Uint8Array([0x68, 0x69]); // "hi"
+    useTerminalStore.getState().handleTerminalOutput('a', first);
+    useTerminalStore.getState().handleTerminalOutput('a', second);
+
+    // Now the view mounts and attaches. setXterm must replay both chunks in
+    // arrival order so xterm's escape parser sees the ESC prefix before its
+    // continuation — otherwise ANSI parsing wedges and the tab looks blank.
+    const write = vi.fn();
+    useTerminalStore.getState().setXterm('a', { write } as never);
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenNthCalledWith(1, first);
+    expect(write).toHaveBeenNthCalledWith(2, second);
+  });
+
+  it('drains the pending buffer only once (no double-replay across attaches)', () => {
+    seed(['a'], 'a');
+    const chunk = new Uint8Array([0x41]); // "A"
+    useTerminalStore.getState().handleTerminalOutput('a', chunk);
+
+    const writeA = vi.fn();
+    useTerminalStore.getState().setXterm('a', { write: writeA } as never);
+    expect(writeA).toHaveBeenCalledTimes(1);
+
+    // A view-switch cycle (unmount then remount) must NOT re-emit the drained
+    // banner — otherwise every tab-switch replays Claude's welcome and the
+    // scrollback duplicates. carryOverBuffer handles the in-lifetime handoff.
+    useTerminalStore.getState().setXterm('a', null);
+    const writeB = vi.fn();
+    useTerminalStore.getState().setXterm('a', { write: writeB } as never);
+    expect(writeB).not.toHaveBeenCalled();
+  });
+
+  it('writes live output directly to xterm when one is attached (no buffering)', () => {
+    seed(['a'], 'a');
+    const write = vi.fn();
+    useTerminalStore.setState((state) => {
+      const next = new Map(state.terminals);
+      const inst = next.get('a')!;
+      next.set('a', { ...inst, xterm: { write } as never });
+      return { terminals: next };
+    });
+
+    const bytes = new Uint8Array([0x42]);
+    useTerminalStore.getState().handleTerminalOutput('a', bytes);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(bytes);
+
+    // After attach, the pending buffer must be empty — a later attach cycle
+    // shouldn't find any queued chunks.
+    useTerminalStore.setState((state) => {
+      const next = new Map(state.terminals);
+      const inst = next.get('a')!;
+      next.set('a', { ...inst, xterm: null });
+      return { terminals: next };
+    });
+    const write2 = vi.fn();
+    useTerminalStore.getState().setXterm('a', { write: write2 } as never);
+    expect(write2).not.toHaveBeenCalled();
+  });
+
+  it('closeTerminal clears any pre-attach buffer so a re-created id starts clean', async () => {
+    seed(['a'], 'a');
+    useTerminalStore.getState().handleTerminalOutput('a', new Uint8Array([0x58]));
+
+    invokeMock.mockClear();
+    invokeMock.mockResolvedValueOnce(undefined); // close_terminal returns void
+    await useTerminalStore.getState().closeTerminal('a');
+
+    // Re-seed the same id, then attach: nothing should be replayed from the
+    // previous life — that data belongs to a dead PTY.
+    seed(['a'], 'a');
+    const write = vi.fn();
+    useTerminalStore.getState().setXterm('a', { write } as never);
+    expect(write).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -13,6 +13,54 @@ import { detectFramework, type FrameworkHint } from '../lib/preview/framework';
 // (multi-hundred KB) don't hit "Write payload too large".
 const TERMINAL_WRITE_CHUNK_BYTES = 60 * 1024;
 
+// PTY output can arrive before the xterm instance is attached: the backend
+// starts streaming as soon as it spawns Claude Code (reader thread + mpsc
+// drainer), while the frontend still needs `await invoke` to resolve, `set()`
+// to add the terminal to the store, React to mount TerminalView, xterm to
+// initialize, and setXterm to register the ref. Anything in that window used
+// to be silently dropped by handleTerminalOutput, which broke ANSI escape
+// parsing and left new tabs showing a blank screen with a stray `[` (issue
+// #48). We buffer chunks here keyed by terminal id and drain them when
+// setXterm attaches the real xterm. Bounded so a runaway id (e.g. events for
+// a terminal that lives in another window) can't grow the buffer forever.
+const pendingOutputBuffers = new Map<string, Uint8Array[]>();
+const MAX_PENDING_OUTPUT_BYTES_PER_TERMINAL = 512 * 1024;
+
+function bufferPendingOutput(id: string, data: Uint8Array): void {
+  let chunks = pendingOutputBuffers.get(id);
+  const currentBytes = chunks?.reduce((n, c) => n + c.byteLength, 0) ?? 0;
+  if (currentBytes + data.byteLength > MAX_PENDING_OUTPUT_BYTES_PER_TERMINAL) {
+    return; // cap reached — drop rather than grow unbounded
+  }
+  if (!chunks) {
+    chunks = [];
+    pendingOutputBuffers.set(id, chunks);
+  }
+  chunks.push(data);
+}
+
+function drainPendingOutput(id: string, xterm: Terminal): void {
+  const chunks = pendingOutputBuffers.get(id);
+  if (!chunks) return;
+  pendingOutputBuffers.delete(id);
+  for (const chunk of chunks) {
+    try {
+      xterm.write(chunk);
+    } catch {
+      // xterm disposed mid-drain — the rest is unrecoverable, stop.
+      return;
+    }
+  }
+}
+
+/** Test-only: clear the pre-attach buffer. Vitest keeps module state across
+ *  test cases, so beforeEach hooks in terminalStore.test.ts call this to stop
+ *  leftover chunks from an earlier case leaking into the next replay. Not for
+ *  production use. */
+export function __resetPendingOutputBuffersForTest(): void {
+  pendingOutputBuffers.clear();
+}
+
 /**
  * Best-effort framework detection for the Preview panel. Reads the terminal's
  * cwd/package.json via the existing `list_package_scripts` IPC (no new Rust
@@ -333,6 +381,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
     await invoke('close_terminal', { id });
 
+    // Drop any pre-attach buffered output — the terminal is gone, so replay
+    // makes no sense and the entry would linger until process exit.
+    pendingOutputBuffers.delete(id);
+    if (childId) pendingOutputBuffers.delete(childId);
+
     set((state) => {
       const newTerminals = new Map(state.terminals);
       const instance = newTerminals.get(id);
@@ -486,6 +539,12 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       xterm.write(instance.carryOverBuffer);
     }
 
+    // Replay any PTY chunks that arrived before this xterm was attached (the
+    // spawn→attach race that used to leave issue-#48 tabs blank). Ordered
+    // after restoredOutput/carryOverBuffer so historical scrollback stays
+    // above the live stream — same ordering rule the reader thread enforces.
+    drainPendingOutput(id, xterm);
+
     set((state) => {
       const newTerminals = new Map(state.terminals);
       const inst = newTerminals.get(id);
@@ -524,6 +583,15 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       } catch {
         /* terminal disposed - drop this chunk */
       }
+    } else {
+      // No xterm attached yet (spawn→attach race on a brand-new tab, or the
+      // instance hasn't been added to state yet because `set()` from
+      // createTerminal is still queued behind this event). Buffer the chunk so
+      // setXterm can replay it once the view mounts. Fixes the "new terminal
+      // opens blank" bug (issue #48): a single dropped byte at the start of
+      // Claude Code's ANSI-heavy welcome banner wedged xterm's escape parser
+      // and left the whole tab looking empty.
+      bufferPendingOutput(id, data);
     }
     // Active-work indicator: record the timestamp in a plain Map (no Zustand
     // set() - that would defeat the streaming-rate optimization below).
@@ -708,6 +776,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         newUnread.delete(id);
         newGitCache.delete(id);
         clearTerminalActivity(id);
+        // The tab is moving to another window; that window's store owns any
+        // replay from here on. Drop our copy so future events for this id
+        // (still fired globally by the shared backend) don't buffer forever.
+        pendingOutputBuffers.delete(id);
 
         // Drop any local script-child entry for this parent. We do NOT close
         // the child's PTY — detach never kills processes — but the child isn't
@@ -718,6 +790,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           if (childInst?.xterm) childInst.xterm.dispose();
           newTerminals.delete(childId);
           newChildren.delete(id);
+          pendingOutputBuffers.delete(childId);
         }
       }
 
@@ -783,6 +856,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     } catch {
       // Already closed - fall through to store cleanup.
     }
+    pendingOutputBuffers.delete(childId);
     set((state) => {
       const nextTerminals = new Map(state.terminals);
       const inst = nextTerminals.get(childId);
@@ -821,6 +895,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     } catch {
       // Already gone - fall through to store cleanup.
     }
+    pendingOutputBuffers.delete(id);
     set((state) => {
       const nextTerminals = new Map(state.terminals);
       const inst = nextTerminals.get(id);


### PR DESCRIPTION
Fixes #48.

## Summary
- **Root cause**: `handleTerminalOutput` silently dropped PTY chunks when `instance?.xterm` was null. There's a reliable spawn→attach race window on every new terminal — backend starts streaming Claude's welcome banner while the frontend is still resolving `invoke`, doing `set()`, mounting `TerminalView`, initializing xterm, and calling `setXterm`. Losing a single byte in the ANSI-heavy banner (typically the leading `\x1b`) wedges xterm's escape parser and the whole tab looks empty. Matches the "blank tab with a stray `[`" screenshots in the issue.
- **Fix**: `src/store/terminalStore.ts` now buffers pre-attach chunks in a module-scoped `Map<terminalId, Uint8Array[]>` (capped at 512 KB per terminal). `setXterm` drains the buffer after `restoredOutput`/`carryOverBuffer` so history still sits above the live stream. Cleanup wired into `closeTerminal`, `detachTerminals`, `closeScript`, and `closeShellTerminal`.
- **Tests**: 4 new cases in `terminalStore.test.ts` covering ordered replay, no double-replay across attach cycles, no buffering when xterm is already attached, and buffer clearing on close.

## Test plan
- [x] `npx vitest run` — 369/369 pass (20 pre-existing terminalStore + 4 new + 345 others)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open the app, spawn several new terminals in succession, confirm each renders Claude's welcome banner instead of a blank viewport
- [ ] Manual: verify the fix survives grid/split view switches (xterm remount) — the existing `carryOverBuffer` handles that path unchanged
- [ ] Manual: verify closed terminals don't leak buffered bytes across an id reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)