### PR TITLE
Fix editor data loss, Git operations, previews and session transfers

### DIFF
--- a/docs/codebase-audit-2026-09-10.md
+++ b/docs/codebase-audit-2026-09-10.md
@@ -1,0 +1,126 @@
+# Codebase audit — 2026-09-10
+
+Reviewed the React frontend, Rust/Tauri command layer, terminal/session and window lifecycle, editor, Git operations, preview configuration, and analytics worker. The findings below describe the reviewed baseline; all nine are addressed by the accompanying changes.
+
+## Fix verification
+
+- Frontend: 565 tests passed across 67 files.
+- Rust: 271 tests passed, including literal Git paths, unborn repositories, and safe directory-link deletion.
+- Analytics worker: 15 tests passed.
+- Production frontend build and diff whitespace checks passed. Existing bundle-size/dynamic-import warnings remain.
+- Headless Chromium with mocked Tauri IPC verified 24px editor text after selecting 24px, a write on file-tab blur, and confirmation/cancellation preserving a dirty file on keyboard close. The configured production CSP allowed a local iframe to load without policy violations.
+- Native multi-window and agent CLI integration still require desktop validation. On this Windows host, directory junction deletion was exercised; unprivileged file-symlink creation is unavailable. The Unix regression test covers file symlinks in CI.
+
+| Finding | Resolution |
+| --- | --- |
+| 1 | Shared dirty-aware close handler for mouse, middle-click, Enter, and Space. |
+| 2 | Resolve/check the parent and unlink the selected symlink or junction; reject root/traversal deletion. |
+| 3 | Reserve explicit sessions before continuation; scope claims per agent and normalized directory. |
+| 4 | Allow HTTP(S) frames in CSP; retain the preview host allowlist and sandbox. |
+| 5 | Shared NUL-delimited Git porcelain parser handles literal paths and rename/copy records. |
+| 6 | Apply stored editor preferences in both modes; auto-save on blur/tab switch, including edits during a pending write. |
+| 7 | Check repository membership separately from branch resolution. |
+| 8 | Wait for receiver readiness and correlated adoption acknowledgement; timeout/cancellation preserves source tabs and rolls back destination views. |
+| 9 | Route windows using saved terminal IDs; migrate only unambiguous legacy identities. |
+
+## Original audit verification
+
+- Frontend: 554 tests passed across 65 files (`npm.cmd run test:run`).
+- Rust: 267 tests passed (`cargo test --manifest-path src-tauri/Cargo.toml`).
+- Worker: 15 tests passed (`npm.cmd run test:run --prefix workers/ct-analytics`).
+- Production frontend build passed (`npm.cmd run build`); it warns about a 5.87 MB minified main JavaScript chunk and ineffective dynamic imports.
+- Headless Chromium: booted the actual frontend with mocked Tauri IPC, opened file tabs, checked editor rendering, switched files, and exercised keyboard closing. No startup page errors in that harness.
+- Browser policy reproduction used the exact CSP from `src-tauri/tauri.conf.json`.
+- Git reproductions used a newly created disposable repository under `.cache`, without touching the project's index or Git configuration.
+
+This was not a full native desktop E2E run: PTY spawning, real agent conversations, OS window transfers, credential stores, native updating, and macOS behavior were not exercised interactively. Mocked IPC does not establish that those integrations work. Findings below distinguish reproduced behavior from source-traced failure paths. Passing tests do not cover these cases.
+
+## 1. High — Keyboard closing silently discards unsaved edits
+
+Location: `src/components/TerminalTabs.tsx:262–265`.
+
+The close control's mouse and middle-click handlers confirm dirty-file discard, but its Enter/Space handler calls `closeFileTab` directly. That removes the file and its unsaved content from the store.
+
+Reproduced in Chromium: open a file, change its content, focus its “Unsaved changes” close control, and press Enter. The tab disappears; no confirmation dialog or write IPC occurs.
+
+Suggested fix: share one dirty-aware close handler across pointer and keyboard activation.
+
+## 2. High — Discarding an untracked symlink deletes its target
+
+Location: `src-tauri/src/commands.rs:5161–5185` (`git_discard_file`).
+
+The untracked-delete branch canonicalizes the selected path, then performs metadata lookup and deletion on that canonical target. An untracked symlink to a tracked file or directory inside the repository passes the containment check. Discarding the link therefore deletes the target file or recursively deletes the target directory, while leaving the link behind. A link to the repository root also passes the current equality-inclusive containment check.
+
+Evidence: source-traced deletion path; destructive behavior was not executed. The UI passes untracked entries to this branch from `ChangelistSection.tsx`.
+
+Suggested fix: inspect links without following them and unlink the selected link itself. Explicitly reject the repository root as a deletion target; preserve containment checks for ordinary entries.
+
+## 3. High — Restore can attach two terminals to one conversation
+
+Location: `src/lib/restorePlan.ts:45–56`; consumed by `src/App.tsx:702–752`.
+
+Session-ID claims and working-directory continuation claims are tracked independently. Given a saved terminal with session ID `newest-session` and an ID-less terminal in the same directory, the planner returns `resume(newest-session)` and `continue`. If that ID is the most recent conversation, both processes attach to it. This violates the planner's explicit isolation invariant.
+
+Reproduced the planner output in the browser against the actual module. Native agent attachment was not run. The existing “mixes id and id-less terminals independently” test currently enshrines this unsafe combination. Deduplication also lacks agent identity, so different agents can unnecessarily consume each other's continuation slots.
+
+Suggested fix: plan per agent and normalized directory; avoid ambiguous continuation whenever another restored terminal might already claim that directory's latest conversation. Resolve exact IDs where possible.
+
+## 4. Medium — Production CSP blocks local app previews
+
+Location: `src-tauri/tauri.conf.json:29`; iframe creation in `src/components/PreviewPanel.tsx:154–180`.
+
+The policy has `default-src 'self'` without a `frame-src` directive. Preview's JavaScript allowlist accepts localhost and configured external hosts, but the browser policy independently rejects their iframe navigation.
+
+Reproduced in Chromium using the exact configured policy and an iframe targeting `http://localhost:3000`: “Framing ... violates ... default-src 'self' ... The request has been blocked.” This policy-level reproduction did not require a running target server.
+
+Suggested fix: define a frame policy compatible with the intended preview destinations while retaining the application allowlist and appropriate iframe restrictions.
+
+## 5. Medium — Git filenames with spaces or non-ASCII characters break file actions
+
+Locations: `src-tauri/src/commands.rs:2119–2150` and `4557–4587`.
+
+Both status parsers read line-oriented `git status --porcelain` and treat the path substring as a literal filename. Git quotes paths containing spaces and escapes non-ASCII bytes under its default quote-path behavior. Neither parser decodes that representation. The resulting quoted/escaped string is passed to filesystem and Git actions.
+
+Reproduced with `file with spaces.txt` and `café.txt` in a disposable repository. The parser produced literal quote-wrapped paths; both subsequent `git add -- <parsed-path>` calls failed with exit 128, “pathspec ... did not match any files.”
+
+Suggested fix: use `--porcelain=v1 -z` and parse NUL-delimited records, including rename/copy records, without shell-style string splitting.
+
+## 6. Medium — Editor preferences and auto-save have no effect
+
+Locations: `src/components/FileEditorView.tsx:171–203`; settings in `src/components/settings/categories/EditorGeneralPage.tsx` and `EditorFontPage.tsx`.
+
+The settings pages persist font family/size/line height, tab size, word wrap, whitespace, minimap, and auto-save-on-blur preferences. The file editor uses hardcoded options and does not subscribe to these preferences. No production consumer implements `editorAutoSaveOnBlur`.
+
+Reproduced: set font size to 24 and enable auto-save, then open an editor. Its rendered text remained 13px. Change file A and switch to file B: zero `write_text_file` calls occurred. Other hardcoded options were confirmed by source inspection.
+
+Suggested fix: consume the stored settings in both editor modes and implement dirty-file saves when the relevant editor/tab loses focus, with save-error handling.
+
+## 7. Medium — Fresh Git repositories are treated as non-repositories
+
+Locations: `src-tauri/src/commands.rs:2091–2112` and `4530–4552`.
+
+The changes commands decide whether a directory is a Git repository by whether `git rev-parse --abbrev-ref HEAD` succeeds. That fails before the first commit, so both commands return `is_git_repo: false` before reading status. The changes UI cannot expose the initial files for staging through these commands.
+
+Reproduced after `git init`: the exact branch command exits 128, while `git rev-parse --is-inside-work-tree` returns `true` and status lists the untracked files.
+
+Suggested fix: test repository membership separately and support an unborn HEAD when resolving the branch.
+
+## 8. Medium — Failed tab transfer removes tabs from the source anyway
+
+Locations: `src/lib/tabTransfer.ts:35–62`, `103`, and `143–159`.
+
+`createDetachedWindow` returns after constructing the asynchronous WebviewWindow, before the created/error event. `routeTabDrop` then immediately detaches the source tabs. If creation fails, the error handler only reports the failure and never restores the tabs. Existing-window transfers also detach before the destination confirms adoption; a destination failure leaves the source empty. Restore uses the same premature-detachment pattern.
+
+Evidence: source-traced asynchronous failure paths. Native window-creation failure was not injected. The PTY can remain running in the backend while its source view has disappeared.
+
+Suggested fix: detach only after successful adoption acknowledgement, with bounded waiting and rollback/error feedback for failure.
+
+## 9. Medium — Window restore maps distinct same-directory shells to one terminal
+
+Locations: `src/lib/windowLayout.ts:25–31`; `src/App.tsx:691–720` and `762–769`.
+
+The fallback layout identity is only `cwd:<working_directory>`. Two shells in the same directory therefore have identical keys. During restore, assignment to `keyToNewId[stableKey]` overwrites the first restored terminal with the second. Saved detached-window entries for either shell resolve to the last terminal, so the wrong shell moves and multiple windows can adopt the same PTY. ID-less agents in the same directory have the same collision.
+
+Evidence: source-traced identity and mapping flow; native multi-window restore was not run.
+
+Suggested fix: persist a unique terminal identity for layout routing and map each saved terminal ID to its newly restored ID. Keep conversation identity separate from window/tab identity.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2088,18 +2088,7 @@ pub async fn get_terminal_changes(
         };
 
         // Check if it's a git repo and get branch name
-        let branch_output = git_cmd_async(&["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(&working_directory)
-            .output()
-            .await;
-
-        let (is_git_repo, branch) = match branch_output {
-            Ok(output) if output.status.success() => {
-                let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                (true, Some(branch))
-            }
-            _ => (false, None),
-        };
+        let (is_git_repo, branch) = crate::git_files::repository_branch(&working_directory).await;
 
         if !is_git_repo {
             return Ok(FileChangesResult {
@@ -2116,7 +2105,7 @@ pub async fn get_terminal_changes(
         let repo_root = resolve_repo_root(&working_directory).await.ok();
 
         // Get changed files
-        let status_output = git_cmd_async(&["status", "--porcelain"])
+        let status_output = git_cmd_async(&["status", "--porcelain=v1", "-z"])
             .current_dir(&working_directory)
             .output()
             .await
@@ -2134,52 +2123,7 @@ pub async fn get_terminal_changes(
             });
         }
 
-        let stdout = String::from_utf8_lossy(&status_output.stdout);
-        let mut changes: Vec<FileChange> = Vec::new();
-        for line in stdout.lines() {
-            if line.len() < 3 { continue; }
-            let x = line.as_bytes().get(0).copied().unwrap_or(b' ') as char;
-            let y = line.as_bytes().get(1).copied().unwrap_or(b' ') as char;
-            // Rename line: "R  old -> new"
-            let raw_path = &line[3..];
-            let path = if raw_path.contains(" -> ") {
-                raw_path.split(" -> ").nth(1).unwrap_or(raw_path).to_string()
-            } else {
-                raw_path.to_string()
-            };
-
-            if x == '?' && y == '?' {
-                // Untracked - always unstaged
-                changes.push(FileChange { path, status: "untracked".into(), staged: false });
-                continue;
-            }
-
-            let map_code = |c: char| match c {
-                'A' => "new",
-                'M' => "modified",
-                'D' => "deleted",
-                'R' => "renamed",
-                'C' => "new",
-                'U' => "modified", // conflicted - treat as modified
-                'T' => "modified", // type change
-                _ => "",
-            };
-
-            // Staged side (X)
-            if x != ' ' && x != '?' {
-                let status = map_code(x);
-                if !status.is_empty() {
-                    changes.push(FileChange { path: path.clone(), status: status.into(), staged: true });
-                }
-            }
-            // Unstaged side (Y)
-            if y != ' ' && y != '?' {
-                let status = map_code(y);
-                if !status.is_empty() {
-                    changes.push(FileChange { path, status: status.into(), staged: false });
-                }
-            }
-        }
+        let changes = crate::git_files::parse_status(&status_output.stdout);
 
         Ok(FileChangesResult {
             terminal_id: id,
@@ -4527,18 +4471,7 @@ pub async fn get_path_changes(
     wrap_cmd("get_path_changes", async move {
         validate_path_is_trusted(&state, &path).await?;
 
-        let branch_output = git_cmd_async(&["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(&path)
-            .output()
-            .await;
-
-        let (is_git_repo, branch) = match branch_output {
-            Ok(output) if output.status.success() => {
-                let b = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                (true, Some(b))
-            }
-            _ => (false, None),
-        };
+        let (is_git_repo, branch) = crate::git_files::repository_branch(&path).await;
 
         if !is_git_repo {
             return Ok(FileChangesResult {
@@ -4554,7 +4487,7 @@ pub async fn get_path_changes(
 
         let repo_root = resolve_repo_root(&path).await.ok();
 
-        let status_output = git_cmd_async(&["status", "--porcelain"])
+        let status_output = git_cmd_async(&["status", "--porcelain=v1", "-z"])
             .current_dir(&path)
             .output()
             .await
@@ -4572,48 +4505,7 @@ pub async fn get_path_changes(
             });
         }
 
-        let stdout = String::from_utf8_lossy(&status_output.stdout);
-        let mut changes: Vec<FileChange> = Vec::new();
-        for line in stdout.lines() {
-            if line.len() < 3 { continue; }
-            let x = line.as_bytes().get(0).copied().unwrap_or(b' ') as char;
-            let y = line.as_bytes().get(1).copied().unwrap_or(b' ') as char;
-            let raw_path = &line[3..];
-            let fpath = if raw_path.contains(" -> ") {
-                raw_path.split(" -> ").nth(1).unwrap_or(raw_path).to_string()
-            } else {
-                raw_path.to_string()
-            };
-
-            if x == '?' && y == '?' {
-                changes.push(FileChange { path: fpath, status: "untracked".into(), staged: false });
-                continue;
-            }
-
-            let map_code = |c: char| match c {
-                'A' => "new",
-                'M' => "modified",
-                'D' => "deleted",
-                'R' => "renamed",
-                'C' => "new",
-                'U' => "modified",
-                'T' => "modified",
-                _ => "",
-            };
-
-            if x != ' ' && x != '?' {
-                let status = map_code(x);
-                if !status.is_empty() {
-                    changes.push(FileChange { path: fpath.clone(), status: status.into(), staged: true });
-                }
-            }
-            if y != ' ' && y != '?' {
-                let status = map_code(y);
-                if !status.is_empty() {
-                    changes.push(FileChange { path: fpath, status: status.into(), staged: false });
-                }
-            }
-        }
+        let changes = crate::git_files::parse_status(&status_output.stdout);
 
         Ok(FileChangesResult {
             terminal_id: String::new(),
@@ -5156,34 +5048,9 @@ pub async fn git_discard_file(
         let root = resolve_repo_root(&path).await?;
 
         if untracked {
-            // Untracked files/directories aren't tracked by git - just remove from disk.
-            // Resolve and sanity-check it ends up inside the repo to avoid `..` escapes.
-            let joined = std::path::Path::new(&root).join(&file);
-            let canonical_target = joined.canonicalize().map_err(|e| {
-                format!("Cannot resolve '{}': {}", joined.display(), e)
-            })?;
-            let canonical_root = std::path::Path::new(&root)
-                .canonicalize()
-                .map_err(|e| format!("Cannot resolve repo '{}': {}", root, e))?;
-            if !canonical_target.starts_with(&canonical_root) {
-                return Err(format!(
-                    "Refusing to delete path outside repo: {}",
-                    canonical_target.display()
-                ));
-            }
-            let meta = tokio::fs::metadata(&canonical_target)
-                .await
-                .map_err(|e| format!("Failed to stat '{}': {}", canonical_target.display(), e))?;
-            if meta.is_dir() {
-                tokio::fs::remove_dir_all(&canonical_target)
-                    .await
-                    .map_err(|e| format!("Failed to delete directory: {}", e))?;
-            } else {
-                tokio::fs::remove_file(&canonical_target)
-                    .await
-                    .map_err(|e| format!("Failed to delete file: {}", e))?;
-            }
-            return Ok(());
+            return tokio::task::spawn_blocking(move || {
+                crate::git_files::discard_untracked(std::path::Path::new(&root), &file)
+            }).await.map_err(|e| format!("Discard task failed: {}", e))?;
         }
 
         // Tracked file - reset index + worktree for just this file to HEAD.

--- a/src-tauri/src/git_files.rs
+++ b/src-tauri/src/git_files.rs
@@ -1,0 +1,231 @@
+use crate::commands::{git_cmd_async, FileChange};
+use std::path::{Component, Path};
+
+/// Porcelain -z uses literal paths and places the destination before the
+/// additional source record for renames/copies. Paths may contain newlines.
+pub fn parse_status(bytes: &[u8]) -> Vec<FileChange> {
+    let mut records = bytes.split(|b| *b == 0);
+    let mut changes = Vec::new();
+    while let Some(record) = records.next() {
+        if record.len() < 4 {
+            continue;
+        }
+        let (x, y) = (record[0], record[1]);
+        let path = String::from_utf8_lossy(&record[3..]).into_owned();
+        if matches!(x, b'R' | b'C') || matches!(y, b'R' | b'C') {
+            records.next();
+        }
+        if x == b'?' && y == b'?' {
+            changes.push(FileChange {
+                path,
+                status: "untracked".into(),
+                staged: false,
+            });
+            continue;
+        }
+        for (code, staged) in [(x, true), (y, false)] {
+            let status = match code {
+                b'A' | b'C' => "new",
+                b'M' | b'U' | b'T' => "modified",
+                b'D' => "deleted",
+                b'R' => "renamed",
+                _ => continue,
+            };
+            changes.push(FileChange {
+                path: path.clone(),
+                status: status.into(),
+                staged,
+            });
+        }
+    }
+    changes
+}
+
+/// Branch resolution is independent of repository membership: HEAD may be unborn.
+pub async fn repository_branch(path: &str) -> (bool, Option<String>) {
+    let inside = git_cmd_async(&["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output()
+        .await;
+    if !inside.is_ok_and(|o| o.status.success() && o.stdout.starts_with(b"true")) {
+        return (false, None);
+    }
+    for args in [
+        vec!["symbolic-ref", "--short", "HEAD"],
+        vec!["rev-parse", "--abbrev-ref", "HEAD"],
+    ] {
+        if let Ok(output) = git_cmd_async(&args).current_dir(path).output().await {
+            if output.status.success() {
+                return (
+                    true,
+                    Some(String::from_utf8_lossy(&output.stdout).trim().into()),
+                );
+            }
+        }
+    }
+    (true, None)
+}
+
+/// Resolve the parent, never the selected entry: deleting a symlink must
+/// unlink it even if its target is outside the repository or is the root.
+pub fn discard_untracked(root: &Path, file: &str) -> Result<(), String> {
+    let relative = Path::new(file);
+    if file.is_empty()
+        || !relative
+            .components()
+            .all(|c| matches!(c, Component::Normal(_)))
+    {
+        return Err("Invalid untracked path".into());
+    }
+    let root = root.canonicalize().map_err(|e| e.to_string())?;
+    let joined = root.join(relative);
+    let parent = joined
+        .parent()
+        .ok_or("Missing parent")?
+        .canonicalize()
+        .map_err(|e| e.to_string())?;
+    if !parent.starts_with(&root) {
+        return Err("Refusing to delete outside repo".into());
+    }
+    let target = parent.join(joined.file_name().ok_or("Missing filename")?);
+    if target == root {
+        return Err("Refusing to delete repo root".into());
+    }
+    let meta = std::fs::symlink_metadata(&target).map_err(|e| e.to_string())?;
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileTypeExt;
+        if meta.file_type().is_symlink_dir() {
+            return std::fs::remove_dir(&target).map_err(|e| e.to_string());
+        }
+    }
+    if meta.file_type().is_symlink() || !meta.is_dir() {
+        std::fs::remove_file(target)
+    } else {
+        std::fs::remove_dir_all(target)
+    }
+    .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_literal_paths_and_rename_records() {
+        let changes = parse_status("?? file with spaces.txt\0?? café.txt\0RM new -> name.txt\0old name.txt\0 M line\nbreak.txt\0".as_bytes());
+        assert_eq!(changes.len(), 5);
+        assert_eq!(changes[0].path, "file with spaces.txt");
+        assert_eq!(changes[1].path, "café.txt");
+        assert_eq!(changes[2].path, "new -> name.txt");
+        assert!(changes[2].staged);
+        assert_eq!(changes[3].path, "new -> name.txt");
+        assert!(!changes[3].staged);
+        assert_eq!(changes[4].path, "line\nbreak.txt");
+    }
+
+    #[tokio::test]
+    async fn unborn_repo_lists_stageable_literal_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_str().unwrap();
+        assert!(git_cmd_async(&["init"])
+            .current_dir(root)
+            .output()
+            .await
+            .unwrap()
+            .status
+            .success());
+        assert_eq!(repository_branch(root).await.0, true);
+        assert!(repository_branch(root).await.1.is_some());
+        for name in ["file with spaces.txt", "café.txt"] {
+            std::fs::write(dir.path().join(name), "test").unwrap();
+        }
+        let status = git_cmd_async(&["status", "--porcelain=v1", "-z"])
+            .current_dir(root)
+            .output()
+            .await
+            .unwrap();
+        let changes = parse_status(&status.stdout);
+        assert_eq!(changes.len(), 2);
+        for change in changes {
+            assert!(git_cmd_async(&["add", "--", &change.path])
+                .current_dir(root)
+                .output()
+                .await
+                .unwrap()
+                .status
+                .success());
+        }
+    }
+
+    #[test]
+    fn discard_rejects_root_and_traversal_and_removes_regular_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        for path in ["", ".", "..", "../other", dir.path().to_str().unwrap()] {
+            assert!(discard_untracked(dir.path(), path).is_err());
+        }
+        std::fs::create_dir(dir.path().join("new")).unwrap();
+        std::fs::write(dir.path().join("new/file"), "test").unwrap();
+        discard_untracked(dir.path(), "new").unwrap();
+        assert!(!dir.path().join("new").exists());
+        assert!(dir.path().exists());
+    }
+
+    #[test]
+    fn discard_links_preserves_file_directory_and_root_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tracked.txt"), "keep").unwrap();
+        std::fs::create_dir(dir.path().join("tracked-dir")).unwrap();
+        for (name, target, is_dir) in [
+            ("file-link", dir.path().join("tracked.txt"), false),
+            ("dir-link", dir.path().join("tracked-dir"), true),
+            ("root-link", dir.path().to_path_buf(), true),
+        ] {
+            let link = dir.path().join(name);
+            #[cfg(unix)]
+            let result = {
+                let _ = is_dir;
+                std::os::unix::fs::symlink(&target, &link)
+            };
+            #[cfg(windows)]
+            let result = if is_dir {
+                std::os::windows::fs::symlink_dir(&target, &link)
+            } else {
+                std::os::windows::fs::symlink_file(&target, &link)
+            };
+            #[cfg(windows)]
+            if result
+                .as_ref()
+                .is_err_and(|e| e.raw_os_error() == Some(1314))
+            {
+                if !is_dir {
+                    // File symlinks need Developer Mode. Unix CI covers this
+                    // case; directory junctions below require no privilege.
+                    continue;
+                }
+                let status = std::process::Command::new("cmd")
+                    .args(["/d", "/c", "mklink", "/J"])
+                    .arg(&link)
+                    .arg(&target)
+                    .output()
+                    .unwrap();
+                assert!(
+                    status.status.success(),
+                    "{}",
+                    String::from_utf8_lossy(&status.stderr)
+                );
+            } else {
+                result.unwrap();
+            }
+            #[cfg(unix)]
+            result.unwrap();
+            discard_untracked(dir.path(), name).unwrap();
+            assert!(target.exists());
+            assert!(std::fs::symlink_metadata(link).is_err());
+        }
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("tracked.txt")).unwrap(),
+            "keep"
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod git_files;
 mod agents;
 mod custom_agents;
 mod credentials;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src ipc: http://ipc.localhost https://github.com https://ct-analytics.claude-terminal.workers.dev"
+      "csp": "default-src 'self'; frame-src http: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src ipc: http://ipc.localhost https://github.com https://ct-analytics.claude-terminal.workers.dev"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ import { DragPreview } from './components/DragPreview';
 import { WebviewWindow, getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { installTransferReceiver, requestTransfer, restoreDetachedWindow } from './lib/tabTransfer';
 import { filterLivePins } from './lib/pinnedTabs';
-import { keyOf, upsertEntry, removeEntry, getDetachedEntries, currentGeometry } from './lib/windowLayout';
+import { keyOf, restoreLayoutKeys, upsertEntry, removeEntry, getDetachedEntries, currentGeometry } from './lib/windowLayout';
 import { planRestoreModes } from './lib/restorePlan';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import type { TerminalConfig } from './store/terminalStore';
@@ -347,7 +347,7 @@ function App() {
   // Detached windows adopt the specific tabs named in their URL: fetch configs
   // from the shared backend (no spawn) and seed scrollback from the session log.
   useEffect(() => {
-    if (!isDetached) return;
+    if (!isDetached || initialIds.length === 0) return;
     let cancelled = false;
     (async () => {
       try {
@@ -387,7 +387,7 @@ function App() {
     let active = true;
     getCurrentWindow()
       .onCloseRequested((event) => {
-        if (closeConfirmedRef.current) return; // a choice was already made
+        if (closeConfirmedRef.current || useTerminalStore.getState().terminals.size === 0) return;
         event.preventDefault();
         setClosePrompt(true);
       })
@@ -426,6 +426,7 @@ function App() {
     ? Array.from(terminals.values()).filter((t) => !t.scriptParentId && !t.isShellTerminal).length
     : 0;
   useEffect(() => {
+    if (isDetached && detachedTabCount > 0) hasAdoptedRef.current = true;
     if (isDetached && hasAdoptedRef.current && detachedTabCount === 0) {
       forceCloseWindow();
     }
@@ -700,13 +701,10 @@ function App() {
     // session in a cwd). A duplicate would make everything typed/pasted in
     // one terminal show up in the others after restore.
     const restoreModes = planRestoreModes(pendingRestoreConfigs);
+    const layoutKeys = restoreLayoutKeys(pendingRestoreConfigs);
 
     for (let i = 0; i < pendingRestoreConfigs.length; i++) {
       const config = pendingRestoreConfigs[i];
-      const stableKey = keyOf({
-        claude_session_id: config.claude_session_id ?? null,
-        working_directory: config.working_directory,
-      });
       try {
         if (config.claude_args[0] === '__shell__') {
           // Plain shell - re-spawn as a main-tab shell. We deliberately don't
@@ -718,7 +716,7 @@ function App() {
             config.color_tag ?? undefined,
             config.nickname ?? undefined,
           );
-          keyToNewId[stableKey] = newId;
+          for (const key of layoutKeys[i]) keyToNewId[key] = newId;
         } else if (config.claude_args[0] === '__script__') {
           // Script runner - owned by parent terminal, skip on restore.
           continue;
@@ -747,7 +745,7 @@ function App() {
             config.agent,
             config.credential_bindings ?? [],
           );
-          keyToNewId[stableKey] = newId;
+          for (const key of layoutKeys[i]) keyToNewId[key] = newId;
         }
       } catch (err) {
         toast.error('Could not restore a session', String(err));
@@ -759,12 +757,14 @@ function App() {
     // of the main window into freshly-created windows at their saved geometry.
     try {
       const entries = getDetachedEntries();
+      const routedIds = new Set<string>();
       for (const { label, entry } of entries) {
         const ids = entry.sessionKeys
           .map((k) => keyToNewId[k])
-          .filter((x): x is string => !!x);
+          .filter((x): x is string => !!x && !routedIds.has(x));
         if (ids.length > 0) {
-          await restoreDetachedWindow(ids, entry.geometry);
+          await restoreDetachedWindow([...new Set(ids)], entry.geometry);
+          ids.forEach(id => routedIds.add(id));
         }
         removeEntry(label); // stale label; the reopened window re-persists fresh
       }

--- a/src/components/FileEditorView.test.tsx
+++ b/src/components/FileEditorView.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn(), editor: vi.fn(), diff: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('./monacoSetup', () => ({ languageFromPath: () => 'typescript' }));
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: unknown) => { mocks.editor(props); return <input aria-label="editor" />; },
+  DiffEditor: (props: unknown) => { mocks.diff(props); return <input aria-label="diff" />; },
+}));
+import { FileEditorView } from './FileEditorView';
+import { useAppStore } from '../store/appStore';
+import { useToastStore } from '../store/toastStore';
+
+const file = (path: string) => ({ path, content: 'edited', original: 'disk', loading: false, saving: false, error: null, mode: 'edit' as const, headContent: '', repoRoot: null, relativePath: null });
+beforeEach(() => {
+  mocks.invoke.mockReset().mockResolvedValue(undefined);
+  useAppStore.setState({ openFiles: [file('a.ts'), file('b.ts')], activeFilePath: 'a.ts', editorAutoSaveOnBlur: false });
+});
+afterEach(cleanup);
+
+describe('file editor preferences and saving', () => {
+  it('applies live preferences to plain and diff editors', () => {
+    useAppStore.setState({ editorFontSize: 24, editorFontFamily: 'test font', editorLineHeight: 1.5, editorWordWrap: true, editorMinimap: false, editorRenderWhitespace: true, editorTabSize: 8 });
+    const view = render(<FileEditorView path="a.ts" />);
+    expect(mocks.editor.mock.lastCall?.[0].options).toMatchObject({ fontSize: 24, fontFamily: 'test font', lineHeight: 36, wordWrap: 'on', minimap: { enabled: false }, renderWhitespace: 'all', tabSize: 8 });
+    useAppStore.getState().setFileTabMode('a.ts', 'diff');
+    view.rerender(<FileEditorView path="a.ts" />);
+    expect(mocks.diff.mock.lastCall?.[0].options).toMatchObject({ fontSize: 24, wordWrap: 'on' });
+  });
+
+  it('saves latest content on tab switch when enabled', async () => {
+    useAppStore.setState({ editorAutoSaveOnBlur: true });
+    const view = render(<FileEditorView path="a.ts" />);
+    useAppStore.getState().setFileTabContent('a.ts', 'latest edit');
+    view.rerender(<FileEditorView path="b.ts" />);
+    await waitFor(() => expect(mocks.invoke).toHaveBeenCalledWith('write_text_file', { path: 'a.ts', content: 'latest edit' }));
+    expect(useAppStore.getState().openFiles[0].original).toBe('latest edit');
+  });
+
+  it('saves on window blur and surfaces write failure without losing content', async () => {
+    useAppStore.setState({ editorAutoSaveOnBlur: true });
+    mocks.invoke.mockRejectedValue('disk full');
+    render(<FileEditorView path="a.ts" />);
+    fireEvent.blur(window);
+    await waitFor(() => expect(useAppStore.getState().openFiles[0].error).toBe('disk full'));
+    expect(useAppStore.getState().openFiles[0].content).toBe('edited');
+    expect(useToastStore.getState().toasts.some(t => t.title === 'Auto-save failed')).toBe(true);
+  });
+
+  it('saves edits made during an in-flight write when the tab loses focus', async () => {
+    useAppStore.setState({ editorAutoSaveOnBlur: true });
+    let finish!: () => void;
+    mocks.invoke.mockImplementationOnce(() => new Promise<void>(resolve => { finish = resolve; }));
+    const view = render(<FileEditorView path="a.ts" />);
+    fireEvent.blur(window);
+    useAppStore.getState().setFileTabContent('a.ts', 'newer edit');
+    view.rerender(<FileEditorView path="b.ts" />);
+    finish();
+    await waitFor(() => expect(mocks.invoke).toHaveBeenCalledWith('write_text_file', { path: 'a.ts', content: 'newer edit' }));
+    expect(useAppStore.getState().openFiles[0].original).toBe('newer edit');
+  });
+
+  it('does not save when disabled or when the file was explicitly discarded', () => {
+    const view = render(<FileEditorView path="a.ts" />);
+    fireEvent.blur(window);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    useAppStore.setState({ editorAutoSaveOnBlur: true });
+    useAppStore.getState().closeFileTab('a.ts');
+    view.unmount();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/FileEditorView.tsx
+++ b/src/components/FileEditorView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Loader2, AlertCircle, Save, RefreshCw, FileCode2, GitCompareArrows } from 'lucide-react';
 import Editor, { DiffEditor, type OnMount, type DiffOnMount } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
@@ -26,6 +26,55 @@ export function FileEditorView({ path }: FileEditorViewProps) {
   const clearEditorNavigation = useAppStore((s) => s.clearEditorNavigation);
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
+
+  const {
+    editorFontFamily, editorFontSize, editorLineHeight, editorTabSize,
+    editorWordWrap, editorMinimap, editorRenderWhitespace,
+  } = useAppStore();
+  const options: editor.IEditorOptions = {
+    fontFamily: editorFontFamily,
+    fontSize: editorFontSize,
+    lineHeight: Math.round(editorFontSize * editorLineHeight),
+    wordWrap: editorWordWrap ? 'on' : 'off',
+    minimap: { enabled: editorMinimap },
+    renderWhitespace: editorRenderWhitespace ? 'all' : 'none',
+    automaticLayout: true,
+    scrollBeyondLastLine: false,
+    smoothScrolling: true,
+    padding: { top: 8, bottom: 8 },
+  };
+  const waitingForSave = useRef<(() => void) | null>(null);
+  const autoSave = useCallback((): void => {
+    const state = useAppStore.getState();
+    const current = state.openFiles.find(t => t.path === path);
+    if (!state.editorAutoSaveOnBlur || !current || current.loading || current.content === current.original) return;
+    if (current.saving) {
+      if (!waitingForSave.current) {
+        waitingForSave.current = useAppStore.subscribe(next => {
+          const latest = next.openFiles.find(t => t.path === path);
+          if (latest?.saving) return;
+          waitingForSave.current?.();
+          waitingForSave.current = null;
+          if (latest && !latest.error) autoSave();
+        });
+      }
+      return;
+    }
+    state.saveFileTab(path).catch(err => toast.error('Auto-save failed', String(err)));
+  }, [path]);
+  useEffect(() => {
+    window.addEventListener('blur', autoSave);
+    return () => {
+      window.removeEventListener('blur', autoSave);
+      // Tab switches unmount the editor; closing/discarding removes the tab
+      // from the store first, so it cannot accidentally save discarded edits.
+      autoSave();
+    };
+  }, [autoSave]);
+  useEffect(() => {
+    editorRef.current?.getModel()?.updateOptions({ tabSize: editorTabSize });
+    diffEditorRef.current?.getModifiedEditor().getModel()?.updateOptions({ tabSize: editorTabSize });
+  }, [editorTabSize]);
 
   const dirty = tab ? tab.content !== tab.original : false;
   const language = useMemo(() => languageFromPath(path), [path]);
@@ -69,6 +118,7 @@ export function FileEditorView({ path }: FileEditorViewProps) {
 
   const onMount: OnMount = (ed) => {
     editorRef.current = ed;
+    ed.getModel()?.updateOptions({ tabSize: editorTabSize });
     ed.focus();
     applyNavigation(ed);
   };
@@ -76,6 +126,7 @@ export function FileEditorView({ path }: FileEditorViewProps) {
   const onDiffMount: DiffOnMount = (ed) => {
     diffEditorRef.current = ed;
     const modified = ed.getModifiedEditor();
+    modified.getModel()?.updateOptions({ tabSize: editorTabSize });
     // Treat the modified (right) side as editable and pipe its changes into
     // the store so dirty tracking and Save continue to work in diff mode.
     modified.onDidChangeModelContent(() => {
@@ -88,7 +139,9 @@ export function FileEditorView({ path }: FileEditorViewProps) {
   if (!tab) return null;
 
   return (
-    <div className="h-full flex flex-col bg-bg-primary">
+    <div className="h-full flex flex-col bg-bg-primary" onBlurCapture={(e) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node | null)) autoSave();
+    }}>
       {/* Breadcrumb / status bar for the file */}
       <div className="flex items-center justify-between px-3 h-7 bg-elevation-0 border-b border-seam flex-shrink-0">
         <p className="text-text-tertiary text-[11px] truncate" title={path} dir="ltr">
@@ -168,17 +221,7 @@ export function FileEditorView({ path }: FileEditorViewProps) {
             modifiedModelPath={modelUri}
             onMount={onDiffMount}
             theme="vs-dark"
-            options={{
-              fontSize: 13,
-              renderSideBySide: true,
-              automaticLayout: true,
-              readOnly: false,
-              originalEditable: false,
-              wordWrap: 'off',
-              scrollBeyondLastLine: false,
-              smoothScrolling: true,
-              padding: { top: 8, bottom: 8 },
-            }}
+            options={{ ...options, renderSideBySide: true, readOnly: false, originalEditable: false }}
           />
         ) : (
           <Editor
@@ -189,18 +232,7 @@ export function FileEditorView({ path }: FileEditorViewProps) {
             onChange={(v) => setFileTabContent(path, v ?? '')}
             onMount={onMount}
             theme="vs-dark"
-            options={{
-              fontSize: 13,
-              minimap: { enabled: true },
-              automaticLayout: true,
-              wordWrap: 'off',
-              tabSize: 2,
-              scrollBeyondLastLine: false,
-              renderWhitespace: 'selection',
-              smoothScrolling: true,
-              cursorBlinking: 'smooth',
-              padding: { top: 8, bottom: 8 },
-            }}
+            options={{ ...options, tabSize: editorTabSize, cursorBlinking: 'smooth' }}
           />
         )}
       </div>

--- a/src/components/TerminalTabs.test.tsx
+++ b/src/components/TerminalTabs.test.tsx
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+vi.mock('./FileEditorView', () => ({ FileEditorView: () => null }));
+vi.mock('./TerminalView', () => ({ TerminalView: () => null }));
+vi.mock('./FileTreePanel', () => ({ FileTreePanel: () => null }));
+vi.mock('./SplitView', () => ({ SplitView: () => null }));
+vi.mock('./TerminalGrid', () => ({ TerminalGrid: () => null }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn().mockResolvedValue([]) }));
+import { TerminalTabs } from './TerminalTabs';
+import { useAppStore } from '../store/appStore';
+import { useTerminalStore } from '../store/terminalStore';
+
+beforeEach(() => {
+  useTerminalStore.setState({ terminals: new Map(), activeTerminalId: null });
+  useAppStore.setState({ gridMode: false, splitMode: false, activeFilePath: 'dirty.ts', openFiles: [{ path: 'dirty.ts', content: 'unsaved', original: 'disk', loading: false, saving: false, error: null, mode: 'edit', headContent: '', repoRoot: null, relativePath: null }] });
+});
+afterEach(cleanup);
+
+describe('dirty file close controls', () => {
+  it.each(['Enter', ' '])('confirms %s and preserves content when cancelled', (key) => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<TerminalTabs />);
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Unsaved changes' }), { key });
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(useAppStore.getState().openFiles[0].content).toBe('unsaved');
+  });
+  it('closes with keyboard after discard is confirmed', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<TerminalTabs />);
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Unsaved changes' }), { key: 'Enter' });
+    expect(useAppStore.getState().openFiles).toEqual([]);
+  });
+});

--- a/src/components/TerminalTabs.tsx
+++ b/src/components/TerminalTabs.tsx
@@ -55,6 +55,12 @@ export function TerminalTabs() {
     setActiveFilePath(path);
   }, [setActiveFilePath]);
 
+  const requestCloseFile = (path: string) => {
+    const tab = useAppStore.getState().openFiles.find(t => t.path === path);
+    if (tab && tab.content !== tab.original && !window.confirm(`Discard unsaved changes in ${fileBasename(path)}?`)) return;
+    closeFileTab(path);
+  };
+
   // Close the active session from the header (#59). Mirrors the sidebar
   // SessionCards' `closeWithReport` so error handling + telemetry stay
   // consistent with the existing close paths (per CLAUDE.md's frontend
@@ -234,11 +240,7 @@ export function TerminalTabs() {
                       onAuxClick={(e) => {
                         if (e.button !== 1) return;
                         e.preventDefault();
-                        if (dirty) {
-                          const ok = window.confirm(`Discard unsaved changes in ${fileBasename(tab.path)}?`);
-                          if (!ok) return;
-                        }
-                        closeFileTab(tab.path);
+                        requestCloseFile(tab.path);
                       }}
                       className={`group relative flex items-center gap-1.5 px-2.5 h-7 rounded-[10px] text-[12px] transition-colors flex-shrink-0 ${
                         isActive
@@ -251,18 +253,15 @@ export function TerminalTabs() {
                       <span
                         onClick={(e) => {
                           e.stopPropagation();
-                          if (dirty) {
-                            const ok = window.confirm(`Discard unsaved changes in ${fileBasename(tab.path)}?`);
-                            if (!ok) return;
-                          }
-                          closeFileTab(tab.path);
+                          requestCloseFile(tab.path);
                         }}
                         role="button"
                         tabIndex={0}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
                             e.stopPropagation();
-                            closeFileTab(tab.path);
+                            requestCloseFile(tab.path);
                           }
                         }}
                         className="p-0.5 rounded hover:bg-fill-active text-text-tertiary hover:text-text-primary transition-colors flex items-center justify-center"

--- a/src/lib/restorePlan.test.ts
+++ b/src/lib/restorePlan.test.ts
@@ -58,7 +58,7 @@ describe('planRestoreModes', () => {
     ]);
   });
 
-  it('mixes id and id-less terminals independently', () => {
+  it('reserves explicit conversations before assigning continuation', () => {
     const modes = planRestoreModes([
       { claude_session_id: 'aaa', working_directory: 'C:\\proj' },
       { claude_session_id: null, working_directory: 'C:\\proj' },
@@ -67,9 +67,23 @@ describe('planRestoreModes', () => {
     ]);
     expect(modes).toEqual([
       { kind: 'resume', sessionId: 'aaa' },
-      { kind: 'continue' },
+      { kind: 'fresh' },
       { kind: 'fresh' },
       { kind: 'fresh' },
     ]);
   });
+  it('reserves later explicit claims too and scopes claims by agent', () => {
+    expect(planRestoreModes([
+      { agent: 'claude', working_directory: 'C:/repo' },
+      { agent: 'claude', working_directory: 'c:\\repo\\', claude_session_id: 's' },
+      { agent: 'codex', working_directory: 'C:/repo' },
+      { agent: 'cursor', working_directory: 'C:/repo', claude_session_id: 's' },
+    ])).toEqual([{ kind: 'fresh' }, { kind: 'resume', sessionId: 's' }, { kind: 'continue' }, { kind: 'resume', sessionId: 's' }]);
+  });
+
+  it('preserves case-sensitive Unix directories', () => {
+    expect(planRestoreModes([{ working_directory: '/Repo' }, { working_directory: '/repo' }]))
+      .toEqual([{ kind: 'continue' }, { kind: 'continue' }]);
+  });
+
 });

--- a/src/lib/restorePlan.ts
+++ b/src/lib/restorePlan.ts
@@ -9,6 +9,7 @@
 // other terminal tabs".
 
 export interface RestorePlanInput {
+  agent?: string;
   claude_session_id?: string | null;
   working_directory: string;
   /** Saved spawn args; `__shell__` / `__script__` sentinels mark non-claude
@@ -32,6 +33,15 @@ export type RestoreMode =
  *    reason.
  */
 export function planRestoreModes(configs: RestorePlanInput[]): RestoreMode[] {
+  const isAgent = (c: RestorePlanInput) => !['__shell__', '__script__'].includes(c.claude_args?.[0] ?? '');
+  const directoryKey = (c: RestorePlanInput) => {
+    let path = c.working_directory.replace(/\\/g, '/').replace(/\/+$/, '');
+    // Fold drive/UNC paths only; Unix filesystems may distinguish case.
+    if (/^[a-z]:/i.test(path) || path.startsWith('//')) path = path.toLowerCase();
+    return JSON.stringify([c.agent ?? 'claude', path]);
+  };
+  // Reserve all explicit claims before assigning continuation, regardless of order.
+  const reservedCwds = new Set(configs.filter(c => isAgent(c) && c.claude_session_id).map(directoryKey));
   const usedSessionIds = new Set<string>();
   const continuedCwds = new Set<string>();
 
@@ -44,13 +54,15 @@ export function planRestoreModes(configs: RestorePlanInput[]): RestoreMode[] {
     }
     const sessionId = config.claude_session_id ?? null;
     if (sessionId) {
-      if (usedSessionIds.has(sessionId)) return { kind: 'fresh' };
-      usedSessionIds.add(sessionId);
+      const sessionKey = JSON.stringify([config.agent ?? 'claude', sessionId]);
+      if (usedSessionIds.has(sessionKey)) return { kind: 'fresh' };
+      usedSessionIds.add(sessionKey);
       return { kind: 'resume', sessionId };
     }
     // Windows paths are case-insensitive; normalize so "C:\Dev" and "c:\dev"
     // count as the same project.
-    const cwd = config.working_directory.toLowerCase();
+    const cwd = directoryKey(config);
+    if (reservedCwds.has(cwd)) return { kind: 'fresh' };
     if (continuedCwds.has(cwd)) return { kind: 'fresh' };
     continuedCwds.add(cwd);
     return { kind: 'continue' };

--- a/src/lib/tabTransfer.test.ts
+++ b/src/lib/tabTransfer.test.ts
@@ -1,149 +1,162 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { installTransferReceiver, requestTransfer, routeTabDrop } from './tabTransfer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDetachedWindow, installTransferReceiver, requestTransfer, routeTabDrop } from './tabTransfer';
 import type { TerminalConfig } from '../store/terminalStore';
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(), emit: vi.fn(), listen: vi.fn(), windows: vi.fn(),
-  detach: vi.fn(), focus: vi.fn(), create: vi.fn(),
+  detach: vi.fn(), focus: vi.fn(), create: vi.fn(), close: vi.fn(), once: vi.fn(),
+  handlers: new Map<string, Set<(e: any) => unknown>>(),
 }));
 vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
 vi.mock('@tauri-apps/api/event', () => ({ emit: mocks.emit, listen: mocks.listen }));
 vi.mock('@tauri-apps/api/webviewWindow', () => ({
   getAllWebviewWindows: mocks.windows,
-  getCurrentWebviewWindow: () => ({ setFocus: mocks.focus }),
-  WebviewWindow: class { constructor(...args: unknown[]) { mocks.create(...args); } once = vi.fn(); },
+  getCurrentWebviewWindow: () => ({ label: 'main', setFocus: mocks.focus }),
+  WebviewWindow: class {
+    constructor(...args: unknown[]) { mocks.create(...args); }
+    once = mocks.once; close = mocks.close;
+    setPosition = vi.fn().mockResolvedValue(undefined);
+    setSize = vi.fn().mockResolvedValue(undefined);
+  },
 }));
 vi.mock('../store/terminalStore', () => ({ useTerminalStore: { getState: () => ({ detachTerminals: mocks.detach }) } }));
 vi.mock('./errorReporter', () => ({ reportError: vi.fn() }));
-import { reportError } from './errorReporter';
-
 const transfer = 'ct://tab-transfer';
 const done = 'ct://tab-transfer-done';
-const windowAt = (label: string, x = 0) => ({
-  label, outerPosition: vi.fn().mockResolvedValue({ x, y: 0 }),
-  outerSize: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
-});
+const ready = 'ct://tab-transfer-ready';
 const config = { id: 'one', label: 'One' } as TerminalConfig;
+const dispatch = async (name: string, payload: unknown) => {
+  for (const fn of [...(mocks.handlers.get(name) ?? [])]) await fn({ payload });
+};
+const flush = async () => { for (let i = 0; i < 12; i++) await Promise.resolve(); };
+const request = () => mocks.emit.mock.calls.find(([name]) => name === transfer)![1];
+const payload = () => ({ ids: ['one'], targetLabel: 'target', sourceLabel: 'main', requestId: 'r1', expiresAt: Date.now() + 15000 });
+const windowAt = (label: string) => ({ label, outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }), outerSize: vi.fn().mockResolvedValue({ width: 100, height: 100 }) });
 
-describe('tab transfer protocol', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    mocks.invoke.mockResolvedValue([50, 50]);
-    mocks.emit.mockResolvedValue(undefined);
-    mocks.focus.mockResolvedValue(undefined);
-    mocks.windows.mockResolvedValue([]);
-    mocks.listen.mockResolvedValue(vi.fn());
+beforeEach(() => {
+  vi.resetAllMocks(); mocks.handlers.clear();
+  mocks.invoke.mockResolvedValue([50, 50]);
+  mocks.windows.mockResolvedValue([]);
+  mocks.focus.mockResolvedValue(undefined); mocks.close.mockResolvedValue(undefined);
+  mocks.once.mockResolvedValue(() => {});
+  mocks.listen.mockImplementation(async (name, fn) => {
+    if (!mocks.handlers.has(name)) mocks.handlers.set(name, new Set());
+    mocks.handlers.get(name)!.add(fn);
+    return () => mocks.handlers.get(name)?.delete(fn);
   });
+  mocks.emit.mockImplementation(dispatch);
+});
+afterEach(() => vi.useRealTimers());
 
-  it('does no desktop work for an empty selection', async () => {
-    await routeTabDrop([], 'main');
-    await requestTransfer('other', [], 'main');
-    expect(mocks.invoke).not.toHaveBeenCalled();
-    expect(mocks.emit).not.toHaveBeenCalled();
-    expect(mocks.create).not.toHaveBeenCalled();
+describe('acknowledged tab transfers', () => {
+  it('does no work for empty selections', async () => {
+    await routeTabDrop([], 'main'); await requestTransfer('target', [], 'main');
+    expect(mocks.emit).not.toHaveBeenCalled(); expect(mocks.create).not.toHaveBeenCalled();
   });
-
-  it('transfers to a hit window while excluding the source and drag overlay', async () => {
+  it('retains source tabs until matching destination acknowledgement', async () => {
     mocks.windows.mockResolvedValue([windowAt('main'), windowAt('drag-preview'), windowAt('target')]);
-    await routeTabDrop(['one'], 'main');
-    expect(mocks.emit).toHaveBeenCalledWith(transfer, { targetLabel: 'target', ids: ['one'], sourceLabel: 'main' });
+    const pending = routeTabDrop(['one'], 'main');
+    await flush();
+    expect(mocks.detach).not.toHaveBeenCalled();
+    await dispatch(done, { ids: ['one'], byLabel: 'other', requestId: request().requestId });
+    expect(mocks.detach).not.toHaveBeenCalled();
+    await dispatch(done, { ids: ['one'], byLabel: 'target', requestId: request().requestId });
+    await pending;
     expect(mocks.detach).toHaveBeenCalledWith(['one']);
-    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.handlers.get(done)?.size).toBe(0);
   });
-
-  it('skips a window that closes during hit testing', async () => {
-    const closed = windowAt('closed');
-    closed.outerPosition.mockRejectedValue(new Error('closed'));
-    mocks.windows.mockResolvedValue([closed, windowAt('target')]);
-    await routeTabDrop(['one'], 'main');
-    expect(mocks.emit).toHaveBeenCalledWith(transfer, expect.objectContaining({ targetLabel: 'target' }));
-  });
-
-  it('opens a detached view outside other windows without killing the PTY', async () => {
-    mocks.windows.mockResolvedValue([windowAt('target', 500)]);
-    await routeTabDrop(['one', 'two'], 'main');
-    expect(mocks.create).toHaveBeenCalledWith(expect.stringMatching(/^detached-/), expect.objectContaining({
-      url: 'index.html?mode=detached&ids=one%2Ctwo',
-    }));
-    expect(mocks.detach).toHaveBeenCalledWith(['one', 'two']);
-    expect(mocks.invoke).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps source tabs when the cursor lookup fails', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    mocks.invoke.mockRejectedValue(new Error('cursor unavailable'));
-    await routeTabDrop(['one'], 'main');
+  it('retains source tabs on timeout and ignores late acknowledgements', async () => {
+    vi.useFakeTimers();
+    const pending = requestTransfer('target', ['one'], 'main');
+    const failed = expect(pending).rejects.toThrow('timed out');
+    await flush();
+    await vi.advanceTimersByTimeAsync(15000);
+    await failed;
+    await dispatch(done, { ids: ['one'], byLabel: 'target', requestId: request().requestId });
     expect(mocks.detach).not.toHaveBeenCalled();
-    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.handlers.get(done)?.size).toBe(0);
   });
-
-  it('keeps source tabs if emitting the handoff fails', async () => {
-    mocks.windows.mockResolvedValue([windowAt('target')]);
+  it('retains source tabs when sending fails', async () => {
     mocks.emit.mockRejectedValue(new Error('event failed'));
-    await expect(routeTabDrop(['one'], 'main')).rejects.toThrow('event failed');
+    await expect(requestTransfer('target', ['one'], 'main')).rejects.toThrow('event failed');
     expect(mocks.detach).not.toHaveBeenCalled();
+    expect(mocks.handlers.get(done)?.size).toBe(0);
   });
-
-  function receive() {
-    const adopt = vi.fn();
-    const detach = vi.fn();
-    const dispose = installTransferReceiver('target', adopt, detach);
-    const handler = (name: string) => mocks.listen.mock.calls.find(([event]) => event === name)![1];
-    return { adopt, detach, dispose, handler };
-  }
-
-  it('ignores transfers for other windows and self-originated requests', async () => {
-    const { handler, adopt } = receive();
-    await handler(transfer)({ payload: { targetLabel: 'other', sourceLabel: 'main', ids: ['one'] } });
-    await handler(transfer)({ payload: { targetLabel: 'target', sourceLabel: 'target', ids: ['one'] } });
-    expect(mocks.invoke).not.toHaveBeenCalled();
-    expect(adopt).not.toHaveBeenCalled();
+  it('retains source tabs when destination rejects adoption', async () => {
+    const pending = requestTransfer('target', ['one'], 'main');
+    const failed = expect(pending).rejects.toThrow('backend unavailable');
+    await flush();
+    await dispatch(done, { ids: [], byLabel: 'target', requestId: request().requestId, error: 'backend unavailable' });
+    await failed; expect(mocks.detach).not.toHaveBeenCalled();
   });
+  it('waits for a new window receiver before requesting adoption', async () => {
+    const pending = createDetachedWindow(['one'], 50, 50);
+    await flush();
+    expect(mocks.emit).not.toHaveBeenCalledWith(transfer, expect.anything());
+    const label = mocks.create.mock.calls[0][0];
+    expect(mocks.create.mock.calls[0][1].url).toBe('index.html?mode=detached');
+    await dispatch(ready, { label }); await flush();
+    expect(mocks.detach).not.toHaveBeenCalled();
+    await dispatch(done, { ids: ['one'], byLabel: label, requestId: request().requestId });
+    await pending; expect(mocks.detach).toHaveBeenCalledWith(['one']);
+  });
+  it('keeps source tabs when window creation fails', async () => {
+    const pending = createDetachedWindow(['one'], 50, 50);
+    const failed = expect(pending).rejects.toThrow('Window creation failed');
+    await flush();
+    mocks.once.mock.calls[0][1]({ payload: 'unavailable' });
+    await failed; expect(mocks.detach).not.toHaveBeenCalled(); expect(mocks.close).toHaveBeenCalledOnce();
+  });
+});
 
-  it('adopts an existing PTY with scrollback before acknowledging and focusing', async () => {
+describe('transfer receiver', () => {
+  it('announces readiness after registration and acknowledges adopted IDs', async () => {
     mocks.invoke.mockResolvedValueOnce([config]).mockResolvedValueOnce('saved output');
-    const { handler, adopt } = receive();
-    await handler(transfer)({ payload: { targetLabel: 'target', sourceLabel: 'main', ids: ['one'] } });
+    const adopt = vi.fn(); const dispose = installTransferReceiver('target', adopt, vi.fn());
+    await flush(); expect(mocks.emit).toHaveBeenCalledWith(ready, { label: 'target' });
+    await dispatch(transfer, payload());
     expect(adopt).toHaveBeenCalledWith(config, 'saved output');
-    expect(mocks.invoke).toHaveBeenNthCalledWith(2, 'get_session_log', { terminalId: 'one' });
-    expect(mocks.emit).toHaveBeenCalledWith(done, { ids: ['one'], byLabel: 'target' });
-    expect(adopt.mock.invocationCallOrder[0]).toBeLessThan(mocks.emit.mock.invocationCallOrder[0]);
-    expect(mocks.focus).toHaveBeenCalledOnce();
+    expect(mocks.emit).toHaveBeenCalledWith(done, { ids: ['one'], byLabel: 'target', requestId: 'r1' });
+    dispose(); expect(mocks.handlers.get(transfer)?.size).toBe(0);
   });
-
-  it('can adopt without scrollback when the session log is unavailable', async () => {
-    mocks.invoke.mockResolvedValueOnce([config]).mockRejectedValueOnce(new Error('no log'));
-    const { handler, adopt } = receive();
-    await handler(transfer)({ payload: { targetLabel: 'target', sourceLabel: 'main', ids: ['one'] } });
-    expect(adopt).toHaveBeenCalledWith(config, undefined);
-    expect(mocks.emit).toHaveBeenCalledOnce();
-  });
-
-  it('reports failed adoption without acknowledging it', async () => {
-    mocks.invoke.mockRejectedValue(new Error('backend unavailable'));
-    const { handler, adopt } = receive();
-    await handler(transfer)({ payload: { targetLabel: 'target', sourceLabel: 'main', ids: ['one'] } });
+  it('rejects missing IDs without partially adopting the selection', async () => {
+    mocks.invoke.mockResolvedValue([config]);
+    const adopt = vi.fn(); const dispose = installTransferReceiver('target', adopt, vi.fn());
+    await flush();
+    await dispatch(transfer, { ...payload(), ids: ['one', 'missing'] });
     expect(adopt).not.toHaveBeenCalled();
-    expect(mocks.emit).not.toHaveBeenCalled();
-    expect(reportError).toHaveBeenCalledWith('tab_transfer_adopt', 'backend unavailable');
-  });
-
-  it('releases tabs adopted elsewhere but retains its own adopted tabs', () => {
-    const { handler, detach } = receive();
-    handler(done)({ payload: { ids: ['one'], byLabel: 'target' } });
-    expect(detach).not.toHaveBeenCalled();
-    handler(done)({ payload: { ids: ['one'], byLabel: 'other' } });
-    expect(detach).toHaveBeenCalledWith(['one']);
-  });
-
-  it('cleans up event registrations even when they resolve after disposal', async () => {
-    const resolvers: Array<(fn: () => void) => void> = [];
-    mocks.listen.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
-    const { dispose } = receive();
+    expect(mocks.emit).toHaveBeenCalledWith(done, expect.objectContaining({ ids: [], error: expect.any(String) }));
     dispose();
-    const unlisteners = [vi.fn(), vi.fn()];
-    resolvers.forEach((resolve, i) => resolve(unlisteners[i]));
-    await Promise.resolve();
-    unlisteners.forEach((fn) => expect(fn).toHaveBeenCalledOnce());
+  });
+  it('does not adopt after the source request has expired', async () => {
+    mocks.invoke.mockResolvedValue([config]);
+    const adopt = vi.fn(); const dispose = installTransferReceiver('target', adopt, vi.fn());
+    await flush();
+    await dispatch(transfer, { ...payload(), expiresAt: Date.now() - 1 });
+    expect(adopt).not.toHaveBeenCalled(); dispose();
+  });
+  it('rolls back destination views if acknowledgement fails', async () => {
+    mocks.invoke.mockResolvedValueOnce([config]).mockResolvedValueOnce(null);
+    const detach = vi.fn(); const dispose = installTransferReceiver('target', vi.fn(), detach);
+    await flush();
+    mocks.emit.mockImplementation(async (event) => { if (event === done) throw new Error('IPC failed'); });
+    await dispatch(transfer, payload());
+    expect(detach).toHaveBeenCalledWith(['one']); dispose();
+  });
+  it('rolls back a destination after late source cancellation', async () => {
+    mocks.invoke.mockResolvedValueOnce([config]).mockResolvedValueOnce(null);
+    const detach = vi.fn(); const dispose = installTransferReceiver('target', vi.fn(), detach);
+    await flush();
+    await dispatch(transfer, payload());
+    await dispatch('ct://tab-transfer-cancel', { targetLabel: 'target', requestId: 'r1' });
+    expect(detach).toHaveBeenCalledWith(['one']); dispose();
+  });
+  it('cleans up registration that resolves after disposal', async () => {
+    let resolve!: (fn: () => void) => void;
+    mocks.listen.mockImplementation(() => new Promise(r => { resolve = r; }));
+    const dispose = installTransferReceiver('target', vi.fn(), vi.fn()); dispose();
+    const unlisten = vi.fn(); resolve(unlisten); await flush();
+    expect(unlisten).toHaveBeenCalledOnce();
+    expect(mocks.emit).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/tabTransfer.ts
+++ b/src/lib/tabTransfer.ts
@@ -13,94 +13,75 @@ import { reportError } from './errorReporter';
 
 const TRANSFER_EVENT = 'ct://tab-transfer';
 const TRANSFER_DONE_EVENT = 'ct://tab-transfer-done';
+const CANCEL_EVENT = 'ct://tab-transfer-cancel';
+const transferringIds = new Set<string>();
+const READY_EVENT = 'ct://tab-transfer-ready';
+const TRANSFER_TIMEOUT_MS = 15000;
 
 interface TransferPayload {
   targetLabel: string;
   ids: string[];
   sourceLabel: string;
+  requestId: string;
+  expiresAt: number;
 }
 interface TransferDonePayload {
   ids: string[];
   byLabel: string;
+  requestId: string;
+  error?: string;
 }
 
-/**
- * Create a new torn-off window at a physical screen position, carrying the
- * given terminal ids (which it adopts on boot). The PTYs are untouched - only a
- * new view is opened.
- */
-export async function createDetachedWindow(ids: string[], physX: number, physY: number): Promise<void> {
-  if (ids.length === 0) return;
-  const label = `detached-${crypto.randomUUID()}`;
-  const idsParam = encodeURIComponent(ids.join(','));
-
-  const win = new WebviewWindow(label, {
-    url: `index.html?mode=detached&ids=${idsParam}`,
-    width: 1000,
-    height: 680,
-    minWidth: 480,
-    minHeight: 320,
-    decorations: false,
-    transparent: true,
-    title: 'Agentrium',
-  });
-
-  win.once('tauri://created', () => {
-    // Cursor position is physical; window-option x/y are logical, so set the
-    // position explicitly in physical pixels after creation, then focus.
-    win
-      .setPosition(new PhysicalPosition(Math.round(physX), Math.round(physY)))
-      .then(() => win.setFocus())
-      .catch(() => {
-        /* positioning is best-effort */
-      });
-  });
-  win.once('tauri://error', (e) => {
-    console.error('[tabTransfer] failed to create detached window:', e);
-    // Window creation is Tauri-internal (not a wrapped command), so nothing
-    // else reports it - and the user is left with a tab that went nowhere.
-    reportError('window_create', `tear-off window failed: ${JSON.stringify(e.payload ?? e)}`);
-  });
+/** Register before sending/creating so even a fast response cannot be missed. */
+async function waitForEvent<T>(name: string, matches: (payload: T) => boolean) {
+  let resolve!: (payload: T) => void;
+  let reject!: (error: Error) => void;
+  const result = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  // A creation error can reject while the caller is still awaiting setup.
+  void result.catch(() => {});
+  const unlisten = await listen<T>(name, event => { if (matches(event.payload)) resolve(event.payload); });
+  const timer = setTimeout(() => reject(new Error('Tab transfer timed out; the source tabs were retained.')), TRANSFER_TIMEOUT_MS);
+  return { result, fail: reject, dispose: () => { clearTimeout(timer); unlisten(); } };
 }
 
-/**
- * Recreate a detached window on startup at its saved geometry and hand it the
- * given (already-restored) terminal ids, detaching them from the main window.
- * Mirrors a tear-off but driven by the persisted layout instead of a drag.
- */
-export async function restoreDetachedWindow(ids: string[], geometry?: WindowGeometry): Promise<void> {
+async function openDetachedWindow(ids: string[], geometry?: WindowGeometry, position?: [number, number]): Promise<void> {
   if (ids.length === 0) return;
   const label = `detached-${crypto.randomUUID()}`;
-  const idsParam = encodeURIComponent(ids.join(','));
-
-  const win = new WebviewWindow(label, {
-    url: `index.html?mode=detached&ids=${idsParam}`,
-    width: 1000,
-    height: 680,
-    minWidth: 480,
-    minHeight: 320,
-    decorations: false,
-    transparent: true,
-    title: 'Agentrium',
-  });
-
-  win.once('tauri://created', () => {
+  const ready = await waitForEvent<{ label: string }>(READY_EVENT, payload => payload.label === label);
+  let win: WebviewWindow | undefined;
+  const unlisteners: Array<() => void> = [];
+  try {
+    // The destination boots empty and announces readiness only after its
+    // transfer receiver is registered. It never adopts URL IDs speculatively.
+    win = new WebviewWindow(label, {
+      url: 'index.html?mode=detached', width: 1000, height: 680,
+      minWidth: 480, minHeight: 320, decorations: false, transparent: true, title: 'Agentrium',
+    });
+    unlisteners.push(await win.once('tauri://error', e => ready.fail(new Error(`Window creation failed: ${JSON.stringify(e.payload)}`))));
+    await ready.result;
     if (geometry) {
-      win
-        .setPosition(new PhysicalPosition(Math.round(geometry.x), Math.round(geometry.y)))
-        .then(() => win.setSize(new PhysicalSize(Math.round(geometry.w), Math.round(geometry.h))))
-        .catch(() => {
-          /* geometry restore is best-effort */
-        });
+      await win.setPosition(new PhysicalPosition(Math.round(geometry.x), Math.round(geometry.y))).catch(() => {});
+      await win.setSize(new PhysicalSize(Math.round(geometry.w), Math.round(geometry.h))).catch(() => {});
+    } else if (position) {
+      await win.setPosition(new PhysicalPosition(Math.round(position[0]), Math.round(position[1]))).catch(() => {});
     }
-  });
-  win.once('tauri://error', (e) => {
-    console.error('[tabTransfer] failed to restore detached window:', e);
-    reportError('window_create', `detached-window restore failed: ${JSON.stringify(e.payload ?? e)}`);
-  });
+    await requestTransfer(label, ids, getCurrentWebviewWindow().label);
+  } catch (err) {
+    await win?.close().catch(() => {});
+    reportError('window_create', String(err));
+    throw err;
+  } finally {
+    ready.dispose();
+    unlisteners.forEach(fn => fn());
+  }
+}
 
-  // The new window adopts these ids on load; remove them from main now.
-  useTerminalStore.getState().detachTerminals(ids);
+export async function createDetachedWindow(ids: string[], physX: number, physY: number): Promise<void> {
+  await openDetachedWindow(ids, undefined, [physX, physY]);
+}
+
+export async function restoreDetachedWindow(ids: string[], geometry?: WindowGeometry): Promise<void> {
+  await openDetachedWindow(ids, geometry);
 }
 
 /**
@@ -144,7 +125,7 @@ export async function routeTabDrop(ids: string[], sourceLabel: string): Promise<
 
   if (target) {
     // Dropped over another window → transfer the tab(s) there.
-    await emit(TRANSFER_EVENT, { targetLabel: target, ids, sourceLabel } as TransferPayload);
+    await requestTransfer(target, ids, sourceLabel);
   } else {
     // Dropped over the source window's own body, or empty desktop → tear off a
     // new window at the cursor. (Drops over the source's tab strip are handled
@@ -152,11 +133,6 @@ export async function routeTabDrop(ids: string[], sourceLabel: string): Promise<
     await createDetachedWindow(ids, cx, cy);
   }
 
-  // Remove the tab(s) from the SOURCE window immediately so they don't linger
-  // there while the destination renders them. The PTYs stay alive in the
-  // backend - the new/target window adopts them independently (and the DONE
-  // event from a transfer makes this a harmless no-op if it lands again).
-  useTerminalStore.getState().detachTerminals(ids);
 }
 
 /**
@@ -165,8 +141,26 @@ export async function routeTabDrop(ids: string[], sourceLabel: string): Promise<
  * adopts them and broadcasts the "done" that releases them from this window.
  */
 export async function requestTransfer(targetLabel: string, ids: string[], sourceLabel: string): Promise<void> {
-  if (ids.length === 0) return;
-  await emit(TRANSFER_EVENT, { targetLabel, ids, sourceLabel } as TransferPayload);
+  if (ids.length === 0 || targetLabel === sourceLabel) return;
+  if (ids.some(id => transferringIds.has(id))) throw new Error('These tabs are already being transferred');
+  ids.forEach(id => transferringIds.add(id));
+  const requestId = crypto.randomUUID();
+  let ack: Awaited<ReturnType<typeof waitForEvent<TransferDonePayload>>> | undefined;
+  try {
+    ack = await waitForEvent<TransferDonePayload>(TRANSFER_DONE_EVENT, p => p.requestId === requestId && p.byLabel === targetLabel);
+    await emit(TRANSFER_EVENT, { targetLabel, ids, sourceLabel, requestId, expiresAt: Date.now() + TRANSFER_TIMEOUT_MS } as TransferPayload);
+    const result = await ack.result;
+    if (result.error) throw new Error(result.error);
+    if (ids.some(id => !result.ids.includes(id))) throw new Error('Destination did not adopt all tabs');
+    useTerminalStore.getState().detachTerminals(ids);
+  } catch (err) {
+    // Roll back a destination that acknowledged just as the source timed out.
+    await emit(CANCEL_EVENT, { targetLabel, requestId }).catch(() => {});
+    throw err;
+  } finally {
+    ack?.dispose();
+    ids.forEach(id => transferringIds.delete(id));
+  }
 }
 
 /**
@@ -175,8 +169,7 @@ export async function requestTransfer(targetLabel: string, ids: string[], source
  *   - `detach` removes terminals from this window's store without killing PTYs.
  *
  * When this window is named as a transfer target it adopts the ids, then
- * broadcasts a "done" so the source window releases them. Events broadcast to
- * all windows; non-owners' detach calls are harmless no-ops.
+ * acknowledges the request so only its waiting source releases them.
  */
 export function installTransferReceiver(
   myLabel: string,
@@ -188,6 +181,14 @@ export function installTransferReceiver(
   // registration - see the same pattern in App.tsx's terminal-output listener.
   let cancelled = false;
   const unlisteners: Array<() => void> = [];
+  const requests = new Map<string, { ids: string[]; cancelled: boolean }>();
+  const remember = (requestId: string) => {
+    const record = { ids: [] as string[], cancelled: false };
+    requests.set(requestId, record);
+    // Retain recent completions long enough to roll back late cancellations.
+    if (requests.size > 128) requests.delete(requests.keys().next().value!);
+    return record;
+  };
 
   const track = (p: Promise<() => void>) => {
     p.then((fn) => {
@@ -198,41 +199,42 @@ export function installTransferReceiver(
     });
   };
 
+  const cancellationReady = listen<{ targetLabel: string; requestId: string }>(CANCEL_EVENT, event => {
+    if (event.payload.targetLabel !== myLabel) return;
+    const record = requests.get(event.payload.requestId) ?? remember(event.payload.requestId);
+    record.cancelled = true;
+    if (record.ids.length) detach(record.ids);
+    record.ids = [];
+  });
+  track(cancellationReady);
   track(
-    listen<TransferPayload>(TRANSFER_EVENT, async (event) => {
-      const { targetLabel, ids, sourceLabel } = event.payload;
-      if (targetLabel !== myLabel || sourceLabel === myLabel) return;
+    cancellationReady.then(() => cancelled ? () => {} : listen<TransferPayload>(TRANSFER_EVENT, async (event) => {
+      const { targetLabel, ids, sourceLabel, requestId, expiresAt } = event.payload;
+      if (targetLabel !== myLabel || sourceLabel === myLabel || cancelled) return;
+      if (requests.has(requestId)) return;
+      const record = remember(requestId);
+      const adopted = record.ids;
       try {
         const all = await invoke<TerminalConfig[]>('get_terminals');
-        const byId = new Map(all.map((c) => [c.id, c]));
-        for (const id of ids) {
-          const cfg = byId.get(id);
-          if (!cfg) continue;
-          let log: string | undefined;
-          try {
-            log = (await invoke<string | null>('get_session_log', { terminalId: id })) ?? undefined;
-          } catch {
-            /* no log - adopt without scrollback */
-          }
-          adopt(cfg, log);
+        const byId = new Map(all.map(c => [c.id, c]));
+        if (ids.some(id => !byId.has(id))) throw new Error('A transferred terminal is no longer available');
+        const logs = await Promise.all(ids.map(id => invoke<string | null>('get_session_log', { terminalId: id }).catch(() => null)));
+        if (cancelled || record.cancelled || Date.now() >= expiresAt) throw new Error('Tab transfer expired');
+        for (let i = 0; i < ids.length; i++) {
+          adopt(byId.get(ids[i])!, logs[i] ?? undefined);
+          adopted.push(ids[i]);
         }
-        await emit(TRANSFER_DONE_EVENT, { ids, byLabel: myLabel } as TransferDonePayload);
-        try {
-          await getCurrentWebviewWindow().setFocus();
-        } catch {
-          /* focus is best-effort */
-        }
+        await emit(TRANSFER_DONE_EVENT, { ids: adopted, byLabel: myLabel, requestId } as TransferDonePayload);
+        await getCurrentWebviewWindow().setFocus().catch(() => {});
       } catch (err) {
-        reportError('tab_transfer_adopt', err instanceof Error ? err.message : String(err));
+        // A failed adoption/acknowledgement must leave ownership at the source.
+        detach(adopted);
+        reportError('tab_transfer_adopt', String(err));
+        await emit(TRANSFER_DONE_EVENT, { ids: [], byLabel: myLabel, requestId, error: String(err) } as TransferDonePayload).catch(() => {});
       }
-    }),
-  );
-
-  track(
-    listen<TransferDonePayload>(TRANSFER_DONE_EVENT, (event) => {
-      const { ids, byLabel } = event.payload;
-      if (byLabel === myLabel) return; // I'm the adopter; keep them
-      detach(ids);
+    })).then(fn => {
+      if (!cancelled) void emit(READY_EVENT, { label: myLabel }).catch(() => {});
+      return fn;
     }),
   );
 

--- a/src/lib/windowLayout.test.ts
+++ b/src/lib/windowLayout.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { currentGeometry, getDetachedEntries, keyOf, removeEntry, upsertEntry } from './windowLayout';
+import { currentGeometry, getDetachedEntries, keyOf, restoreLayoutKeys, removeEntry, upsertEntry } from './windowLayout';
 
 const win = vi.hoisted(() => ({ outerPosition: vi.fn(), outerSize: vi.fn() }));
 vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow: () => win }));
@@ -8,9 +8,14 @@ const key = 'ct-window-layout';
 describe('window layout persistence', () => {
   beforeEach(() => localStorage.clear());
 
-  it('uses session identity with a working-directory fallback', () => {
-    expect(keyOf({ claude_session_id: 's1', working_directory: '/repo' })).toBe('sid:s1');
-    expect(keyOf({ claude_session_id: null, working_directory: '/repo' })).toBe('cwd:/repo');
+  it('keeps same-directory shells distinct and refuses ambiguous legacy routing', () => {
+    const configs = [
+      { id: 'a', claude_session_id: null, working_directory: '/repo' },
+      { id: 'b', claude_session_id: null, working_directory: '/repo' },
+      { id: 'c', claude_session_id: 's1', working_directory: '/repo' },
+    ];
+    expect(configs.map(keyOf)).toEqual(['tab:a', 'tab:b', 'tab:c']);
+    expect(restoreLayoutKeys(configs)).toEqual([['tab:a'], ['tab:b'], ['tab:c', 'sid:s1']]);
   });
 
   it('updates and removes one window without losing others; excludes main', () => {

--- a/src/lib/windowLayout.ts
+++ b/src/lib/windowLayout.ts
@@ -19,13 +19,17 @@ export interface WindowEntry {
 }
 type Layout = Record<string, WindowEntry>;
 
-/**
- * Stable identity for a terminal across an app restart. Tab/config ids are
- * regenerated on restore, so we key off the Claude session id when present and
- * fall back to the working directory (good enough for plain shells).
- */
-export function keyOf(cfg: Pick<TerminalConfig, 'claude_session_id' | 'working_directory'>): string {
-  return cfg.claude_session_id ? `sid:${cfg.claude_session_id}` : `cwd:${cfg.working_directory}`;
+/** Saved terminal IDs identify tabs independently of conversation or directory. */
+export function keyOf(cfg: Pick<TerminalConfig, 'id'>): string {
+  return `tab:${cfg.id}`;
+}
+
+/** Legacy layout keys are usable only when they identify exactly one saved tab. */
+export function restoreLayoutKeys(configs: Array<Pick<TerminalConfig, 'id' | 'claude_session_id' | 'working_directory'>>): string[][] {
+  const legacy = configs.map(c => c.claude_session_id ? `sid:${c.claude_session_id}` : `cwd:${c.working_directory}`);
+  const counts = new Map<string, number>();
+  for (const key of legacy) counts.set(key, (counts.get(key) ?? 0) + 1);
+  return configs.map((c, i) => [keyOf(c), ...(counts.get(legacy[i]) === 1 ? [legacy[i]] : [])]);
 }
 
 function read(): Layout {


### PR DESCRIPTION
Fix nine failures affecting file edits, Git operations, previews, session restore, and detached windows. Keyboard-closing a dirty file now asks before discarding edits, and discarding an untracked symlink or junction removes the link while preserving its target.

- Apply editor font/layout preferences in both modes and save on blur, including edits made during an in-flight write.
- Parse NUL-delimited Git status records so spaces, Unicode, and rename paths survive file actions; recognize repositories before their first commit.
- Allow HTTP(S) preview frames through the production CSP while retaining the preview host allowlist and sandbox.
- Reserve explicit conversation claims before choosing continuation, scoped by agent and normalized directory.
- Route restored windows by saved terminal IDs, migrating only unambiguous legacy layout keys.
- Wait for receiver readiness and correlated adoption acknowledgement before removing source tabs. Handle creation failures, timeouts, cancellation, and destination rollback.

Validation: 565 frontend tests, 271 Rust tests, and 15 analytics-worker tests passed. Production frontend build and whitespace checks passed. Headless Chromium with mocked Tauri IPC verified editor font size, auto-save, dirty-file close cancellation, and local iframe loading under the configured production CSP.

Native multi-window/agent CLI integration and macOS behavior were not exercised interactively. Windows directory-junction deletion was tested; file-symlink coverage runs on Unix because this Windows host lacks unprivileged file-symlink creation. Existing build chunk-size warnings remain.

The audit report includes the original reproductions and a resolution table for all nine findings.
